### PR TITLE
PDS: Implemented Sign PLC Operation API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rand = "0.8.5"
 rand_core = "0.6.4"
 secp256k1 = { version = "0.28.2", features = ["global-context", "serde", "rand", "hashes","rand-std"] }
 serde_json = { version = "1.0.96",features = ["preserve_order"] }
-rsky-lexicon = {path = "rsky-lexicon", version = "0.2.3"}
+rsky-lexicon = {path = "rsky-lexicon", version = "0.2.5"}
 rsky-identity = {path = "rsky-identity", version = "0.1.0"}
 rsky-crypto = {path = "rsky-crypto", version = "0.1.1"}
 rsky-syntax = {path = "rsky-syntax", version = "0.1.0"}

--- a/rsky-lexicon/Cargo.toml
+++ b/rsky-lexicon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-lexicon"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 publish = true
 description = "Bluesky API library"

--- a/rsky-lexicon/src/com/atproto/identity.rs
+++ b/rsky-lexicon/src/com/atproto/identity.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ResolveHandleOutput {
@@ -11,4 +12,14 @@ pub struct ResolveHandleOutput {
 pub struct UpdateHandleInput {
     /// The new handle.
     pub handle: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignPlcOperationRequest {
+    pub token: String,
+    pub rotation_keys: Vec<String>,
+    pub also_known_as: Vec<String>,
+    pub verification_methods: BTreeMap<String, String>,
+    pub services: BTreeMap<String, Service>,
 }

--- a/rsky-lexicon/src/com/atproto/identity.rs
+++ b/rsky-lexicon/src/com/atproto/identity.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -18,8 +19,8 @@ pub struct UpdateHandleInput {
 #[serde(rename_all = "camelCase")]
 pub struct SignPlcOperationRequest {
     pub token: String,
-    pub rotation_keys: Vec<String>,
-    pub also_known_as: Vec<String>,
-    pub verification_methods: BTreeMap<String, String>,
-    pub services: BTreeMap<String, Service>,
+    pub rotation_keys: Option<Vec<String>>,
+    pub also_known_as: Option<Vec<String>>,
+    pub verification_methods: Option<BTreeMap<String, String>>,
+    pub services: Option<JsonValue>,
 }

--- a/rsky-pds/src/account_manager/mod.rs
+++ b/rsky-pds/src/account_manager/mod.rs
@@ -440,6 +440,15 @@ impl AccountManager {
         email_token::assert_valid_token(did, purpose, token, None).await
     }
 
+    pub async fn assert_valid_email_token_and_cleanup(
+        did: &String,
+        purpose: EmailTokenPurpose,
+        token: &String,
+    ) -> Result<()> {
+        email_token::assert_valid_token(did, purpose, token, None).await?;
+        email_token::delete_email_token(did, purpose).await
+    }
+
     pub async fn create_email_token(did: &String, purpose: EmailTokenPurpose) -> Result<String> {
         email_token::create_email_token(did, purpose).await
     }

--- a/rsky-pds/src/apis/com/atproto/identity/mod.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/mod.rs
@@ -1,3 +1,3 @@
 pub mod resolve_handle;
-pub mod update_handle;
 pub mod sign_plc_operation;
+pub mod update_handle;

--- a/rsky-pds/src/apis/com/atproto/identity/mod.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/mod.rs
@@ -1,2 +1,3 @@
 pub mod resolve_handle;
 pub mod update_handle;
+pub mod sign_plc_operation;

--- a/rsky-pds/src/apis/com/atproto/identity/sign_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/sign_plc_operation.rs
@@ -8,17 +8,8 @@ use crate::plc::operations::create_update_op;
 use crate::plc::types::{CompatibleOp, CompatibleOpOrTombstone, Operation, Service};
 use rocket::serde::json::Json;
 use rsky_common::env::env_str;
+use rsky_lexicon::com::atproto::identity::SignPlcOperationRequest;
 use std::collections::BTreeMap;
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SignPlcOperationRequest {
-    pub token: String,
-    pub rotation_keys: Vec<String>,
-    pub also_known_as: Vec<String>,
-    pub verification_methods: BTreeMap<String, String>,
-    pub services: BTreeMap<String, Service>,
-}
 
 #[rocket::post(
     "/xrpc/com.atproto.identity.signPlcOperation",

--- a/rsky-pds/src/apis/com/atproto/identity/sign_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/sign_plc_operation.rs
@@ -1,0 +1,99 @@
+use crate::account_manager::AccountManager;
+use crate::apis::com::atproto::server::get_keys_from_private_key_str;
+use crate::apis::ApiError;
+use crate::auth_verifier::AccessFull;
+use crate::models::models::EmailTokenPurpose;
+use crate::plc;
+use crate::plc::operations::{create_update_op};
+use crate::plc::types::{CompatibleOp, CompatibleOpOrTombstone, Operation, Service};
+use rocket::serde::json::Json;
+use rsky_common::env::env_str;
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignPlcOperationRequest {
+    pub token: String,
+    pub rotation_keys: Vec<String>,
+    pub also_known_as: Vec<String>,
+    pub verification_methods: BTreeMap<String, String>,
+    pub services: BTreeMap<String, Service>,
+}
+
+#[rocket::post(
+    "/xrpc/com.atproto.identity.signPlcOperation",
+    format = "json",
+    data = "<body>"
+)]
+#[tracing::instrument(skip_all)]
+pub async fn sign_plc_operation(
+    body: Json<SignPlcOperationRequest>,
+    auth: AccessFull,
+) -> Result<Operation, ApiError> {
+    let did = auth.access.credentials.unwrap().did.unwrap();
+    let request = body.into_inner();
+    let token = request.token.clone();
+
+    if request.token.is_empty() {
+        return Err(ApiError::InvalidRequest(
+            "email confirmation token required to sign PLC operations".to_string(),
+        ));
+    }
+    AccountManager::assert_valid_email_token_and_cleanup(
+        &did,
+        EmailTokenPurpose::PlcOperation,
+        &token,
+    )
+    .await?;
+
+    let plc_url = env_str("PDS_DID_PLC_URL").unwrap_or("https://plc.directory".to_owned());
+    let plc_client = plc::Client::new(plc_url);
+    let last_op: CompatibleOp = match plc_client.get_last_op(&did).await {
+        Ok(res) => match res {
+            CompatibleOpOrTombstone::CreateOpV1(op) => CompatibleOp::CreateOpV1(op),
+            CompatibleOpOrTombstone::Operation(op) => CompatibleOp::Operation(op),
+            CompatibleOpOrTombstone::Tombstone(_) => {
+                return Err(ApiError::InvalidRequest("Did is tombstoned".to_string()))
+            }
+        },
+        Err(error) => {
+            tracing::error!("Error getting last PLC operation\n{error}");
+            return Err(ApiError::RuntimeError);
+        }
+    };
+
+    let handle;
+    match request.also_known_as.first() {
+        Some(res) => {
+            handle = Some(res.clone());
+        }
+        None => {
+            handle = None;
+        }
+    }
+    let private_key = env_str("PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX").unwrap();
+    let (secret_rotation_key, _) = get_keys_from_private_key_str(private_key)?;
+
+    let operation = match create_update_op(
+        last_op,
+        &secret_rotation_key,
+        |normalized: Operation| -> Operation {
+            let mut updated = normalized.clone();
+            updated.also_known_as = request.also_known_as;
+            updated.services = request.services;
+            updated.verification_methods = request.verification_methods;
+            updated.rotation_keys = request.rotation_keys;
+            updated
+        },
+    )
+    .await
+    {
+        Ok(res) => res,
+        Err(error) => {
+            tracing::error!("Error creating signed operation", error);
+            return Err(ApiError::RuntimeError);
+        }
+    };
+
+    Ok(operation)
+}

--- a/rsky-pds/src/main.rs
+++ b/rsky-pds/src/main.rs
@@ -242,6 +242,7 @@ async fn rocket() -> _ {
                 com::atproto::admin::update_subject_status::update_subject_status,
                 com::atproto::identity::resolve_handle::resolve_handle,
                 com::atproto::identity::update_handle::update_handle,
+                com::atproto::identity::sign_plc_operation::sign_plc_operation,
                 com::atproto::repo::apply_writes::apply_writes,
                 com::atproto::repo::create_record::create_record,
                 com::atproto::repo::delete_record::delete_record,


### PR DESCRIPTION
This implements the Sign PLC Operation API endpoint. This is necesary for any case where a user wants us to sign a given PLC operation, but not necessarily use it right away. Examples include, but are not limited to, if a user wants to migrate away from our PDS