### PR TITLE
BugFix:Token Validation

### DIFF
--- a/rsky-pds/src/account_manager/helpers/email_token.rs
+++ b/rsky-pds/src/account_manager/helpers/email_token.rs
@@ -1,6 +1,6 @@
 use crate::apis::com::atproto::server::get_random_token;
 use crate::common;
-use crate::common::time::{from_str_to_utc, less_than_ago_ms, MINUTE};
+use crate::common::time::{from_str_to_utc, less_than_ago_s, MINUTE};
 use crate::db::establish_connection;
 use crate::models::models::EmailTokenPurpose;
 use crate::models::EmailToken;
@@ -49,7 +49,7 @@ pub async fn assert_valid_token(
         .optional()?;
     if let Some(res) = res {
         let requested_at = from_str_to_utc(&res.requested_at);
-        let expired = !less_than_ago_ms(requested_at, expiration_len);
+        let expired = !less_than_ago_s(requested_at, expiration_len);
         if expired {
             bail!("Token is expired")
         }
@@ -76,7 +76,7 @@ pub async fn assert_valid_token_and_find_did(
         .optional()?;
     if let Some(res) = res {
         let requested_at = from_str_to_utc(&res.requested_at);
-        let expired = !less_than_ago_ms(requested_at, expiration_len);
+        let expired = !less_than_ago_s(requested_at, expiration_len);
         if expired {
             bail!("Token is expired")
         }

--- a/rsky-pds/src/apis/com/atproto/server/mod.rs
+++ b/rsky-pds/src/apis/com/atproto/server/mod.rs
@@ -69,10 +69,12 @@ pub struct AssertionContents {
 pub fn get_random_token() -> String {
     let token: String = rand::thread_rng()
         .sample_iter(&Alphanumeric)
-        .take(32)
+        .take(50)
         .map(char::from)
         .collect();
-    token[0..5].to_owned() + "-" + &token[5..10]
+    //Bluesky Client doesn't support 1,8,9,0 in the email verification tokens
+    let allowed_token = token.replace(&['1', '8', '9', '0'][..], "");
+    allowed_token[0..5].to_owned() + "-" + &allowed_token[5..10]
 }
 
 pub async fn safe_resolve_did_doc(

--- a/rsky-pds/src/common/time.rs
+++ b/rsky-pds/src/common/time.rs
@@ -9,12 +9,13 @@ pub const MINUTE: i32 = SECOND * 60;
 pub const HOUR: i32 = MINUTE * 60;
 pub const DAY: i32 = HOUR * 24;
 
-pub fn less_than_ago_ms(time: DateTime<UtcOffset>, range: i32) -> bool {
+pub fn less_than_ago_s(time: DateTime<UtcOffset>, range: i32) -> bool {
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("timestamp in micros since UNIX epoch")
-        .as_micros() as usize;
-    now < (time.timestamp() as usize + range as usize)
+        .as_secs() as usize;
+    let x = time.timestamp() as usize + range as usize;
+    now < x
 }
 
 pub fn from_str_to_micros(str: &String) -> i64 {


### PR DESCRIPTION
Current token validation behavior causes tokens to always be expired as the token is measured in seconds, but the comparison uses microseconds.  This fixes that issue.

In addition, the bsky client doesn't allow for certain characters in the token value, so have removed those from possible values to allow for support.