### PR TITLE
`use libipld::cid::Cid`

### DIFF
--- a/rsky-feedgen/Cargo.toml
+++ b/rsky-feedgen/Cargo.toml
@@ -22,7 +22,6 @@ serde_cbor = "0.11.2"
 diesel = { version = "2.1.0", features = ["postgres"] }
 dotenvy = "0.15"
 chrono = "0.4.26"
-cid = { version = "0.10.1", features = ["serde-codec"] }
 regex = "1.8.4"
 lazy_static = "1.4.0"
 base64 = "0.21.2"

--- a/rsky-firehose/Cargo.toml
+++ b/rsky-firehose/Cargo.toml
@@ -18,7 +18,6 @@ tokio = { version = "1.28.0", features = ["full"] }
 tokio-tungstenite = { version = "0.18.0", features = ["native-tls"] }
 url = "2.3.1"
 chrono = { version = "0.4.24", features = ["serde"] }
-cid = { version = "0.10.1", features = ["serde-codec"] }
 derive_builder = "0.12.0"
 miette = "5.8.0"
 parking_lot = "0.12.1"
@@ -33,3 +32,4 @@ thiserror = "1.0.40"
 dotenvy = "0.15.7"
 retry = "2.0.0"
 anyhow = "1.0.81"
+libipld = { version = "0.16.0", features = ["serde-codec"] }

--- a/rsky-firehose/src/car.rs
+++ b/rsky-firehose/src/car.rs
@@ -3,13 +3,13 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::io::{Cursor, Read};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     UvarintEof,
     UvarintBad,
     ChunkEof,
-    HeaderCbor,
-    BlockCid,
+    HeaderCbor(String),
+    BlockCid(String),
     BlockData,
 }
 
@@ -45,7 +45,7 @@ fn read_chunk<T: Read>(reader: &mut T) -> Result<Vec<u8>, Error> {
     Ok(buf)
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Header {
     pub version: u8,
     pub roots: Vec<Cid>,
@@ -53,8 +53,8 @@ pub struct Header {
 
 pub fn read_header<T: Read>(reader: &mut T) -> Result<Header, Error> {
     let mut reader = Cursor::new(read_chunk(reader)?);
-    let header =
-        serde_ipld_dagcbor::from_reader::<Header, _>(&mut reader).map_err(|_| Error::HeaderCbor)?;
+    let header = serde_ipld_dagcbor::from_reader::<Header, _>(&mut reader)
+        .map_err(|e| Error::HeaderCbor(e.to_string()))?;
     Ok(header)
 }
 
@@ -64,7 +64,7 @@ pub fn read_blocks<T: Read>(mut reader: &mut T) -> Result<HashMap<Cid, Vec<u8>>,
     while let Ok(chunk) = read_chunk(&mut reader) {
         let mut block_reader = Cursor::new(chunk);
 
-        let cid = Cid::read_bytes(&mut block_reader).map_err(|_| Error::BlockCid)?;
+        let cid = Cid::read_bytes(&mut block_reader).map_err(|e| Error::BlockCid(e.to_string()))?;
         let mut block = Vec::new();
         block_reader
             .read_to_end(&mut block)
@@ -73,4 +73,76 @@ pub fn read_blocks<T: Read>(mut reader: &mut T) -> Result<HashMap<Cid, Vec<u8>>,
     }
 
     Ok(blocks)
+}
+
+#[cfg(test)]
+mod tests {
+
+    use libipld::Multihash;
+
+    use super::*;
+
+    #[test]
+    fn test_read_uvarint() {
+        let mut reader = Cursor::new(vec![0x01, 0x02, 0x03]);
+        assert_eq!(read_uvarint64(&mut reader).unwrap(), 1);
+        assert_eq!(read_uvarint64(&mut reader).unwrap(), 2);
+        assert_eq!(read_uvarint64(&mut reader).unwrap(), 3);
+        assert_eq!(read_uvarint64(&mut reader).unwrap_err(), Error::UvarintEof);
+    }
+
+    #[test]
+    fn test_read_chunk() {
+        let mut reader = Cursor::new(vec![0x01, 0x02, 0x01, 0x03, 0x01]);
+        assert_eq!(read_chunk(&mut reader).unwrap(), vec![0x02]);
+        assert_eq!(read_chunk(&mut reader).unwrap(), vec![0x03]);
+        assert_eq!(read_chunk(&mut reader), Err(Error::ChunkEof));
+
+        reader = Cursor::new(vec![0x02, 0x02, 0x03]);
+        assert_eq!(read_chunk(&mut reader).unwrap(), vec![0x02, 0x03]);
+        assert_eq!(read_chunk(&mut reader), Err(Error::UvarintEof));
+
+        reader = Cursor::new(vec![0x03, 0x02, 0x03]);
+        assert_eq!(read_chunk(&mut reader), Err(Error::ChunkEof));
+    }
+
+    #[test]
+    fn test_read_header() {
+        let header = Header {
+            version: 1,
+            roots: vec![Cid::new(
+                libipld::cid::Version::V1,
+                1,
+                Multihash::from_bytes(&[0x01, 0x03, 0x01, 0x02, 0x03]).unwrap(),
+            )
+            .unwrap()],
+        };
+        let serialized = serde_ipld_dagcbor::to_vec(&header).unwrap();
+        let mut buffer = vec![serialized.len() as u8];
+        buffer.extend(serialized);
+        let mut reader = Cursor::new(buffer);
+        assert_eq!(read_header(&mut reader).unwrap(), header);
+    }
+
+    #[test]
+    fn test_read_blocks() {
+        let block = vec![0x04, 0x04, 0x04, 0x04];
+
+        let bytes = vec![0x01, 0x01, 0x02, 0x01, 0x01];
+        let bytes_reader = Cursor::new(&bytes);
+        let hash = Multihash::read(bytes_reader).unwrap();
+        let cid = Cid::new(libipld::cid::Version::V1, 1, hash).unwrap();
+
+        let chunk_len = bytes.len() + block.len();
+
+        let mut buffer = vec![chunk_len as u8];
+        buffer.extend(cid.to_bytes());
+        buffer.extend(&block);
+
+        let mut reader = Cursor::new(buffer);
+        assert_eq!(
+            read_blocks(&mut reader).unwrap(),
+            HashMap::from([(cid, block)])
+        );
+    }
 }

--- a/rsky-firehose/src/car.rs
+++ b/rsky-firehose/src/car.rs
@@ -1,4 +1,4 @@
-use cid::Cid;
+use libipld::cid::Cid;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::io::{Cursor, Read};

--- a/rsky-firehose/src/firehose.rs
+++ b/rsky-firehose/src/firehose.rs
@@ -1,7 +1,7 @@
+use anyhow::{bail, Result};
 use rsky_lexicon::com::atproto::sync::SubscribeRepos;
 use serde::Deserialize;
 use std::io::Cursor;
-use anyhow::{Result, bail};
 
 #[derive(Debug, Deserialize)]
 pub struct Header {
@@ -39,8 +39,11 @@ pub fn read(data: &[u8]) -> Result<(Header, SubscribeRepos)> {
         "#tombstone" => SubscribeRepos::Handle(serde_ipld_dagcbor::from_reader(&mut reader)?),
         _ => {
             eprintln!("Received unknown header {:?}", header.type_.as_str());
-            bail!(format!("Received unknown header {:?}", header.type_.as_str()))
-        },
+            bail!(format!(
+                "Received unknown header {:?}",
+                header.type_.as_str()
+            ))
+        }
     };
 
     Ok((header, body))

--- a/rsky-firehose/src/main.rs
+++ b/rsky-firehose/src/main.rs
@@ -8,11 +8,11 @@ use rsky_lexicon::com::atproto::sync::SubscribeRepos;
 use serde::Deserialize;
 use std::env;
 use std::io::Cursor;
+use std::{thread, time::Duration};
 use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::protocol::Message;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 use url::Url;
-use std::{thread, time::Duration};
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "$type")]
@@ -111,7 +111,7 @@ async fn process(message: Vec<u8>, client: &reqwest::Client) {
                         &commit.sequence,
                         client,
                     )
