### PR TITLE
PLC Client: Properly Serialize Update Op

### DIFF
--- a/rsky-pds/src/apis/com/atproto/server/mod.rs
+++ b/rsky-pds/src/apis/com/atproto/server/mod.rs
@@ -225,7 +225,7 @@ pub async fn create_did_and_plc_op(
     // @TODO: Use plc::Client instead
     let plc_url = format!(
         "{0}/{1}",
-        env::var("PLC_SERVER").unwrap_or("plc.directory".to_owned()),
+        env::var("PDS_DID_PLC_URL").unwrap_or("https://plc.directory".to_owned()),
         did_plc
     );
     println!("Publishing to {plc_url}");

--- a/rsky-pds/src/main.rs
+++ b/rsky-pds/src/main.rs
@@ -150,7 +150,9 @@ async fn rocket() -> _ {
     let id_resolver = SharedIdResolver {
         id_resolver: RwLock::new(IdResolver::new(IdentityResolverOpts {
             timeout: None,
-            plc_url: Some(env::var("PLC_SERVER").unwrap_or("plc.directory".to_owned())),
+            plc_url: Some(
+                env::var("PDS_DID_PLC_URL").unwrap_or("https://plc.directory".to_owned()),
+            ),
             did_cache: Some(DidCache::new(None, None)),
             backup_nameservers: Some(env_list("PDS_HANDLE_BACKUP_NAMESERVERS")),
         })),

--- a/rsky-pds/src/plc/mod.rs
+++ b/rsky-pds/src/plc/mod.rs
@@ -20,6 +20,7 @@ impl Client {
         format!("{0}/{1}", self.url, encode_uri_component(did))
     }
 
+    // @TODO: Add better failure mode here
     async fn make_get_req<T: DeserializeOwned>(
         &self,
         url: String,
@@ -52,8 +53,8 @@ impl Client {
             .await?;
         let res = &response;
         match res.error_for_status_ref() {
-            Ok(_res) => Ok(()),
-            Err(error) => bail!(error.to_string()),
+            Ok(_) => Ok(()),
+            Err(_) => bail!(response.text().await?),
         }
     }
 

--- a/rsky-pds/src/plc/operations.rs
+++ b/rsky-pds/src/plc/operations.rs
@@ -2,8 +2,10 @@ use crate::common::ipld::cid_for_cbor;
 use crate::common::sign::atproto_sign;
 use crate::plc::types::{CompatibleOp, CompatibleOpOrTombstone, Operation, Service, Tombstone};
 use anyhow::Result;
+use indexmap::IndexMap;
 use libipld::Cid;
 use secp256k1::SecretKey;
+use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]
@@ -145,7 +147,9 @@ pub async fn create_update_op<G>(
 where
     G: Fn(Operation) -> Operation,
 {
-    let prev = cid_for_cbor(&last_op)?;
+    let last_op_json = serde_json::to_string(&last_op)?;
+    let last_op_index_map: IndexMap<String, JsonValue> = serde_json::from_str(&last_op_json)?;
+    let prev = cid_for_cbor(&last_op_index_map)?;
     // omit sig so it doesn't accidentally make its way into the next operation
     let mut normalized = normalize_op(last_op);
     normalized.sig = None;

--- a/rsky-pds/src/plc/types.rs
+++ b/rsky-pds/src/plc/types.rs
@@ -29,7 +29,6 @@ pub struct CreateOpV1 {
     pub recovery_key: String,
     pub handle: String,
     pub service: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub prev: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sig: Option<String>,
@@ -47,7 +46,6 @@ pub struct Operation {
     pub also_known_as: Vec<String>,
     pub services: BTreeMap<String, Service>,
     // Omit<t.UnsignedOperation, 'prev'>
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub prev: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sig: Option<String>,
@@ -89,6 +87,7 @@ impl CompatibleOpOrTombstone {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(untagged)] // will be posted to API so needs to not be tagged
 pub enum CompatibleOp {
     CreateOpV1(CreateOpV1),
     Operation(Operation),


### PR DESCRIPTION
Remove tag from PLC op enum, serialize prev even when null and ensure op is ordered correctly during serialization. Fixes #25 

Also ensures that the same environment variable is used throughout.