### PR TITLE
Add CI Workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,60 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Rust Cache
+      uses: Swatinem/rust-cache@v2
+    - name: Run cargo check
+      run: cargo check
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Rust Cache
+      uses: Swatinem/rust-cache@v2
+    - name: Run cargo build
+      run: cargo build --release
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Rust Cache
+      uses: Swatinem/rust-cache@v2
+    - name: Run cargo test
+      run: cargo test 
+
+  # clippy:
+  #   runs-on: ubuntu-latest
+  #   needs: test
+  #   steps:
+  #   - name: Checkout code
+  #     uses: actions/checkout@v4
+  #   - name: Rust Cache
+  #     uses: Swatinem/rust-cache@v2
+  #   - name: Run Clippy
+  #     run: cargo clippy  -- -D warnings
+
+  formatting:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Rust Cache
+      uses: Swatinem/rust-cache@v2
+    - name: Run cargo fmt
+      run: cargo fmt -- --check

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 Cargo.lock
 .openapi-generator-ignore
 .openapi-generator
-.github
 .DS_Store
 .cargo
 NOTE.md

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2024-06-23"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Round 2, this replaces #2, just adding the workflow file, `rust-toolchain`, and branching off of `main` instead.  no other changes.