-                        .await;
+                    .await;
                     match resp {
                         Ok(()) => (),
                         Err(error) => eprintln!("Failed to update cursor: {error:?}"),
@@ -281,11 +281,12 @@ async fn main() {
                     "{}/xrpc/com.atproto.sync.subscribeRepos",
                     default_subscriber_path
                 )
-                    .as_str(),
+                .as_str(),
             )
-                .unwrap(),
+            .unwrap(),
         )
-            .await {
+        .await
+        {
             Ok((mut socket, _response)) => {
                 println!("Connected to {default_subscriber_path:?}.");
                 while let Some(Ok(Message::Binary(message))) = socket.next().await {
@@ -294,7 +295,7 @@ async fn main() {
                         process(message, &client).await;
                     });
                 }
-            },
+            }
             Err(error) => {
                 eprintln!("Error connecting to {default_subscriber_path:?}. Waiting to reconnect: {error:?}");
                 thread::sleep(Duration::from_millis(500));

--- a/rsky-lexicon/Cargo.toml
+++ b/rsky-lexicon/Cargo.toml
@@ -22,4 +22,4 @@ serde_cbor = "0.11.2"
 serde_derive = "^1.0"
 serde_bytes = "0.11.9"
 thiserror = "1.0.40"
-cid = { version = "0.10.1", features = ["serde-codec"] }
+libipld = { version = "0.16.0", features = ["serde-codec"] }

--- a/rsky-lexicon/src/com/atproto/repo.rs
+++ b/rsky-lexicon/src/com/atproto/repo.rs
@@ -1,4 +1,4 @@
-use cid::Cid;
+use libipld::cid::Cid;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_cbor::tags::Tagged;
 
@@ -98,7 +98,7 @@ pub struct BlobOutput {
     pub blob: Blob,
 }
 
-fn deserialize_cid_v1<'de, D>(deserializer: D) -> Result<Option<cid::Cid>, D::Error>
+fn deserialize_cid_v1<'de, D>(deserializer: D) -> Result<Option<Cid>, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/rsky-lexicon/src/com/atproto/sync.rs
+++ b/rsky-lexicon/src/com/atproto/sync.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use cid::Cid;
+use libipld::cid::Cid;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
closes #9

this appears to compile and pass checks, without having to do much other than swapping out the libraries.  