### PR TITLE
Afbase/aturi validation rsky syntax

### DIFF
--- a/rsky-syntax/ATURI_VALIDATION.md
+++ b/rsky-syntax/ATURI_VALIDATION.md
@@ -1,0 +1,9 @@
+# Notes on AT-URI Validation
+
+At the time of writing this, this rsky-syntax validation of AT-URI reflects the Typescript implementation of the [syntax package](https://github.com/bluesky-social/atproto/tree/main/packages/syntax) instead of the atproto.com [specification](https://atproto.com/specs/at-uri-scheme).  There are some differences with the typescript and rust validation implementations and the specification for AT URIs:
+
+  - The validation conforms more to the "Full AT URI Syntax" form than the "Restricted AT URI Syntax" that is used in the [lexicon](https://github.com/bluesky-social/atproto/tree/main/packages/lexicon).  
+  - The Rust AT-URI validation does admit some invalid syntax.
+  - The Rust DID and Handle validation adheres to the specification.
+  - The Rust NSID and TID validation adheres to the specification.
+  - The Rust Record Key validation adheres to the specification.

--- a/rsky-syntax/ATURI_VALIDATION.md
+++ b/rsky-syntax/ATURI_VALIDATION.md
@@ -7,3 +7,7 @@ At the time of writing this, this rsky-syntax validation of AT-URI reflects the 
   - The Rust DID and Handle validation adheres to the specification.
   - The Rust NSID and TID validation adheres to the specification.
   - The Rust Record Key validation adheres to the specification.
+
+  # References
+
+  1. [rsky-syntax PR](https://github.com/blacksky-algorithms/rsky/pull/39).

--- a/rsky-syntax/Cargo.toml
+++ b/rsky-syntax/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.rs/rsky-syntax"
 
 [dependencies]
 anyhow = "1.0.86"
+chrono = "0.4.39"
 lazy_static = "1.5.0"
 regex = "1.10.5"
 serde = { version = "1.0.160", features = ["derive"] }

--- a/rsky-syntax/src/aturi.rs
+++ b/rsky-syntax/src/aturi.rs
@@ -288,6 +288,24 @@ impl TryFrom<&String> for AtUri {
     }
 }
 
+impl From<AtUri> for String {
+    fn from(value: AtUri) -> Self {
+        value.to_string()
+    }
+}
+
+impl From<&AtUri> for String {
+    fn from(value: &AtUri) -> Self {
+        value.to_string()
+    }
+}
+
+impl From<&&AtUri> for String {
+    fn from(value: &&AtUri) -> Self {
+        value.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rsky-syntax/src/aturi.rs
+++ b/rsky-syntax/src/aturi.rs
@@ -191,8 +191,8 @@ impl AtUri {
     }
 }
 
-pub fn parse(str: &String) -> Result<Option<ParsedOutput>> {
-    match atp_uri_regex(str) {
+pub fn parse(str: &str) -> Result<Option<ParsedOutput>> {
+    match atp_uri_regex(&str) {
         None => Ok(None),
         Some(matches) => {
             // The query string we want to parse
@@ -216,7 +216,7 @@ pub fn parse(str: &String) -> Result<Option<ParsedOutput>> {
     }
 }
 
-pub fn parse_relative(str: &String) -> Result<Option<ParsedRelativeOutput>> {
+pub fn parse_relative(str: &str) -> Result<Option<ParsedRelativeOutput>> {
     match relative_regex(str) {
         None => Ok(None),
         Some(matches) => {
@@ -535,6 +535,15 @@ mod tests {
         let invalid_cases = vec![
             "",                          // Empty string
             // @TODO implement AtUri Validation
+            // Note: At this point in time, (commit bd39665) the reference typescript
+            // packages/syntax/src/aturi.ts
+            // does not use ensureValidAtUri or ensureValidAtUriRegex
+            // from packages/syntax/src/aturi_validation.ts
+            // although does "export * from './aturi_validation'"
+            // idk if this is an ommission or not so i won't implment
+            // validation in AtUri at this time.
+            //
+            //
             // "invalid/uri/format",        // Missing host
             // "http://not-at-protocol",    // Wrong protocol
             // "at://",                     // Missing everything after protocol

--- a/rsky-syntax/src/aturi.rs
+++ b/rsky-syntax/src/aturi.rs
@@ -8,22 +8,26 @@ pub fn atp_uri_regex(input: &str) -> Option<Vec<&str>> {
     lazy_static! {
         static ref RE: Regex = Regex::new(r"(?i)^(at://)?((?:did:[a-z0-9:%-]+)|(?:[a-z0-9][a-z0-9.:-]*))(/[^?#\s]*)?(\?[^#\s]+)?(#[^\s]+)?$").unwrap();
     }
-    RE.captures(input).map(|captures| captures
-                .iter()
-                .skip(1) // Skip the first capture which is the entire match
-                .map(|c| c.map_or("", |m| m.as_str()))
-                .collect())
+    RE.captures(input).map(|captures| {
+        captures
+            .iter()
+            .skip(1) // Skip the first capture which is the entire match
+            .map(|c| c.map_or("", |m| m.as_str()))
+            .collect()
+    })
 }
 
 pub fn relative_regex(input: &str) -> Option<Vec<&str>> {
     lazy_static! {
         static ref RE: Regex = Regex::new(r"(?i)^(/[^?#\s]*)?(\?[^#\s]+)?(#[^\s]+)?$").unwrap();
     }
-    RE.captures(input).map(|captures| captures
-                .iter()
-                .skip(1) // Skip the first capture which is the entire match
-                .map(|c| c.map_or("", |m| m.as_str()))
-                .collect())
+    RE.captures(input).map(|captures| {
+        captures
+            .iter()
+            .skip(1) // Skip the first capture which is the entire match
+            .map(|c| c.map_or("", |m| m.as_str()))
+            .collect()
+    })
 }
 
 pub struct ParsedOutput {
@@ -238,7 +242,9 @@ impl Display for AtUri {
             path = format!("/{path}");
         }
         let qs = match self.get_search() {
-            Ok(Some(search_params)) if !search_params.starts_with("?") && !search_params.is_empty() => {
+            Ok(Some(search_params))
+                if !search_params.starts_with("?") && !search_params.is_empty() =>
+            {
                 format!("?{search_params}")
             }
             Ok(Some(search_params)) => search_params,
@@ -534,21 +540,6 @@ mod tests {
     fn test_invalid_str_conversion() {
         let invalid_cases = vec![
             "", // Empty string
-               // @TODO implement AtUri Validation
-               // Note: At this point in time, (commit bd39665) the reference typescript
-               // packages/syntax/src/aturi.ts
-               // does not use ensureValidAtUri or ensureValidAtUriRegex
-               // from packages/syntax/src/aturi_validation.ts
-               // although does "export * from './aturi_validation'"
-               // idk if this is an ommission or not so i won't implment
-               // validation in AtUri at this time.
-               //
-               //
-               // "invalid/uri/format",        // Missing host
-               // "http://not-at-protocol",    // Wrong protocol
-               // "at://",                     // Missing everything after protocol
-               // "at://@invalid-chars@",      // Invalid characters
-               // "at://host/collection/rkey/extra", // Too many path segments
         ];
 
         for case in invalid_cases {
@@ -559,15 +550,7 @@ mod tests {
 
     #[test]
     fn test_invalid_string_conversion() {
-        let invalid_cases = vec![
-            String::from(""),
-            // @TODO implement AtUri Validation
-            // String::from("invalid/uri/format"),
-            // String::from("http://not-at-protocol"),
-            // String::from("at://"),
-            // String::from("at://@invalid-chars@"),
-            // String::from("at://host/collection/rkey/extra"),
-        ];
+        let invalid_cases = vec![String::from("")];
 
         for case in invalid_cases {
             let result: Result<AtUri, _> = case.clone().try_into();

--- a/rsky-syntax/src/aturi.rs
+++ b/rsky-syntax/src/aturi.rs
@@ -258,7 +258,13 @@ impl Display for AtUri {
         };
         let hash = match self.hash == "" {
             true => self.hash.clone(),
-            false => format!("#{}", self.hash),
+            false => {
+                if self.hash.starts_with("#") {
+                    format!("{}", self.hash)
+                } else {
+                    format!("#{}", self.hash)
+                }
+            }
         };
         write!(f, "at://{}{}{}{}", self.host, path, qs, hash)
     }
@@ -507,9 +513,12 @@ mod tests {
         for case in valid_cases {
             let result: Result<AtUri, _> = case.try_into();
             assert!(result.is_ok(), "Failed to parse valid URI: {}", case);
-            
+
             let uri = result.unwrap();
-            assert_eq!(uri.to_string(), format!("at://{}", case.trim_start_matches("at://")));
+            assert_eq!(
+                uri.to_string(),
+                format!("at://{}", case.trim_start_matches("at://"))
+            );
         }
     }
 
@@ -524,31 +533,34 @@ mod tests {
         for case in valid_cases {
             let result: Result<AtUri, _> = case.clone().try_into();
             assert!(result.is_ok(), "Failed to parse valid URI: {}", case);
-            
+
             let uri = result.unwrap();
-            assert_eq!(uri.to_string(), format!("at://{}", case.trim_start_matches("at://")));
+            assert_eq!(
+                uri.to_string(),
+                format!("at://{}", case.trim_start_matches("at://"))
+            );
         }
     }
 
     #[test]
     fn test_invalid_str_conversion() {
         let invalid_cases = vec![
-            "",                          // Empty string
-            // @TODO implement AtUri Validation
-            // Note: At this point in time, (commit bd39665) the reference typescript
-            // packages/syntax/src/aturi.ts
-            // does not use ensureValidAtUri or ensureValidAtUriRegex
-            // from packages/syntax/src/aturi_validation.ts
-            // although does "export * from './aturi_validation'"
-            // idk if this is an ommission or not so i won't implment
-            // validation in AtUri at this time.
-            //
-            //
-            // "invalid/uri/format",        // Missing host
-            // "http://not-at-protocol",    // Wrong protocol
-            // "at://",                     // Missing everything after protocol
-            // "at://@invalid-chars@",      // Invalid characters
-            // "at://host/collection/rkey/extra", // Too many path segments
+            "", // Empty string
+               // @TODO implement AtUri Validation
+               // Note: At this point in time, (commit bd39665) the reference typescript
+               // packages/syntax/src/aturi.ts
+               // does not use ensureValidAtUri or ensureValidAtUriRegex
+               // from packages/syntax/src/aturi_validation.ts
+               // although does "export * from './aturi_validation'"
+               // idk if this is an ommission or not so i won't implment
+               // validation in AtUri at this time.
+               //
+               //
+               // "invalid/uri/format",        // Missing host
+               // "http://not-at-protocol",    // Wrong protocol
+               // "at://",                     // Missing everything after protocol
+               // "at://@invalid-chars@",      // Invalid characters
+               // "at://host/collection/rkey/extra", // Too many path segments
         ];
 
         for case in invalid_cases {
@@ -584,7 +596,10 @@ mod tests {
         assert_eq!(uri.host, "host.com");
         assert_eq!(uri.get_collection(), "collection");
         assert_eq!(uri.get_rkey(), "123");
-        assert_eq!(uri.search_params, vec![("key".to_string(), "value".to_string())]);
+        assert_eq!(
+            uri.search_params,
+            vec![("key".to_string(), "value".to_string())]
+        );
     }
 
     #[test]
@@ -603,123 +618,130 @@ mod tests {
     fn test_conversion_full_uri() {
         let uri_str = "at://host.com/collection/123?key=value#fragment";
         let result: Result<AtUri, _> = uri_str.try_into();
-        assert!(result.is_ok());
+        assert!(
+            result.is_ok(),
+            "test_conversion_full_uri error: Validation error {:?}",
+            result
+        );
         let uri = result.unwrap();
         assert_eq!(uri.host, "host.com");
         assert_eq!(uri.get_collection(), "collection");
         assert_eq!(uri.get_rkey(), "123");
-        assert_eq!(uri.search_params, vec![("key".to_string(), "value".to_string())]);
+        assert_eq!(
+            uri.search_params,
+            vec![("key".to_string(), "value".to_string())]
+        );
         assert_eq!(uri.hash, "#fragment");
     }
 
     #[test]
-fn test_uri_modifications() -> Result<()> {
-    // Start with basic URI
-    let mut uri = AtUri::new("at://foo.com".to_string(), None)?;
-    assert_eq!(uri.to_string(), "at://foo.com/");
+    fn test_uri_modifications() -> Result<()> {
+        // Start with basic URI
+        let mut uri = AtUri::new("at://foo.com".to_string(), None)?;
+        assert_eq!(uri.to_string(), "at://foo.com/");
 
-    // Test host modifications
-    uri.set_hostname("bar.com".to_string());
-    assert_eq!(uri.to_string(), "at://bar.com/");
-    uri.set_hostname("did:web:localhost%3A1234".to_string());
-    assert_eq!(uri.to_string(), "at://did:web:localhost%3A1234/");
-    uri.set_hostname("foo.com".to_string());
-    assert_eq!(uri.to_string(), "at://foo.com/");
+        // Test host modifications
+        uri.set_hostname("bar.com".to_string());
+        assert_eq!(uri.to_string(), "at://bar.com/");
+        uri.set_hostname("did:web:localhost%3A1234".to_string());
+        assert_eq!(uri.to_string(), "at://did:web:localhost%3A1234/");
+        uri.set_hostname("foo.com".to_string());
+        assert_eq!(uri.to_string(), "at://foo.com/");
 
-    // Test pathname modifications
-    uri.pathname = "/".to_string();
-    assert_eq!(uri.to_string(), "at://foo.com/");
-    uri.pathname = "/foo".to_string();
-    assert_eq!(uri.to_string(), "at://foo.com/foo");
-    uri.pathname = "foo".to_string();
-    assert_eq!(uri.to_string(), "at://foo.com/foo");
+        // Test pathname modifications
+        uri.pathname = "/".to_string();
+        assert_eq!(uri.to_string(), "at://foo.com/");
+        uri.pathname = "/foo".to_string();
+        assert_eq!(uri.to_string(), "at://foo.com/foo");
+        uri.pathname = "foo".to_string();
+        assert_eq!(uri.to_string(), "at://foo.com/foo");
 
-    // Test collection and rkey modifications
-    uri.set_collection("com.example.foo".to_string());
-    uri.set_rkey("123".to_string());
-    assert_eq!(uri.to_string(), "at://foo.com/com.example.foo/123");
-    uri.set_rkey("124".to_string());
-    assert_eq!(uri.to_string(), "at://foo.com/com.example.foo/124");
-    uri.set_collection("com.other.foo".to_string());
-    assert_eq!(uri.to_string(), "at://foo.com/com.other.foo/124");
-    uri.pathname = "".to_string();
-    uri.set_rkey("123".to_string());
-    assert_eq!(uri.to_string(), "at://foo.com/123");
-    uri.pathname = "foo".to_string();
-    
-    // Test search parameter modifications
-    uri.set_search("?foo=bar".to_string())?;
-    assert_eq!(uri.to_string(), "at://foo.com/foo?foo=bar");
-    uri.search_params = vec![
-        ("foo".to_string(), "bar".to_string()),
-        ("baz".to_string(), "buux".to_string())
-    ];
-    assert_eq!(uri.to_string(), "at://foo.com/foo?foo=bar&baz=buux");
+        // Test collection and rkey modifications
+        uri.set_collection("com.example.foo".to_string());
+        uri.set_rkey("123".to_string());
+        assert_eq!(uri.to_string(), "at://foo.com/com.example.foo/123");
+        uri.set_rkey("124".to_string());
+        assert_eq!(uri.to_string(), "at://foo.com/com.example.foo/124");
+        uri.set_collection("com.other.foo".to_string());
+        assert_eq!(uri.to_string(), "at://foo.com/com.other.foo/124");
+        uri.pathname = "".to_string();
+        uri.set_rkey("123".to_string());
+        assert_eq!(uri.to_string(), "at://foo.com/123");
+        uri.pathname = "foo".to_string();
 
-    // Test hash modifications 
-    // @TODO should set # automatically if not set to conform with typescript
-    // see https://github.com/bluesky-social/atproto/blob/688ff0/packages/syntax/tests/aturi.test.ts#L314
-    // uri.hash = "#hash".to_string();
-    // assert_eq!(uri.to_string(), "at://foo.com/foo?foo=bar&baz=buux#hash");
-    // uri.hash = "hash".to_string();  // Should automatically add # when missing
-    // assert_eq!(uri.to_string(), "at://foo.com/foo?foo=bar&baz=buux#hash");
+        // Test search parameter modifications
+        uri.set_search("?foo=bar".to_string())?;
+        assert_eq!(uri.to_string(), "at://foo.com/foo?foo=bar");
+        uri.search_params = vec![
+            ("foo".to_string(), "bar".to_string()),
+            ("baz".to_string(), "buux".to_string()),
+        ];
+        assert_eq!(uri.to_string(), "at://foo.com/foo?foo=bar&baz=buux");
 
-    Ok(())
-}
+        // Test hash modifications
+        // @TODO should set # automatically if not set to conform with typescript
+        // see https://github.com/bluesky-social/atproto/blob/688ff0/packages/syntax/tests/aturi.test.ts#L314
+        // uri.hash = "#hash".to_string();
+        // assert_eq!(uri.to_string(), "at://foo.com/foo?foo=bar&baz=buux#hash");
+        // uri.hash = "hash".to_string();  // Should automatically add # when missing
+        // assert_eq!(uri.to_string(), "at://foo.com/foo?foo=bar&baz=buux#hash");
 
-#[test]
-fn test_relative_uris() -> Result<()> {
-    // Define test cases as tuples of (input, expected_pathname, expected_search, expected_hash)
-    let test_cases = vec![
-        ("", "", "", ""),
-        ("/", "/", "", ""),
-        ("/foo", "/foo", "", ""),
-        ("/foo/", "/foo/", "", ""),
-        ("/foo/bar", "/foo/bar", "", ""),
-        ("?foo=bar", "", "foo=bar", ""),
-        ("?foo=bar&baz=buux", "", "foo=bar&baz=buux", ""),
-        ("/?foo=bar", "/", "foo=bar", ""),
-        ("/foo?foo=bar", "/foo", "foo=bar", ""),
-        ("/foo/?foo=bar", "/foo/", "foo=bar", ""),
-        ("#hash", "", "", "#hash"),
-        ("/#hash", "/", "", "#hash"),
-        ("/foo#hash", "/foo", "", "#hash"),
-        ("/foo/#hash", "/foo/", "", "#hash"),
-        ("?foo=bar#hash", "", "foo=bar", "#hash"),
-    ];
-
-    // Define base URIs to test against
-    let base_uris = vec![
-        "did:web:localhost%3A1234",
-        "at://did:web:localhost%3A1234",
-        "at://did:web:localhost%3A1234/foo/bar?foo=bar&baz=buux#hash",
-    ];
-
-    for base in base_uris {
-        let base_uri = AtUri::new(base.to_string(), None)?;
-        
-        for (relative, exp_path, exp_search, exp_hash) in test_cases.iter() {
-            let uri = AtUri::new(relative.to_string(), Some(base.to_string()))?;
-            
-            // Verify the components match expectations
-            assert_eq!(uri.get_protocol(), "at:".to_string());
-            assert_eq!(uri.host, base_uri.host);
-            assert_eq!(uri.get_hostname(), base_uri.get_hostname());
-            assert_eq!(uri.get_origin(), base_uri.get_origin());
-            assert_eq!(uri.pathname, exp_path.to_string());
-            
-            // Compare search params
-            if exp_search.is_empty() {
-                assert!(uri.get_search()?.is_none() || uri.get_search()?.unwrap().is_empty());
-            } else {
-                assert_eq!(uri.get_search()?.unwrap(), exp_search.to_string());
-            }
-            
-            // Compare hash
-            assert_eq!(uri.hash, exp_hash.to_string());
-        }
+        Ok(())
     }
 
-    Ok(())
-}
+    #[test]
+    fn test_relative_uris() -> Result<()> {
+        // Define test cases as tuples of (input, expected_pathname, expected_search, expected_hash)
+        let test_cases = vec![
+            ("", "", "", ""),
+            ("/", "/", "", ""),
+            ("/foo", "/foo", "", ""),
+            ("/foo/", "/foo/", "", ""),
+            ("/foo/bar", "/foo/bar", "", ""),
+            ("?foo=bar", "", "foo=bar", ""),
+            ("?foo=bar&baz=buux", "", "foo=bar&baz=buux", ""),
+            ("/?foo=bar", "/", "foo=bar", ""),
+            ("/foo?foo=bar", "/foo", "foo=bar", ""),
+            ("/foo/?foo=bar", "/foo/", "foo=bar", ""),
+            ("#hash", "", "", "#hash"),
+            ("/#hash", "/", "", "#hash"),
+            ("/foo#hash", "/foo", "", "#hash"),
+            ("/foo/#hash", "/foo/", "", "#hash"),
+            ("?foo=bar#hash", "", "foo=bar", "#hash"),
+        ];
+
+        // Define base URIs to test against
+        let base_uris = vec![
+            "did:web:localhost%3A1234",
+            "at://did:web:localhost%3A1234",
+            "at://did:web:localhost%3A1234/foo/bar?foo=bar&baz=buux#hash",
+        ];
+
+        for base in base_uris {
+            let base_uri = AtUri::new(base.to_string(), None)?;
+
+            for (relative, exp_path, exp_search, exp_hash) in test_cases.iter() {
+                let uri = AtUri::new(relative.to_string(), Some(base.to_string()))?;
+
+                // Verify the components match expectations
+                assert_eq!(uri.get_protocol(), "at:".to_string());
+                assert_eq!(uri.host, base_uri.host);
+                assert_eq!(uri.get_hostname(), base_uri.get_hostname());
+                assert_eq!(uri.get_origin(), base_uri.get_origin());
+                assert_eq!(uri.pathname, exp_path.to_string());
+
+                // Compare search params
+                if exp_search.is_empty() {
+                    assert!(uri.get_search()?.is_none() || uri.get_search()?.unwrap().is_empty());
+                } else {
+                    assert_eq!(uri.get_search()?.unwrap(), exp_search.to_string());
+                }
+
+                // Compare hash
+                assert_eq!(uri.hash, exp_hash.to_string());
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/rsky-syntax/src/aturi_validation.rs
+++ b/rsky-syntax/src/aturi_validation.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 // Note: Typescript implementation allows for (8 * 1024) bytes
-const MAX_URI_LEN: usize = 512;
+const MAX_URI_LEN: usize = 8 * 1024;
 
 lazy_static! {
     static ref ATURI_REGEX: Regex = Regex::new(
@@ -32,7 +32,9 @@ pub struct AtUriValidationError(String);
 // Human-readable constraints on ATURI:
 //   - following regular URLs, a 8KByte hard total length limit
 //   - follows ATURI docs on website
-//      - all ASCII characters, no whitespace. non-ASCII could be URL-encoded
+//      - all ASCII characters, no whitespace. non-ASCII could be URL-encoded;
+//        - I believe "non-ASCII could be URL-encoded" to conform to
+//          "Hex-encoding of characters is permitted (but in practice not necessary)" in the docs
 //      - starts "at://"
 //      - "authority" is a valid DID or a valid handle
 //      - optionally, follow "authority" with "/" and valid NSID as start of path
@@ -205,7 +207,7 @@ mod tests {
     fn test_debug_me() {
         expect_invalid(&format!(
             "at://did:plc:asdf123/com.atproto.feed.post/{}",
-            "o".repeat(800)
+            "o".repeat(MAX_URI_LEN + 100)
         ));
     }
 
@@ -367,7 +369,7 @@ mod tests {
         expect_valid("at://did:plc:asdf123/com.atproto.feed.post/abc%30123");
     }
     #[test]
-    fn test_is_provabably_too_permissive_about_url_encoding() {
+    fn test_is_probably_too_permissive_about_url_encoding() {
         expect_valid("at://did:plc:asdf123/com.atproto.feed.post/%30");
         expect_valid("at://did:plc:asdf123/com.atproto.feed.post/%3");
         expect_valid("at://did:plc:asdf123/com.atproto.feed.post/%");

--- a/rsky-syntax/src/aturi_validation.rs
+++ b/rsky-syntax/src/aturi_validation.rs
@@ -51,7 +51,7 @@ pub fn ensure_valid_at_uri<S: Into<String>>(uri: S) -> Result<AtUri, AtUriValida
         ));
     }
     let hacky_empty = String::from("");
-    let fragment_part = uri_parts.get(1).unwrap_or_else(|| &hacky_empty).to_string();
+    let fragment_part = uri_parts.get(1).unwrap_or(&hacky_empty).to_string();
     let uri = uri_parts.first().unwrap().to_string();
     // check that all chars are boring ASCII
     if !VALID_PATH_CHARS.is_match(&uri) {

--- a/rsky-syntax/src/aturi_validation.rs
+++ b/rsky-syntax/src/aturi_validation.rs
@@ -1,0 +1,357 @@
+use lazy_static::lazy_static;
+use regex::Regex;
+use thiserror::Error;
+
+use crate::{
+    aturi::AtUri, did::ensure_valid_did_regex, handle::ensure_valid_handle_regex, nsid::ensure_valid_nsid_regex
+};
+
+// Human-readable constraints on ATURI:
+//   - following regular URLs, a 8KByte hard total length limit
+//   - follows ATURI docs on website
+//      - all ASCII characters, no whitespace. non-ASCII could be URL-encoded
+//      - starts "at://"
+//      - "authority" is a valid DID or a valid handle
+//      - optionally, follow "authority" with "/" and valid NSID as start of path
+//      - optionally, if NSID given, follow that with "/" and rkey
+//      - rkey path component can include URL-encoded ("percent encoded"), or:
+//          ALPHA / DIGIT / "-" / "." / "_" / "~" / ":" / "@" / "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+//          [a-zA-Z0-9._~:@!$&\'()*+,;=-]
+//      - rkey must have at least one char
+//      - regardless of path component, a fragment can follow as "#" and then a JSON pointer (RFC-6901)
+
+lazy_static! {
+    // static ref ATURI_REGEX: Regex = Regex::new(
+    //     // Fixed regex pattern with properly escaped fragment section and optional at:// prefix
+    //     r"^(?:at://)?(?P<authority>[a-zA-Z0-9._:%-]+)(?:/(?P<collection>[a-zA-Z0-9-.]+)(?:/(?P<rkey>[a-zA-Z0-9._~:@!$&%')(*+,;=-]+))?)?(?:#(?P<fragment>/[a-zA-Z0-9._~:@!$&%'()*+,;=\[\]/\\-]*))?$"
+    // ).unwrap();
+
+    static ref ATURI_REGEX: Regex = Regex::new(
+        // Support both NSID-style paths and bsky profile paths
+        r"^at://(?P<authority>[a-zA-Z0-9._:%-]+)(?:/(?:(?P<collection>[a-zA-Z0-9-.]+)(?:/(?P<rkey>[a-zA-Z0-9._~:@!$&%')(*+,;=-]+))?|profile/[a-zA-Z0-9.-]+/post/[a-zA-Z0-9]+))?(?:#(?P<fragment>/[a-zA-Z0-9._~:@!$&%'()*+,;=\[\]/\\-]*))?$"
+    ).unwrap();
+
+    // Path component characters
+    static ref VALID_PATH_CHARS: Regex = Regex::new(r"^[a-zA-Z0-9._~:@!$&'()*+,;=%/-]*$").unwrap();
+
+    // Fragment validation - fixed pattern
+    static ref VALID_FRAGMENT_CHARS: Regex = Regex::new(r"^/[a-zA-Z0-9._~:@!$&'()*+,;=\[\]/\\-]*$").unwrap();
+}
+
+#[derive(Error, Debug)]
+#[error("AtUriValidationError: {0}")]
+pub struct AtUriValidationError(String);
+
+/// Validates an AT URI according to AT Protocol specification.
+pub fn ensure_valid_at_uri<S: Into<String>>(uri: S) -> Result<AtUri, AtUriValidationError> {
+    let uri: String = uri.into();
+    // Split fragment first as it's special
+    let parts: Vec<&str> = uri.split('#').collect();
+    if parts.len() > 2 {
+        return Err(AtUriValidationError(
+            "ATURI can have at most one \"#\", separating fragment out".into(),
+        ));
+    }
+
+    let uri_without_fragment = parts[0];
+    let fragment_part = parts.get(1);
+
+    // Check that all chars are boring ASCII
+    if !VALID_PATH_CHARS.is_match(uri_without_fragment) {
+        return Err(AtUriValidationError(
+            "Disallowed characters in ATURI (ASCII)".into(),
+        ));
+    }
+
+    // Split the URI on '/' but keep the at:// prefix together
+    let mut segments: Vec<&str> = vec![];
+    if let Some(rest) = uri_without_fragment.strip_prefix("at://") {
+        segments.push("at://");
+        segments.extend(rest.split('/'));
+    } else {
+        segments.extend(uri_without_fragment.split('/'));
+    }
+
+    // Must have at least authority segment
+    if segments.is_empty() {
+        return Err(AtUriValidationError(
+            "ATURI requires at least an authority section".into(),
+        ));
+    }
+
+    // Validate authority (DID or handle)
+    let authority = if segments[0] == "at://" {
+        if segments.len() < 2 {
+            return Err(AtUriValidationError(
+                "ATURI requires an authority after at://".into(),
+            ));
+        }
+        segments[1]
+    } else {
+        segments[0]
+    };
+
+    if ensure_valid_did_regex(authority).is_err() && ensure_valid_handle_regex(authority).is_err() {
+        return Err(AtUriValidationError(
+            "ATURI authority must be a valid handle or DID".into(),
+        ));
+    }
+
+    // Check if we have a path and validate it
+    let collection_idx = if segments[0] == "at://" { 2 } else { 1 };
+    if segments.len() > collection_idx {
+        if segments[collection_idx].is_empty() {
+            return Err(AtUriValidationError(
+                "ATURI can not have a slash after authority without a path segment".into(),
+            ));
+        }
+
+        // Special case for bsky.app profile paths
+        if segments[collection_idx] == "profile" {
+            // Check for valid profile path format
+            if !(segments.len() >= collection_idx + 4 && segments[collection_idx + 2] == "post") {
+                return Err(AtUriValidationError("Invalid profile path format".into()));
+            }
+        } else {
+            // Normal NSID path validation
+            if ensure_valid_nsid_regex(segments[collection_idx]).is_err() {
+                return Err(AtUriValidationError(
+                    "ATURI requires first path segment (if supplied) to be valid NSID".into(),
+                ));
+            }
+
+            // If there's a record key, validate it
+            let rkey_idx = collection_idx + 1;
+            if segments.len() > rkey_idx && segments[rkey_idx].is_empty() {
+                    return Err(AtUriValidationError(
+                        "ATURI can not have a slash after collection, unless record key is provided".into()
+                    ));
+                }
+
+            // Validate max path segments for NSID paths
+            if segments.len() > (collection_idx + 2) {
+                return Err(AtUriValidationError(
+                    "ATURI path can have at most two parts, and no trailing slash".into(),
+                ));
+            }
+        }
+    }
+
+    // Validate fragment if present
+    if let Some(fragment) = fragment_part {
+        if fragment.is_empty() || !fragment.starts_with('/') {
+            return Err(AtUriValidationError(
+                "ATURI fragment must be non-empty and start with slash".into(),
+            ));
+        }
+
+        if !VALID_FRAGMENT_CHARS.is_match(fragment) {
+            return Err(AtUriValidationError(
+                "Disallowed characters in ATURI fragment (ASCII)".into(),
+            ));
+        }
+    }
+
+    if uri.len() > 8 * 1024 {
+        return Err(AtUriValidationError("ATURI is far too long".into()));
+    }
+
+    match uri.try_into() {
+        Ok(at_uri) => Ok(at_uri),
+        // should never fail since it is valid
+        Err(err) => Err(AtUriValidationError(err.to_string())),
+    }
+}
+
+pub fn ensure_valid_at_uri_regex<S: Into<String>>(uri: S) -> Result<(), AtUriValidationError> {
+    let uri: String = uri.into();
+    // Simple regex to enforce most constraints via just regex and length
+    let captures = ATURI_REGEX
+        .captures(uri.as_str())
+        .ok_or_else(|| AtUriValidationError("ATURI didn't validate via regex".into()))?;
+
+    let authority = captures
+        .name("authority")
+        .ok_or_else(|| AtUriValidationError("ATURI must contain an authority".into()))?
+        .as_str();
+
+    // Validate authority is valid handle or DID
+    if ensure_valid_handle_regex(authority).is_err() && ensure_valid_did_regex(authority).is_err() {
+        return Err(AtUriValidationError(
+            "ATURI authority must be a valid handle or DID".into(),
+        ));
+    }
+
+    // If collection exists, validate it's a valid NSID
+    if let Some(collection) = captures.name("collection") {
+        if ensure_valid_nsid_regex(collection.as_str()).is_err() {
+            return Err(AtUriValidationError(
+                "ATURI collection path segment must be a valid NSID".into(),
+            ));
+        }
+    }
+
+    if uri.len() > 8 * 1024 {
+        return Err(AtUriValidationError("ATURI is far too long".into()));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expect_valid(uri: &str) {
+        ensure_valid_at_uri(uri).unwrap_or_else(|e| {
+            panic!(
+                "ensure_valid_at_uri validation test: Expected '{}' to be valid, but got error: {}",
+                uri, e
+            )
+        });
+        ensure_valid_at_uri_regex(uri).unwrap_or_else(|e| panic!("ensure_valid_at_uri_regex validation test: Expected '{}' to be valid, but got error: {}", uri, e));
+    }
+
+    fn expect_invalid(uri: &str) {
+        assert!(ensure_valid_at_uri(uri).is_err(), "ensure_valid_at_uri invalidation test: Expected '{}' to be invalid, but it was considered valid", uri);
+        assert!(ensure_valid_at_uri_regex(uri).is_err(),  "ensure_valid_at_uri_regex invalidation test: Expected '{}' to be invalid, but it was considered valid", uri);
+    }
+
+    #[test]
+    fn test_enforces_spec_basics() {
+        // Valid URIs
+        expect_valid("at://did:plc:asdf123");
+        expect_valid("at://user.bsky.social");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/record");
+        expect_valid("at://did:plc:asdf123#/frag");
+        expect_valid("at://user.bsky.social#/frag");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post#/frag");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/record#/frag");
+
+        // Invalid URIs
+        expect_invalid("a://did:plc:asdf123");
+        expect_invalid("at//did:plc:asdf123");
+        expect_invalid("at:/a/did:plc:asdf123");
+        expect_invalid("at:/did:plc:asdf123");
+        expect_invalid("AT://did:plc:asdf123");
+        expect_invalid("http://did:plc:asdf123");
+        expect_invalid("://did:plc:asdf123");
+        expect_invalid("at:did:plc:asdf123");
+        expect_invalid("at:/did:plc:asdf123");
+        expect_invalid("at:///did:plc:asdf123");
+        expect_invalid("at://:/did:plc:asdf123");
+        expect_invalid("at:/ /did:plc:asdf123");
+        expect_invalid("at://did:plc:asdf123 ");
+        expect_invalid("at://did:plc:asdf123/ ");
+        expect_invalid(" at://did:plc:asdf123");
+        expect_invalid("at://did:plc:asdf123/com.atproto.feed.post ");
+        expect_invalid("at://did:plc:asdf123/com.atproto.feed.post# ");
+        expect_invalid("at://did:plc:asdf123/com.atproto.feed.post#/ ");
+        expect_invalid("at://did:plc:asdf123/com.atproto.feed.post#/frag ");
+        expect_invalid("at://did:plc:asdf123/com.atproto.feed.post#fr ag");
+        expect_invalid("//did:plc:asdf123");
+        expect_invalid("at://name");
+        expect_invalid("at://name.0");
+        expect_invalid("at://diD:plc:asdf123");
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        // Test slashes
+        expect_invalid("at://user.bsky.social//");
+        expect_invalid("at://user.bsky.social//com.atproto.feed.post");
+        expect_invalid("at://user.bsky.social/com.atproto.feed.post//");
+
+        // Test path depth
+        expect_invalid("at://did:plc:asdf123/com.atproto.feed.post/asdf123/more/more");
+        expect_invalid("at://did:plc:asdf123/short/stuff");
+        expect_invalid("at://did:plc:asdf123/12345");
+
+        // Test no trailing slashes
+        expect_valid("at://did:plc:asdf123");
+        expect_invalid("at://did:plc:asdf123/");
+        expect_valid("at://user.bsky.social");
+        expect_invalid("at://user.bsky.social/");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post");
+        expect_invalid("at://did:plc:asdf123/com.atproto.feed.post/");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/record");
+        expect_invalid("at://did:plc:asdf123/com.atproto.feed.post/record/");
+        expect_invalid("at://did:plc:asdf123/com.atproto.feed.post/record/#/frag");
+    }
+
+    #[test]
+    fn test_record_keys() {
+        // Test valid record keys
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/asdf123");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/a");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/%23");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/$@!*)(:,;~.sdf123");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/~'sdf123");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/$");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/@");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/!");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/*");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/(");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/,");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/;");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/abc%30123");
+    }
+
+    #[test]
+    fn test_fragments() {
+        // Test valid fragments
+        expect_valid("at://did:plc:asdf123#/frac");
+        expect_valid("at://did:plc:asdf123#/com.atproto.feed.post");
+        expect_valid("at://did:plc:asdf123#/com.atproto.feed.post/");
+        expect_valid("at://did:plc:asdf123#/asdf/");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post#/$@!*():,;~.sdf123");
+        expect_valid("at://did:plc:asdf123#/[asfd]");
+        expect_valid("at://did:plc:asdf123#/$");
+        expect_valid("at://did:plc:asdf123#/*");
+        expect_valid("at://did:plc:asdf123#/;");
+        expect_valid("at://did:plc:asdf123#/,");
+
+        // Test invalid fragments
+        expect_invalid("at://did:plc:asdf123#");
+        expect_invalid("at://did:plc:asdf123##");
+        expect_invalid("#at://did:plc:asdf123");
+        expect_invalid("at://did:plc:asdf123#/asdf#/asdf");
+    }
+
+    #[test]
+    fn test_url_encoding() {
+        // Test URL encoding acceptance
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/%30");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/%3");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/%");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/%zz");
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/%%%");
+    }
+
+    #[test]
+    fn test_length_limits() {
+        // Test valid length
+        expect_valid("at://did:plc:asdf123/com.atproto.feed.post/record");
+        expect_valid(&format!(
+            "at://did:plc:asdf123/com.atproto.feed.post/{}",
+            "o".repeat(800)
+        ));
+
+        // Test invalid length
+        expect_invalid(&format!(
+            "at://did:plc:asdf123/com.atproto.feed.post/{}",
+            "o".repeat(8200)
+        ));
+    }
+
+    #[test]
+    fn test_real_world_examples() {
+        expect_valid("at://did:plc:44ybard66vv44zksje25o7dz/app.bsky.feed.post/3jsrpdyf6ss23");
+        expect_valid("at://bsky.app/profile/jay.bsky.team/post/3jv5k4ooqw22e");
+        expect_valid("at://did:plc:ewvi7nxzyoun6zhxrhs64oiz/app.bsky.feed.post/3jstfwkdnpj2z");
+        expect_valid("at://bsky.app/profile/why.bsky.team/post/3jskxsox7r22g");
+        expect_valid("at://did:plc:ewvi7nxzyoun6zhxrhs64oiz/app.bsky.feed.generator/confirmed");
+        expect_valid("at://did:plc:ewvi7nxzyoun6zhxrhs64oiz/app.bsky.graph.follow/3juj6kquchx2f");
+    }
+}

--- a/rsky-syntax/src/aturi_validation.rs
+++ b/rsky-syntax/src/aturi_validation.rs
@@ -3,7 +3,8 @@ use regex::Regex;
 use thiserror::Error;
 
 use crate::{
-    aturi::AtUri, did::ensure_valid_did_regex, handle::ensure_valid_handle_regex, nsid::ensure_valid_nsid_regex
+    aturi::AtUri, did::ensure_valid_did_regex, handle::ensure_valid_handle_regex,
+    nsid::ensure_valid_nsid_regex,
 };
 
 // Human-readable constraints on ATURI:
@@ -123,10 +124,11 @@ pub fn ensure_valid_at_uri<S: Into<String>>(uri: S) -> Result<AtUri, AtUriValida
             // If there's a record key, validate it
             let rkey_idx = collection_idx + 1;
             if segments.len() > rkey_idx && segments[rkey_idx].is_empty() {
-                    return Err(AtUriValidationError(
-                        "ATURI can not have a slash after collection, unless record key is provided".into()
-                    ));
-                }
+                return Err(AtUriValidationError(
+                    "ATURI can not have a slash after collection, unless record key is provided"
+                        .into(),
+                ));
+            }
 
             // Validate max path segments for NSID paths
             if segments.len() > (collection_idx + 2) {

--- a/rsky-syntax/src/datetime.rs
+++ b/rsky-syntax/src/datetime.rs
@@ -1,0 +1,279 @@
+use chrono::{DateTime, Datelike, NaiveDateTime, Utc};
+use lazy_static::lazy_static;
+use regex::Regex;
+use thiserror::Error;
+
+/* Validates datetime string against atproto Lexicon 'datetime' format.
+ * Syntax is described at: https://atproto.com/specs/lexicon#datetime
+ */
+
+lazy_static! {
+    static ref DATETIME_REGEX: Regex = Regex::new(
+        r"^[0-9]{4}-[01][0-9]-[0-3][0-9]T[0-2][0-9]:[0-5][0-9]:[0-5][0-9](.[0-9]{1,20})?(Z|([+-][0-2][0-9]:[0-5][0-9]))$"
+    ).unwrap();
+}
+
+#[derive(Error, Debug)]
+#[error("InvalidDatetimeError: {0}")]
+pub struct InvalidDatetimeError(String);
+
+pub fn ensure_valid_datetime<S: Into<String>>(dt_str: S) -> Result<(), InvalidDatetimeError> {
+    let dt_str: String = dt_str.into();
+    // Regex check first - this validates the basic format
+    if !DATETIME_REGEX.is_match(&dt_str) {
+        return Err(InvalidDatetimeError(
+            "datetime didn't validate via regex".into(),
+        ));
+    }
+
+    // Check for negative dates and year zero
+    if dt_str.starts_with('-') {
+        return Err(InvalidDatetimeError(
+            "datetime normalized to a negative time".into(),
+        ));
+    }
+
+    if dt_str.starts_with("000") {
+        return Err(InvalidDatetimeError(
+            "datetime so close to year zero not allowed".into(),
+        ));
+    }
+
+    // Must parse as ISO 8601; this also verifies semantics like month is not 13 or 00
+    let parsed = DateTime::parse_from_rfc3339(&dt_str)
+        .map_err(|_| InvalidDatetimeError("datetime did not parse as ISO 8601".into()))?;
+
+    if dt_str.len() > 64 {
+        return Err(InvalidDatetimeError(
+            "datetime is too long (64 chars max)".into(),
+        ));
+    }
+
+    if dt_str.ends_with("-00:00") {
+        return Err(InvalidDatetimeError(
+            "datetime can not use \"-00:00\" for UTC timezone".into(),
+        ));
+    }
+
+    // Additional validation: the datetime must be valid according to the calendar
+    if parsed.year() < 1 {
+        return Err(InvalidDatetimeError(
+            "datetime before year 1 not allowed".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn is_valid_datetime<S: Into<String>>(dt_str: S) -> bool {
+    ensure_valid_datetime(dt_str).is_ok()
+}
+
+/* Takes a flexible datetime string and normalizes representation.
+ *
+ * This function will work with any valid atproto datetime (eg, anything which is_valid_datetime() is true for).
+ * It *additionally* is more flexible about accepting datetimes that don't comply to RFC 3339,
+ * or are missing timezone information, and normalizing them to a valid datetime.
+ *
+ * One use-case is a consistent, sortable string. Another is to work with older invalid createdAt datetimes.
+ *
+ * Successful output will be a valid atproto datetime with millisecond precision (3 sub-second digits)
+ * and UTC timezone with trailing 'Z' syntax. Throws `InvalidDatetimeError` if the input string could
+ * not be parsed as a datetime, even with permissive parsing.
+ *
+ * Expected output format: YYYY-MM-DDTHH:mm:ss.sssZ
+ */
+pub fn normalize_datetime<S: Into<String>>(dt_str: S) -> Result<String, InvalidDatetimeError> {
+    let dt_str: String = dt_str.into();
+    // First try strict RFC3339/ISO8601 parsing
+    if let Ok(dt) = DateTime::parse_from_rfc3339(&dt_str) {
+        let utc_dt = dt.with_timezone(&Utc);
+        let formatted = utc_dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
+        if is_valid_datetime(&formatted) {
+            return Ok(formatted);
+        }
+    }
+
+    // Special case for timestamps with milliseconds but no timezone
+    if let Ok(naive_dt) = NaiveDateTime::parse_from_str(&dt_str, "%Y-%m-%dT%H:%M:%S%.3f") {
+        let utc_dt = DateTime::<Utc>::from_naive_utc_and_offset(naive_dt, Utc);
+        let formatted = utc_dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
+        if is_valid_datetime(&formatted) {
+            return Ok(formatted);
+        }
+    }
+
+    // If no timezone specified, try parsing as naive datetime and then convert to UTC
+    if !dt_str.ends_with('Z') && !dt_str.contains('+') && !dt_str.contains('-') {
+        if let Ok(naive_dt) = NaiveDateTime::parse_from_str(&dt_str, "%Y-%m-%dT%H:%M:%S") {
+            let utc_dt = DateTime::<Utc>::from_naive_utc_and_offset(naive_dt, Utc);
+            let formatted = utc_dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
+            if is_valid_datetime(&formatted) {
+                return Ok(formatted);
+            }
+        }
+    }
+
+    // Try other flexible parsing formats
+    let parsed = DateTime::parse_from_rfc3339(&dt_str)
+        .or_else(|_| DateTime::parse_from_str(&dt_str, "%Y-%m-%dT%H:%M:%S%.f%:z"))
+        .or_else(|_| DateTime::parse_from_str(&dt_str, "%Y-%m-%d %H:%M:%S%.f%:z"))
+        // Try multiple variations of the RFC 822/RFC 2822 date format
+        .or_else(|_| DateTime::parse_from_str(&dt_str, "%a, %d %b %Y %H:%M:%S GMT"))
+        .or_else(|_| DateTime::parse_from_str(&dt_str, "%a, %d %B %Y %H:%M:%S GMT")) // Full month name
+        .or_else(|_| DateTime::parse_from_str(&dt_str, "%A, %d %b %Y %H:%M:%S GMT")) // Full weekday
+        .or_else(|_| DateTime::parse_from_str(&dt_str, "%A, %d %B %Y %H:%M:%S GMT")) // Both full
+        // Try with %Z
+        .or_else(|_| DateTime::parse_from_str(&dt_str, "%a, %d %b %Y %H:%M:%S %Z"))
+        .or_else(|_| DateTime::parse_from_str(&dt_str, "%a, %d %B %Y %H:%M:%S %Z")) // Full month name
+        .or_else(|_| DateTime::parse_from_str(&dt_str, "%A, %d %b %Y %H:%M:%S %Z")) // Full weekday
+        .or_else(|_| DateTime::parse_from_str(&dt_str, "%A, %d %B %Y %H:%M:%S %Z")) // Both full
+        // Try multiple variations of the RFC 822/RFC 2822 date format
+        .or_else(|_| DateTime::parse_from_rfc2822(&dt_str)); // last chance to parse format
+
+    match parsed {
+        Ok(dt) => {
+            let utc_dt = dt.with_timezone(&Utc);
+            let formatted = utc_dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
+            if is_valid_datetime(&formatted) {
+                Ok(formatted)
+            } else {
+                Err(InvalidDatetimeError(
+                    "datetime normalized to invalid timestamp string".into(),
+                ))
+            }
+        }
+        Err(e) => {
+            let kind_error = format!(
+                "datetime did not parse as any timestamp format, ParseErrorKind: {:?}",
+                e.kind()
+            );
+            Err(InvalidDatetimeError(kind_error))
+        }
+    }
+}
+
+/* Variant of normalizeDatetime() which always returns a valid datetime string.
+ *
+ * If a InvalidDatetimeError is encountered, returns the UNIX epoch time as a UTC datetime (1970-01-01T00:00:00.000Z).
+ */
+pub fn normalize_datetime_always<S: Into<String>>(dt_str: S) -> String {
+    match normalize_datetime(dt_str) {
+        Ok(dt) => dt,
+        Err(_) => "1970-01-01T00:00:00.000Z".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expect_valid(dt: &str) {
+        ensure_valid_datetime(dt)
+            .unwrap_or_else(|e| panic!("Expected '{}' to be valid, but got error: {}", dt, e));
+        assert!(is_valid_datetime(dt), "Expected '{}' to be valid", dt);
+        normalize_datetime(dt)
+            .unwrap_or_else(|e| panic!("Expected '{}' to normalize, but got error: {}", dt, e));
+        normalize_datetime_always(dt);
+    }
+
+    fn expect_invalid(dt: &str) {
+        assert!(
+            ensure_valid_datetime(dt).is_err(),
+            "Expected '{}' to be invalid, but it was considered valid",
+            dt
+        );
+        assert!(
+            !is_valid_datetime(dt),
+            "Expected '{}' to be invalid, but is_valid_datetime returned true",
+            dt
+        );
+    }
+
+    #[test]
+    fn test_valid_datetimes() {
+        expect_valid("2023-01-01T00:00:00Z");
+        expect_valid("2023-01-01T00:00:00.000Z");
+        expect_valid("2023-01-01T00:00:00.123Z");
+        expect_valid("2023-01-01T00:00:00+00:00");
+        expect_valid("2023-01-01T00:00:00-07:00");
+        expect_valid("2023-01-01T00:00:00.123456789Z");
+        expect_valid("9999-12-31T23:59:59.999Z");
+    }
+
+    #[test]
+    fn test_invalid_datetimes() {
+        expect_invalid("");
+        expect_invalid("2023");
+        expect_invalid("2023-01-01");
+        expect_invalid("2023-01-01T");
+        expect_invalid("2023-01-01T00:00:00");
+        expect_invalid("2023-01-01 00:00:00Z");
+        expect_invalid("2023-13-01T00:00:00Z");
+        expect_invalid("2023-00-01T00:00:00Z");
+        expect_invalid("2023-01-32T00:00:00Z");
+        expect_invalid("2023-01-01T24:00:00Z");
+        expect_invalid("2023-01-01T00:60:00Z");
+        expect_invalid("2023-01-01T00:00:60Z");
+        expect_invalid("-2023-01-01T00:00:00Z");
+        expect_invalid("0000-01-01T00:00:00Z");
+        expect_invalid("2023-01-01T00:00:00-00:00");
+        expect_invalid(&format!("2023-01-01T00:00:00{}", "0".repeat(65)));
+    }
+
+    #[test]
+    fn test_datetime_normalization() {
+        // Test basic normalization
+        assert_eq!(
+            normalize_datetime("1234-04-12T23:20:50Z").unwrap(),
+            "1234-04-12T23:20:50.000Z"
+        );
+        assert_eq!(
+            normalize_datetime("1985-04-12T23:20:50Z").unwrap(),
+            "1985-04-12T23:20:50.000Z"
+        );
+        assert_eq!(
+            normalize_datetime("1985-04-12T23:20:50.123").unwrap(),
+            "1985-04-12T23:20:50.123Z"
+        );
+
+        // Test timezone conversion
+        assert_eq!(
+            normalize_datetime("1985-04-12T10:20:50.1+01:00").unwrap(),
+            "1985-04-12T09:20:50.100Z"
+        );
+
+        // Test alternative formats
+        assert_eq!(
+            // The original typescript test was Fri, 02 Jan 1999 12:34:56 GMT
+            // however, January 2, 1999 is actually a Saturday
+            normalize_datetime("Sat, 02 Jan 1999 12:34:56 GMT").unwrap(),
+            "1999-01-02T12:34:56.000Z"
+        );
+    }
+
+    #[test]
+    fn test_invalid_normalization() {
+        assert!(normalize_datetime("").is_err());
+        assert!(normalize_datetime("blah").is_err());
+        assert!(normalize_datetime("1999-19-39T23:20:50.123Z").is_err());
+        assert!(normalize_datetime("-000001-12-31T23:00:00.000Z").is_err());
+        assert!(normalize_datetime("0000-01-01T00:00:00+01:00").is_err());
+    }
+
+    #[test]
+    fn test_normalize_always() {
+        assert_eq!(
+            normalize_datetime_always("1985-04-12T23:20:50Z"),
+            "1985-04-12T23:20:50.000Z"
+        );
+        assert_eq!(
+            normalize_datetime_always("blah"),
+            "1970-01-01T00:00:00.000Z"
+        );
+        assert_eq!(
+            normalize_datetime_always("0000-01-01T00:00:00+01:00"),
+            "1970-01-01T00:00:00.000Z"
+        );
+    }
+}

--- a/rsky-syntax/src/datetime.rs
+++ b/rsky-syntax/src/datetime.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Datelike, NaiveDateTime, Utc};
+use chrono::{DateTime, Datelike, FixedOffset, NaiveDateTime, Utc};
 use lazy_static::lazy_static;
 use regex::Regex;
 use thiserror::Error;
@@ -17,7 +17,9 @@ lazy_static! {
 #[error("InvalidDatetimeError: {0}")]
 pub struct InvalidDatetimeError(String);
 
-pub fn ensure_valid_datetime<S: Into<String>>(dt_str: S) -> Result<(), InvalidDatetimeError> {
+pub fn ensure_valid_datetime<S: Into<String>>(
+    dt_str: S,
+) -> Result<DateTime<FixedOffset>, InvalidDatetimeError> {
     let dt_str: String = dt_str.into();
     // Regex check first - this validates the basic format
     if !DATETIME_REGEX.is_match(&dt_str) {
@@ -62,7 +64,7 @@ pub fn ensure_valid_datetime<S: Into<String>>(dt_str: S) -> Result<(), InvalidDa
         ));
     }
 
-    Ok(())
+    Ok(parsed)
 }
 
 pub fn is_valid_datetime<S: Into<String>>(dt_str: S) -> bool {

--- a/rsky-syntax/src/datetime.rs
+++ b/rsky-syntax/src/datetime.rs
@@ -201,6 +201,19 @@ mod tests {
         expect_valid("2023-01-01T00:00:00-07:00");
         expect_valid("2023-01-01T00:00:00.123456789Z");
         expect_valid("9999-12-31T23:59:59.999Z");
+        // from documentation
+        // preferred
+        expect_valid("1985-04-12T23:20:50.123Z");
+        expect_valid("1985-04-12T23:20:50.123456Z");
+        expect_valid("1985-04-12T23:20:50.120Z");
+        expect_valid("1985-04-12T23:20:50.120000Z");
+
+        // supported
+        expect_valid("1985-04-12T23:20:50.12345678912345Z");
+        expect_valid("1985-04-12T23:20:50Z");
+        expect_valid("1985-04-12T23:20:50.0Z");
+        expect_valid("1985-04-12T23:20:50.123+00:00");
+        expect_valid("1985-04-12T23:20:50.123-07:00");
     }
 
     #[test]
@@ -221,6 +234,34 @@ mod tests {
         expect_invalid("0000-01-01T00:00:00Z");
         expect_invalid("2023-01-01T00:00:00-00:00");
         expect_invalid(&format!("2023-01-01T00:00:00{}", "0".repeat(65)));
+        expect_invalid("0000-01-01T00:00:00.000Z");
+        // Documentation invalid examples
+        expect_invalid("1985-04-12");
+        expect_invalid("1985-04-12T23:20Z");
+        expect_invalid("1985-04-12T23:20:5Z");
+        expect_invalid("1985-04-12T23:20:50.123");
+        expect_invalid("+001985-04-12T23:20:50.123Z");
+        expect_invalid("23:20:50.123Z");
+        expect_invalid("-1985-04-12T23:20:50.123Z");
+        expect_invalid("1985-4-12T23:20:50.123Z");
+        expect_invalid("01985-04-12T23:20:50.123Z");
+        expect_invalid("1985-04-12T23:20:50.123+00");
+        expect_invalid("1985-04-12T23:20:50.123+0000");
+
+        //ISO-8601 strict capitalization
+        expect_invalid("1985-04-12t23:20:50.123Z");
+        expect_invalid("1985-04-12T23:20:50.123z");
+
+        // RFC-3339, but not ISO-8601
+        expect_invalid("1985-04-12T23:20:50.123-00:00");
+        expect_invalid("1985-04-12 23:20:50.123Z");
+
+        // timezone is required
+        expect_invalid("1985-04-12T23:20:50.123");
+
+        // syntax looks ok, but datetime is not valid
+        expect_invalid("1985-04-12T23:99:50.123Z");
+        expect_invalid("1985-00-12T23:20:50.123Z");
     }
 
     #[test]

--- a/rsky-syntax/src/did.rs
+++ b/rsky-syntax/src/did.rs
@@ -1,0 +1,157 @@
+use lazy_static::lazy_static;
+use regex::Regex;
+use thiserror::Error;
+
+// Human-readable constraints:
+//   - valid W3C DID (https://www.w3.org/TR/did-core/#did-syntax)
+//      - entire URI is ASCII: [a-zA-Z0-9._:%-]
+//      - always starts "did:" (lower-case)
+//      - method name is one or more lower-case letters, followed by ":"
+//      - remaining identifier can have any of the above chars, but can not end in ":"
+//      - it seems that a bunch of ":" can be included, and don't need spaces between
+//      - "%" is used only for "percent encoding" and must be followed by two hex characters (and thus can't end in "%")
+//      - query ("?") and fragment ("#") stuff is defined for "DID URIs", but not as part of identifier itself
+//      - "The current specification does not take a position on the maximum length of a DID"
+//   - in current atproto, only allowing did:plc and did:web. But not *forcing* this at lexicon layer
+//   - hard length limit of 8KBytes
+//   - not going to validate "percent encoding" here
+
+lazy_static! {
+    // Regex for basic ASCII character validation
+    static ref ASCII_CHARS_REGEX: Regex = Regex::new(r"^[a-zA-Z0-9._:%-]*$").unwrap();
+
+    // Complex regex for full DID validation
+    static ref DID_FULL_REGEX: Regex = Regex::new(r"^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]$").unwrap();
+}
+
+#[derive(Error, Debug)]
+#[error("InvalidDidError: {0}")]
+pub struct InvalidDidError(String);
+
+pub fn ensure_valid_did<S: Into<String>>(did: S) -> Result<(), InvalidDidError> {
+    let did: String = did.into();
+    if !did.starts_with("did:") {
+        return Err(InvalidDidError("DID requires \"did:\" prefix".into()));
+    }
+
+    // Check that all chars are boring ASCII
+    if !ASCII_CHARS_REGEX.is_match(did.as_str()) {
+        return Err(InvalidDidError(
+            "Disallowed characters in DID (ASCII letters, digits, and a couple other characters only)".into(),
+        ));
+    }
+
+    let parts: Vec<&str> = did.split(':').collect();
+    if parts.len() < 3 {
+        return Err(InvalidDidError(
+            "DID requires prefix, method, and method-specific content".into(),
+        ));
+    }
+
+    let method = parts[1];
+    if !method.chars().all(|c| c.is_ascii_lowercase()) {
+        return Err(InvalidDidError(
+            "DID method must be lower-case letters".into(),
+        ));
+    }
+
+    if did.ends_with(':') || did.ends_with('%') {
+        return Err(InvalidDidError(
+            "DID can not end with \":\" or \"%\"".into(),
+        ));
+    }
+
+    if did.len() > 2 * 1024 {
+        return Err(InvalidDidError("DID is too long (2048 chars max)".into()));
+    }
+
+    Ok(())
+}
+
+pub fn ensure_valid_did_regex<S: Into<String>>(did: S) -> Result<(), InvalidDidError> {
+    let did: String = did.into();
+    if !DID_FULL_REGEX.is_match(did.as_str()) {
+        return Err(InvalidDidError("DID didn't validate via regex".into()));
+    }
+
+    if did.len() > 2 * 1024 {
+        return Err(InvalidDidError("DID is too long (2048 chars max)".into()));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expect_valid(did: &str) {
+        ensure_valid_did(did).unwrap();
+        ensure_valid_did_regex(did).unwrap();
+    }
+
+    fn expect_invalid(did: &str) {
+        assert!(ensure_valid_did(did).is_err());
+        assert!(ensure_valid_did_regex(did).is_err());
+    }
+
+    #[test]
+    fn test_enforces_spec_details() {
+        // Valid DIDs
+        expect_valid("did:method:val");
+        expect_valid("did:method:VAL");
+        expect_valid("did:method:val123");
+        expect_valid("did:method:123");
+        expect_valid("did:method:val-two");
+        expect_valid("did:method:val_two");
+        expect_valid("did:method:val.two");
+        expect_valid("did:method:val:two");
+        expect_valid("did:method:val%BB");
+
+        // Invalid DIDs
+        expect_invalid("did");
+        expect_invalid("didmethodval");
+        expect_invalid("method:did:val");
+        expect_invalid("did:method:");
+        expect_invalid("didmethod:val");
+        expect_invalid("did:methodval");
+        expect_invalid(":did:method:val");
+        expect_invalid("did.method.val");
+        expect_invalid("did:method:val:");
+        expect_invalid("did:method:val%");
+        expect_invalid("DID:method:val");
+        expect_invalid("did:METHOD:val");
+        expect_invalid("did:m123:val");
+
+        // Length checks
+        expect_valid(&format!("did:method:{}", "v".repeat(240)));
+        expect_invalid(&format!("did:method:{}", "v".repeat(8500)));
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        expect_valid("did:m:v");
+        expect_valid("did:method::::val");
+        expect_valid("did:method:-");
+        expect_valid("did:method:-:_:.:%ab");
+        expect_valid("did:method:.");
+        expect_valid("did:method:_");
+        expect_valid("did:method::.");
+
+        expect_invalid("did:method:val/two");
+        expect_invalid("did:method:val?two");
+        expect_invalid("did:method:val#two");
+        expect_invalid("did:method:val%");
+    }
+
+    #[test]
+    fn test_real_dids() {
+        expect_valid("did:example:123456789abcdefghi");
+        expect_valid("did:plc:7iza6de2dwap2sbkpav7c6c6");
+        expect_valid("did:web:example.com");
+        expect_valid("did:web:localhost%3A1234");
+        expect_valid("did:key:zQ3shZc2QzApp2oymGvQbzP8eKheVshBHbU4ZYjeXqwSKEn6N");
+        expect_valid("did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a");
+        expect_valid("did:onion:2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid");
+    }
+}

--- a/rsky-syntax/src/handle.rs
+++ b/rsky-syntax/src/handle.rs
@@ -33,13 +33,13 @@ lazy_static! {
 
 #[derive(Error, Debug)]
 pub enum HandleError {
-    #[error("{0}")]
+    #[error("HandleError: Invalid Handle {0}")]
     InvalidHandle(String),
-    #[error("{0}")]
+    #[error("HandleError: Reserved Handle {0}")]
     ReservedHandle(String),
-    #[error("{0}")]
+    #[error("HandleError: Unsupported Domain {0}")]
     UnsupportedDomain(String),
-    #[error("{0}")]
+    #[error("HandleError: Disallowed Domain {0}")]
     DisallowedDomain(String),
 }
 
@@ -69,9 +69,10 @@ pub fn is_valid_tld(handle: &str) -> bool {
 //  - does not validate whether domain or TLD exists, or is a reserved or
 //    special TLD (eg, .onion or .local)
 //  - does not validate punycode
-pub fn ensure_valid_handle(handle: &str) -> Result<(), HandleError> {
+pub fn ensure_valid_handle<S: Into<String>>(handle: S) -> Result<(), HandleError> {
+    let handle: String = handle.into();
     // Check that all chars are boring ASCII
-    if !ASCII_CHARS_REGEX.is_match(handle) {
+    if !ASCII_CHARS_REGEX.is_match(&handle) {
         return Err(HandleError::InvalidHandle(
             "Disallowed characters in handle (ASCII letters, digits, dashes, periods only)".into(),
         ));
@@ -122,8 +123,9 @@ pub fn ensure_valid_handle(handle: &str) -> Result<(), HandleError> {
     Ok(())
 }
 
-pub fn ensure_valid_handle_regex(handle: &str) -> Result<(), HandleError> {
-    if !HANDLE_FULL_REGEX.is_match(handle) {
+pub fn ensure_valid_handle_regex<S: Into<String>>(handle: S) -> Result<(), HandleError> {
+    let handle: String = handle.into();
+    if !HANDLE_FULL_REGEX.is_match(&handle) {
         return Err(HandleError::InvalidHandle(
             "Handle didn't validate via regex".into(),
         ));
@@ -138,17 +140,18 @@ pub fn ensure_valid_handle_regex(handle: &str) -> Result<(), HandleError> {
     Ok(())
 }
 
-pub fn normalize_handle(handle: &str) -> String {
+pub fn normalize_handle<S: Into<String>>(handle: S) -> String {
+    let handle: String = handle.into();
     handle.to_lowercase()
 }
 
-pub fn normalize_and_ensure_valid_handle(handle: &str) -> Result<String, HandleError> {
+pub fn normalize_and_ensure_valid_handle<S: Into<String>>(handle: S) -> Result<String, HandleError> {
     let normalized = normalize_handle(handle);
     ensure_valid_handle(&normalized)?;
     Ok(normalized)
 }
 
-pub fn is_valid_handle(handle: &str) -> bool {
+pub fn is_valid_handle<S: Into<String>>(handle: S) -> bool {
     ensure_valid_handle(handle).is_ok()
 }
 

--- a/rsky-syntax/src/handle.rs
+++ b/rsky-syntax/src/handle.rs
@@ -146,7 +146,9 @@ pub fn normalize_handle<S: Into<String>>(handle: S) -> String {
     handle.to_lowercase()
 }
 
-pub fn normalize_and_ensure_valid_handle<S: Into<String>>(handle: S) -> Result<String, HandleError> {
+pub fn normalize_and_ensure_valid_handle<S: Into<String>>(
+    handle: S,
+) -> Result<String, HandleError> {
     let normalized = normalize_handle(handle);
     ensure_valid_handle(&normalized)?;
     Ok(normalized)

--- a/rsky-syntax/src/handle.rs
+++ b/rsky-syntax/src/handle.rs
@@ -43,7 +43,8 @@ pub enum HandleError {
     DisallowedDomain(String),
 }
 
-pub fn is_valid_tld(handle: &str) -> bool {
+pub fn is_valid_tld<S: Into<String>>(handle: S) -> bool {
+    let handle: String = handle.into();
     let handle_lower = handle.to_lowercase();
     !DISALLOWED_TLDS
         .iter()

--- a/rsky-syntax/src/lib.rs
+++ b/rsky-syntax/src/lib.rs
@@ -3,4 +3,10 @@ extern crate serde_derive;
 extern crate serde;
 
 pub mod aturi;
+pub mod aturi_validation;
+pub mod datetime;
+pub mod did;
 pub mod handle;
+pub mod nsid;
+pub mod record_key;
+pub mod tid;

--- a/rsky-syntax/src/nsid.rs
+++ b/rsky-syntax/src/nsid.rs
@@ -1,0 +1,282 @@
+use std::fmt::Display;
+use lazy_static::lazy_static;
+use regex::Regex;
+use thiserror::Error;
+
+/*
+Grammar:
+
+alpha     = "a" / "b" / "c" / "d" / "e" / "f" / "g" / "h" / "i" / "j" / "k" / "l" / "m" / "n" /
+            "o" / "p" / "q" / "r" / "s" / "t" / "u" / "v" / "w" / "x" / "y" / "z" / "A" / "B" /
+            "C" / "D" / "E" / "F" / "G" / "H" / "I" / "J" / "K" / "L" / "M" / "N" / "O" / "P" /
+            "Q" / "R" / "S" / "T" / "U" / "V" / "W" / "X" / "Y" / "Z"
+number    = "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9" / "0"
+delim     = "."
+segment   = alpha *( alpha / number / "-" )
+authority = segment *( delim segment )
+name      = alpha *( alpha )
+nsid      = authority delim name
+*/
+
+lazy_static! {
+    // Regex for basic ASCII character validation
+    static ref ASCII_CHARS_REGEX: Regex = Regex::new(r"^[a-zA-Z0-9.-]*$").unwrap();
+
+    // Complex regex for full NSID validation
+    static ref NSID_FULL_REGEX: Regex = Regex::new(
+        r"^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(\.[a-zA-Z]([a-zA-Z]{0,61}[a-zA-Z])?)$"
+    ).unwrap();
+}
+
+#[derive(Error, Debug)]
+#[error("InvalidNsidError: {0}")]
+pub struct InvalidNsidError(String);
+
+// Human readable constraints on NSID:
+// - a valid domain in reversed notation
+// - followed by an additional period-separated name, which is camel-case letters
+pub fn ensure_valid_nsid<S: Into<String>>(nsid: S) -> Result<(), InvalidNsidError> {
+    let nsid: String = nsid.into();
+    // Check that all chars are boring ASCII
+    if !ASCII_CHARS_REGEX.is_match(&nsid) {
+        return Err(InvalidNsidError(
+            "Disallowed characters in NSID (ASCII letters, digits, dashes, periods only)".into(),
+        ));
+    }
+
+    // Check overall length
+    if nsid.len() > 253 + 1 + 63 {
+        return Err(InvalidNsidError("NSID is too long (317 chars max)".into()));
+    }
+
+    // Split into labels and validate each part
+    let labels: Vec<&str> = nsid.split('.').collect();
+    if labels.len() < 3 {
+        return Err(InvalidNsidError("NSID needs at least three parts".into()));
+    }
+
+    for (i, label) in labels.iter().enumerate() {
+        if label.is_empty() {
+            return Err(InvalidNsidError("NSID parts can not be empty".into()));
+        }
+
+        if label.len() > 63 {
+            return Err(InvalidNsidError("NSID part too long (max 63 chars)".into()));
+        }
+
+        if label.ends_with('-') || label.starts_with('-') {
+            return Err(InvalidNsidError(
+                "NSID parts can not start or end with hyphen".into(),
+            ));
+        }
+
+        if i == 0 && label.starts_with(char::is_numeric) {
+            return Err(InvalidNsidError(
+                "NSID first part may not start with a digit".into(),
+            ));
+        }
+
+        // Validate the final name segment is only letters
+        if i == labels.len() - 1 && !label.chars().all(|c| c.is_ascii_alphabetic()) {
+            return Err(InvalidNsidError(
+                "NSID name part must be only letters".into(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn ensure_valid_nsid_regex(nsid: &str) -> Result<(), InvalidNsidError> {
+    if !NSID_FULL_REGEX.is_match(nsid) {
+        return Err(InvalidNsidError("NSID didn't validate via regex".into()));
+    }
+
+    if nsid.len() > 253 + 1 + 63 {
+        return Err(InvalidNsidError("NSID is too long (317 chars max)".into()));
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Nsid {
+    segments: Vec<String>,
+}
+
+impl Nsid {
+    pub fn parse<S: Into<String>>(nsid: S) -> Result<Self, InvalidNsidError> {
+        let nsid: String = nsid.into();
+        ensure_valid_nsid(&nsid)?;
+        Ok(Self {
+            segments: nsid.split('.').map(String::from).collect(),
+        })
+    }
+
+    pub fn create(authority: &str, name: &str) -> Result<Self, InvalidNsidError> {
+        let mut segments: Vec<String> = authority.split('.').rev().map(String::from).collect();
+        segments.push(name.to_string());
+        let nsid = segments.join(".");
+        ensure_valid_nsid(&nsid)?;
+        Ok(Self { segments })
+    }
+
+    pub fn authority(&self) -> String {
+        self.segments[..self.segments.len() - 1]
+            .iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<String>>()
+            .join(".")
+    }
+
+    pub fn name(&self) -> &str {
+        self.segments.last().unwrap()
+    }
+}
+
+impl Display for Nsid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.segments.join("."))
+    }
+}
+
+impl TryFrom<&str> for Nsid {
+    type Error = InvalidNsidError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Nsid::parse(value.to_string())
+    }
+}
+
+impl TryFrom<String> for Nsid {
+    type Error = InvalidNsidError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Nsid::parse(value.to_string())
+    }
+}
+
+impl TryFrom<&String> for Nsid {
+    type Error = InvalidNsidError;
+
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        Nsid::parse(value.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expect_valid(nsid: &str) {
+        ensure_valid_nsid(nsid).unwrap();
+        ensure_valid_nsid_regex(nsid).unwrap();
+    }
+
+    fn expect_invalid(nsid: &str) {
+        assert!(ensure_valid_nsid(nsid).is_err());
+        assert!(ensure_valid_nsid_regex(nsid).is_err());
+    }
+
+    #[test]
+    fn test_nsid_parsing_and_creation() {
+        let nsid = Nsid::parse("com.example.foo").unwrap();
+        assert_eq!(nsid.authority(), "example.com");
+        assert_eq!(nsid.name(), "foo");
+        assert_eq!(nsid.to_string(), "com.example.foo");
+
+        let nsid = Nsid::parse("com.long-thing1.cool.fooBarBaz").unwrap();
+        assert_eq!(nsid.authority(), "cool.long-thing1.com");
+        assert_eq!(nsid.name(), "fooBarBaz");
+        assert_eq!(nsid.to_string(), "com.long-thing1.cool.fooBarBaz");
+    }
+
+    #[test]
+    fn test_nsid_creation() {
+        let nsid = Nsid::create("example.com", "foo").unwrap();
+        assert_eq!(nsid.authority(), "example.com");
+        assert_eq!(nsid.name(), "foo");
+        assert_eq!(nsid.to_string(), "com.example.foo");
+
+        let nsid = Nsid::create("cool.long-thing1.com", "fooBarBaz").unwrap();
+        assert_eq!(nsid.authority(), "cool.long-thing1.com");
+        assert_eq!(nsid.name(), "fooBarBaz");
+        assert_eq!(nsid.to_string(), "com.long-thing1.cool.fooBarBaz");
+    }
+
+    #[test]
+    fn test_enforces_spec_details() {
+        // Valid NSIDs
+        expect_valid("com.example.foo");
+        expect_valid("net.users.bob.ping");
+        expect_valid("a.b.c");
+        expect_valid("m.xn--masekowski-d0b.pl");
+        expect_valid("one.two.three");
+        expect_valid("one.two.three.four-and.FiVe");
+        expect_valid("one.2.three");
+        expect_valid("a-0.b-1.c");
+        expect_valid("a0.b1.cc");
+        expect_valid("cn.8.lex.stuff");
+        expect_valid("test.12345.record");
+        expect_valid("a01.thing.record");
+        expect_valid("a.0.c");
+        expect_valid("xn--fiqs8s.xn--fiqa61au8b7zsevnm8ak20mc4a87e.record.two");
+
+        // Test max length segments
+        let long_nsid = format!("com.{}.foo", "o".repeat(63));
+        expect_valid(&long_nsid);
+
+        // Invalid NSIDs
+        expect_invalid("com.example.foo.*");
+        expect_invalid("com.example.foo.blah*");
+        expect_invalid("com.example.foo.*blah");
+        expect_invalid("com.example.f00");
+        expect_invalid("com.exa💩ple.thing");
+        expect_invalid("a-0.b-1.c-3");
+        expect_invalid("a-0.b-1.c-o");
+        expect_invalid("a0.b1.c3");
+        expect_invalid("1.0.0.127.record");
+        expect_invalid("0two.example.foo");
+        expect_invalid("example.com");
+        expect_invalid("com.example");
+        expect_invalid("a.");
+        expect_invalid(".one.two.three");
+        expect_invalid("one.two.three ");
+        expect_invalid("one.two..three");
+        expect_invalid("one .two.three");
+        expect_invalid(" one.two.three");
+        expect_invalid("com.exa💩ple.thing");
+        expect_invalid("com.atproto.feed.p@st");
+        expect_invalid("com.atproto.feed.p_st");
+        expect_invalid("com.atproto.feed.p*st");
+        expect_invalid("com.atproto.feed.po#t");
+        expect_invalid("com.atproto.feed.p!ot");
+        expect_invalid("com.example-.foo");
+
+        // Test segments too long
+        let too_long_nsid = format!("com.{}.foo", "o".repeat(64));
+        expect_invalid(&too_long_nsid);
+
+        // Test overall too long
+        let too_long_overall = format!("com.{}.foo", "middle.".repeat(50));
+        expect_invalid(&too_long_overall);
+    }
+
+    #[test]
+    fn test_allows_onion_nsids() {
+        expect_valid("onion.expyuzz4wqqyqhjn.spec.getThing");
+        expect_valid(
+            "onion.g2zyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.lex.deleteThing",
+        );
+    }
+
+    #[test]
+    fn test_allows_numeric_segments() {
+        expect_valid("org.4chan.lex.getThing");
+        expect_valid("cn.8.lex.stuff");
+        expect_valid(
+            "onion.2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.lex.deleteThing",
+        );
+    }
+}

--- a/rsky-syntax/src/nsid.rs
+++ b/rsky-syntax/src/nsid.rs
@@ -1,6 +1,6 @@
-use std::fmt::Display;
 use lazy_static::lazy_static;
 use regex::Regex;
+use std::fmt::Display;
 use thiserror::Error;
 
 /*

--- a/rsky-syntax/src/record_key.rs
+++ b/rsky-syntax/src/record_key.rs
@@ -1,0 +1,264 @@
+use lazy_static::lazy_static;
+use regex::Regex;
+use thiserror::Error;
+
+lazy_static! {
+    // Regex to validate record key syntax:
+    // - ASCII alphanumeric chars, plus underscore, tilde, period, colon, hyphen
+    // - Length between 1 and 512 characters
+    static ref RKEY_REGEX: Regex = Regex::new(r"^[a-zA-Z0-9_~.:-]{1,512}$").unwrap();
+}
+
+#[derive(Error, Debug)]
+#[error("InvalidRecordKeyError: {0}")]
+pub struct InvalidRecordKeyError(String);
+
+/// Validates a record key according to AT Protocol specification.
+///
+/// Record Keys constraints:
+/// - Must contain only a subset of ASCII characters: alphanumeric (A-Za-z0-9),
+///   period, dash, underscore, colon, or tilde (.-_:~)
+/// - Must have at least 1 and at most 512 characters
+/// - The specific values "." and ".." are not allowed
+/// - Must be a permissible part of repository MST path string
+/// - Must be permissible to include in a path component of a URI (following RFC-3986, section 3.3)
+///
+/// Record Keys are case-sensitive.
+pub fn ensure_valid_record_key<S: Into<String>>(rkey: S) -> Result<(), InvalidRecordKeyError> {
+    let rkey: String = rkey.into();
+    if rkey.is_empty() || rkey.len() > 512 {
+        return Err(InvalidRecordKeyError(
+            "record key must be 1 to 512 characters".into(),
+        ));
+    }
+
+    // Check for forbidden exact values
+    if rkey == "." || rkey == ".." {
+        return Err(InvalidRecordKeyError(
+            "record key can not be \".\" or \"..\"".into(),
+        ));
+    }
+
+    // Validate format using regex
+    if !RKEY_REGEX.is_match(&rkey) {
+        return Err(InvalidRecordKeyError(
+            "record key syntax not valid (regex)".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Returns true if the given string is a valid record key, false otherwise.
+pub fn is_valid_record_key<S: Into<String>>(rkey: S) -> bool {
+    ensure_valid_record_key(rkey).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expect_valid(rkey: &str) {
+        ensure_valid_record_key(rkey).unwrap_or_else(|e| panic!("ensure_valid_record_key validation test: Expected '{}' to be valid, but got error: {}", rkey, e));
+        assert!(
+            is_valid_record_key(rkey),
+            "is_valid_record_key validation error: Expected '{}' to be true, but got false",
+            rkey
+        );
+    }
+
+    fn expect_invalid(rkey: &str) {
+        assert!(ensure_valid_record_key(rkey).is_err(), "ensure_valid_record_key invalidation test: Expected '{}' to be invalid, but it was considered valid", rkey);
+        assert!(
+            !is_valid_record_key(rkey),
+            "is_valid_record_key invalidation test:  Expected '{}' to be false, but it was true",
+            rkey
+        );
+    }
+
+    #[test]
+    fn test_valid_record_keys() {
+        // Basic valid keys
+        expect_valid("3jui7kd54zh2y");
+        expect_valid("self");
+        expect_valid("example.com");
+        expect_valid("~1.2-3_");
+        expect_valid("dHJ1ZQ");
+        expect_valid("pre:fix");
+        expect_valid("_");
+
+        // Test allowed special characters
+        expect_valid("test.record");
+        expect_valid("test-record");
+        expect_valid("test_record");
+        expect_valid("test~record");
+        expect_valid("test:record");
+
+        // Test mixed case
+        expect_valid("TestRecord");
+        expect_valid("testRecord");
+        expect_valid("TESTRECORD");
+
+        // Test numbers
+        expect_valid("123");
+        expect_valid("test123");
+        expect_valid("123test");
+
+        // Test edge cases for length
+        expect_valid("a");
+        expect_valid(&"a".repeat(512));
+    }
+
+    #[test]
+    fn test_invalid_record_keys() {
+        // Invalid characters
+        expect_invalid("alpha/beta");
+        expect_invalid("@handle");
+        expect_invalid("any space");
+        expect_invalid("any+space");
+        expect_invalid("number[3]");
+        expect_invalid("number(3)");
+        expect_invalid("\"quote\"");
+        expect_invalid("test\\record");
+        expect_invalid("test?record");
+        expect_invalid("test#record");
+        expect_invalid("test&record");
+        expect_invalid("test%record");
+
+        // Reserved names
+        expect_invalid(".");
+        expect_invalid("..");
+
+        // Length violations
+        expect_invalid("");
+        expect_invalid(&"a".repeat(513));
+
+        // Spaces and special characters
+        expect_invalid(" test");
+        expect_invalid("test ");
+        expect_invalid("test test");
+        expect_invalid("\ttest");
+        expect_invalid("test\n");
+
+        // Non-ASCII characters
+        expect_invalid("tést");
+        expect_invalid("テスト");
+        expect_invalid("🔑");
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        // Length boundary tests
+        expect_invalid(""); // empty string
+        expect_valid("a"); // minimum length (1)
+        expect_valid(&"a".repeat(512)); // maximum length
+        expect_invalid(&"a".repeat(513)); // exceeds maximum
+        expect_valid(&"z".repeat(512)); // different char at max length
+        expect_valid(&"9".repeat(512)); // numbers at max length
+
+        // Special character combinations
+        expect_valid("a~b_c.d:e-f"); // all allowed special chars
+        expect_valid("~~~~~~~~~"); // all tildes
+        expect_valid("........"); // multiple dots (but not . or ..)
+        expect_valid("::::::::"); // all colons
+        expect_valid("--------"); // all hyphens
+        expect_valid("________"); // all underscores
+
+        // Dots in various positions (but avoiding . and .. exactly)
+        expect_valid("a."); // dot at end
+        expect_valid(".a"); // dot at start
+        expect_valid("a.a"); // single dot middle
+        expect_valid("a..a"); // double dot middle
+        expect_valid("...a"); // multiple dots start
+        expect_valid("a..."); // multiple dots end
+
+        // Almost . and .. cases
+        expect_valid(".suffix"); // starts with dot
+        expect_valid("prefix."); // ends with dot
+        expect_valid("..suffix"); // starts with dots
+        expect_valid("prefix.."); // ends with dots
+        expect_invalid(".."); // exactly .. (invalid)
+        expect_invalid("."); // exactly . (invalid)
+
+        // Case sensitivity tests
+        expect_valid("UPPER");
+        expect_valid("lower");
+        expect_valid("MiXeDcAsE");
+        expect_valid("camelCase");
+        expect_valid("PascalCase");
+        expect_valid("snake_case");
+        expect_valid("SCREAMING_SNAKE_CASE");
+        expect_valid("kebab-case");
+        expect_valid("UPPER-KEBAB-CASE");
+
+        // Number patterns
+        expect_valid("123"); // all numbers
+        expect_valid("0"); // single zero
+        expect_valid("000"); // multiple zeros
+        expect_valid("0a"); // zero prefix
+        expect_valid("a0"); // zero suffix
+        expect_valid("99999999"); // many numbers
+
+        // Mixed pattern tests
+        expect_valid("a-b_c.d:e~f"); // alternating chars and special chars
+        expect_valid("A-B_C.D:E~F"); // upper case version
+        expect_valid("123-456_789.0:1~2"); // numbers with special chars
+        expect_valid("a~1_b~2_c~3"); // repeating pattern
+        expect_valid("...___---~~~:::"); // grouped special chars
+
+        // Boundary pattern tests
+        expect_valid("~a"); // tilde start
+        expect_valid("a~"); // tilde end
+        expect_valid("-a"); // hyphen start
+        expect_valid("a-"); // hyphen end
+        expect_valid("_a"); // underscore start
+        expect_valid("a_"); // underscore end
+        expect_valid(":a"); // colon start
+        expect_valid("a:"); // colon end
+
+        // Invalid special character tests
+        expect_invalid("/"); // just slash
+        expect_invalid(" "); // just space
+        expect_invalid("\t"); // just tab
+        expect_invalid("\n"); // just newline
+        expect_invalid("\r"); // just carriage return
+        expect_invalid("a b"); // space in middle
+        expect_invalid("a/b"); // slash in middle
+        expect_invalid("a\tb"); // tab in middle
+        expect_invalid("a\nb"); // newline in middle
+        expect_invalid("a\rb"); // carriage return in middle
+
+        // Invalid character combinations
+        expect_invalid("hello world"); // space
+        expect_invalid("hello/world"); // forward slash
+        expect_invalid("hello\\world"); // backslash
+        expect_invalid("hello'world"); // single quote
+        expect_invalid("hello\"world"); // double quote
+        expect_invalid("hello`world"); // backtick
+        expect_invalid("hello!world"); // exclamation
+        expect_invalid("hello@world"); // at sign
+        expect_invalid("hello#world"); // hash
+        expect_invalid("hello$world"); // dollar
+        expect_invalid("hello%world"); // percent
+        expect_invalid("hello^world"); // caret
+        expect_invalid("hello&world"); // ampersand
+        expect_invalid("hello*world"); // asterisk
+        expect_invalid("hello(world"); // open paren
+        expect_invalid("hello)world"); // close paren
+        expect_invalid("hello+world"); // plus
+        expect_invalid("hello=world"); // equals
+        expect_invalid("hello{world"); // open brace
+        expect_invalid("hello}world"); // close brace
+        expect_invalid("hello[world"); // open bracket
+        expect_invalid("hello]world"); // close bracket
+        expect_invalid("hello|world"); // pipe
+        expect_invalid("hello\\world"); // backslash
+        expect_invalid("hello<world"); // less than
+        expect_invalid("hello>world"); // greater than
+        expect_invalid("hello?world"); // question mark
+        expect_invalid("hello,world"); // comma
+        expect_invalid("hello;world"); // semicolon
+        expect_invalid("hello世界"); // unicode
+        expect_invalid("hello👋world"); // emoji
+    }
+}

--- a/rsky-syntax/src/tid.rs
+++ b/rsky-syntax/src/tid.rs
@@ -1,0 +1,142 @@
+use lazy_static::lazy_static;
+use regex::Regex;
+use thiserror::Error;
+
+lazy_static! {
+    // Reference regex for TID:
+    // Must be exactly 13 characters from base32-sortable charset
+    // First character must be one of 234567abcdefghij
+    // All other characters from base32-sortable charset: 234567abcdefghijklmnopqrstuvwxyz
+    static ref TID_REGEX: Regex = Regex::new(
+        r"^[234567abcdefghij][234567abcdefghijklmnopqrstuvwxyz]{12}$"
+    ).unwrap();
+}
+
+#[derive(Error, Debug)]
+#[error("InvalidTidError: {0}")]
+pub struct InvalidTidError(String);
+
+/// Validates a TID string according to the atproto specification.
+///
+/// TID ("timestamp identifier") is a compact string identifier based on an integer timestamp.
+/// The string must be:
+/// - 64-bit integer based
+/// - big-endian byte ordering
+/// - encoded as base32-sortable (chars: 234567abcdefghijklmnopqrstuvwxyz)
+/// - no padding characters
+/// - length is always 13 ASCII characters
+/// - first character must be one of 234567abcdefghij (indicating high bit is 0)
+///
+/// The integer layout is:
+/// - top bit always 0
+/// - next 53 bits are microseconds since UNIX epoch (for JavaScript safe integers)
+/// - final 10 bits are a random "clock identifier"
+pub fn ensure_valid_tid<S: Into<String>>(tid: S) -> Result<(), InvalidTidError> {
+    let tid: String = tid.into();
+    // Check fixed length
+    if tid.len() != 13 {
+        return Err(InvalidTidError("TID must be 13 characters".into()));
+    }
+
+    // Validate format using regex
+    if !TID_REGEX.is_match(&tid) {
+        return Err(InvalidTidError("TID syntax not valid (regex)".into()));
+    }
+
+    Ok(())
+}
+
+/// Returns true if the given string is a valid TID, false otherwise.
+pub fn is_valid_tid<S: Into<String>>(tid: S) -> bool {
+    ensure_valid_tid(tid).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expect_valid(tid: &str) {
+        ensure_valid_tid(tid).unwrap();
+        assert!(is_valid_tid(tid));
+    }
+
+    fn expect_invalid(tid: &str) {
+        assert!(ensure_valid_tid(tid).is_err());
+        assert!(!is_valid_tid(tid));
+    }
+
+    #[test]
+    fn test_valid_tids() {
+        // Test known valid TIDs
+        expect_valid("3jzfcijpj2z2a");
+        expect_valid("7777777777777");
+        expect_valid("3zzzzzzzzzzzz");
+        expect_valid("2222222222222");
+
+        // Test various first characters
+        for c in "234567abcdefghij".chars() {
+            let tid = format!("{}222222222222", c);
+            expect_valid(&tid);
+        }
+    }
+
+    #[test]
+    fn test_invalid_tids() {
+        // Wrong length
+        expect_invalid("3jzfcijpj2z2");
+        expect_invalid("3jzfcijpj2z2aa");
+        expect_invalid("");
+        expect_invalid("222");
+
+        // Invalid characters
+        expect_invalid("3jzfcijpj2z21"); // contains '1'
+        expect_invalid("0000000000000"); // contains '0'
+        expect_invalid("3JZFCIJPJ2Z2A"); // uppercase
+
+        // Legacy dash syntax not supported
+        expect_invalid("3jzf-cij-pj2z-2a");
+
+        // High bit can't be set (first char restrictions)
+        expect_invalid("zzzzzzzzzzzzz");
+        expect_invalid("kjzfcijpj2z2a");
+        expect_invalid("lzzzzzzzzzzzz");
+        expect_invalid("mzzzzzzzzzzzz");
+        expect_invalid("nzzzzzzzzzzzz");
+        expect_invalid("ozzzzzzzzzzzz");
+        expect_invalid("pzzzzzzzzzzzz");
+        expect_invalid("qzzzzzzzzzzzz");
+        expect_invalid("rzzzzzzzzzzzz");
+        expect_invalid("szzzzzzzzzzzz");
+        expect_invalid("tzzzzzzzzzzzz");
+        expect_invalid("uzzzzzzzzzzzz");
+        expect_invalid("vzzzzzzzzzzzz");
+        expect_invalid("wzzzzzzzzzzzz");
+        expect_invalid("xzzzzzzzzzzzz");
+        expect_invalid("yzzzzzzzzzzzz");
+        expect_invalid("zzzzzzzzzzzzz");
+
+        // Invalid characters in the rest of the string
+        expect_invalid("3jzfcijpj2z2!");
+        expect_invalid("3jzfcijpj2z2@");
+        expect_invalid("3jzfcijpj2z2#");
+        expect_invalid("3jzfcijpj2z2$");
+        expect_invalid("3jzfcijpj2z2%");
+        expect_invalid("3jzfcijpj2z2^");
+        expect_invalid("3jzfcijpj2z2&");
+        expect_invalid("3jzfcijpj2z2*");
+        expect_invalid("3jzfcijpj2z2(");
+        expect_invalid("3jzfcijpj2z2)");
+        expect_invalid("3jzfcijpj2z2_");
+        expect_invalid("3jzfcijpj2z2+");
+        expect_invalid("3jzfcijpj2z2=");
+        expect_invalid("3jzfcijpj2z2`");
+        expect_invalid("3jzfcijpj2z2~");
+
+        // Spaces and special characters
+        expect_invalid(" 3jzfcijpj2z2");
+        expect_invalid("3jzfcijpj2z2 ");
+        expect_invalid("3jzf ijpj2z2a");
+        expect_invalid("\t3jzfcijpj2z2");
+        expect_invalid("3jzfcijpj2z2\n");
+    }
+}


### PR DESCRIPTION
Closes #38 

>Should we validate AT URIs in our codebase even though TypeScript doesn't? The validation code exists but isn't used.

Okay upon further testing and review, the [ensureValidAtUri](https://github.com/bluesky-social/atproto/blob/main/packages/syntax/src/aturi_validation.ts#L18)  in the typscript codebase does not consider:
1. AtURIs with the query parameters.  
2. As far as I can tell, it is _only_ used to validate the "subject" URIs that you may find in repository records.
3. My implementation conforms to the typescript capability and so I have decided to not incorporate it in `AtUri::new` code.


You'll still be able to:
```rust
// New Rust-style (one step)
let at_uri = ensure_valid_at_uri(uri)?;
// or...
let _ = ensure_valid_at_uri(uri)?;
```

and similarly in the other validation functions implementations, `ensure_valid_datetime`, if ok, will return a `DateTime<FixedOffset>>`.  So you'll be able to:
```rust
// New Rust-style (one step)
let validated_datetime = ensure_valid_datetime(date_str)?;
// or...
let _ = ensure_valid_datetime(date_str)?;
```

I'm doing so since the code parses the string to a datetime object successfully.  The other validation code evaluates strings and it's a bit redundant to return a string again.

