### PR TITLE
Enhancement: DbConn fully implemented in place of establish_connection

### DIFF
--- a/rsky-pds/src/account_manager/helpers/email_token.rs
+++ b/rsky-pds/src/account_manager/helpers/email_token.rs
@@ -1,5 +1,5 @@
 use crate::apis::com::atproto::server::get_random_token;
-use crate::db::establish_connection;
+use crate::db::DbConn;
 use crate::models::models::EmailTokenPurpose;
 use crate::models::EmailToken;
 use anyhow::{bail, Result};
@@ -7,46 +7,59 @@ use diesel::*;
 use rsky_common;
 use rsky_common::time::{from_str_to_utc, less_than_ago_s, MINUTE};
 
-pub async fn create_email_token(did: &String, purpose: EmailTokenPurpose) -> Result<String> {
+pub async fn create_email_token(
+    did: &str,
+    purpose: EmailTokenPurpose,
+    db: &DbConn,
+) -> Result<String> {
     use crate::schema::pds::email_token::dsl as EmailTokenSchema;
-    let conn = &mut establish_connection()?;
     let token = get_random_token().to_uppercase();
     let now = rsky_common::now();
 
-    insert_into(EmailTokenSchema::email_token)
-        .values((
-            EmailTokenSchema::purpose.eq(purpose),
-            EmailTokenSchema::did.eq(did),
-            EmailTokenSchema::token.eq(&token),
-            EmailTokenSchema::requestedAt.eq(&now),
-        ))
-        .on_conflict((EmailTokenSchema::purpose, EmailTokenSchema::did))
-        .do_update()
-        .set((
-            EmailTokenSchema::token.eq(&token),
-            EmailTokenSchema::requestedAt.eq(&now),
-        ))
-        .execute(conn)?;
-    Ok(token)
+    let did = did.to_owned();
+    db.run(move |conn| {
+        insert_into(EmailTokenSchema::email_token)
+            .values((
+                EmailTokenSchema::purpose.eq(purpose),
+                EmailTokenSchema::did.eq(did),
+                EmailTokenSchema::token.eq(&token),
+                EmailTokenSchema::requestedAt.eq(&now),
+            ))
+            .on_conflict((EmailTokenSchema::purpose, EmailTokenSchema::did))
+            .do_update()
+            .set((
+                EmailTokenSchema::token.eq(&token),
+                EmailTokenSchema::requestedAt.eq(&now),
+            ))
+            .execute(conn)?;
+        Ok(token)
+    })
+    .await
 }
 
 pub async fn assert_valid_token(
-    did: &String,
+    did: &str,
     purpose: EmailTokenPurpose,
-    token: &String,
+    token: &str,
     expiration_len: Option<i32>,
+    db: &DbConn,
 ) -> Result<()> {
     let expiration_len = expiration_len.unwrap_or(MINUTE * 15);
     use crate::schema::pds::email_token::dsl as EmailTokenSchema;
-    let conn = &mut establish_connection()?;
 
-    let res = EmailTokenSchema::email_token
-        .filter(EmailTokenSchema::purpose.eq(purpose))
-        .filter(EmailTokenSchema::did.eq(did))
-        .filter(EmailTokenSchema::token.eq(token.to_uppercase()))
-        .select(EmailToken::as_select())
-        .first(conn)
-        .optional()?;
+    let did = did.to_owned();
+    let token = token.to_owned();
+    let res = db
+        .run(move |conn| {
+            EmailTokenSchema::email_token
+                .filter(EmailTokenSchema::purpose.eq(purpose))
+                .filter(EmailTokenSchema::did.eq(did))
+                .filter(EmailTokenSchema::token.eq(token.to_uppercase()))
+                .select(EmailToken::as_select())
+                .first(conn)
+                .optional()
+        })
+        .await?;
     if let Some(res) = res {
         let requested_at = from_str_to_utc(&res.requested_at);
         let expired = !less_than_ago_s(requested_at, expiration_len);
@@ -61,19 +74,24 @@ pub async fn assert_valid_token(
 
 pub async fn assert_valid_token_and_find_did(
     purpose: EmailTokenPurpose,
-    token: &String,
+    token: &str,
     expiration_len: Option<i32>,
+    db: &DbConn,
 ) -> Result<String> {
     let expiration_len = expiration_len.unwrap_or(MINUTE * 15);
     use crate::schema::pds::email_token::dsl as EmailTokenSchema;
-    let conn = &mut establish_connection()?;
 
-    let res = EmailTokenSchema::email_token
-        .filter(EmailTokenSchema::purpose.eq(purpose))
-        .filter(EmailTokenSchema::token.eq(token.to_uppercase()))
-        .select(EmailToken::as_select())
-        .first(conn)
-        .optional()?;
+    let token = token.to_owned();
+    let res = db
+        .run(move |conn| {
+            EmailTokenSchema::email_token
+                .filter(EmailTokenSchema::purpose.eq(purpose))
+                .filter(EmailTokenSchema::token.eq(token.to_uppercase()))
+                .select(EmailToken::as_select())
+                .first(conn)
+                .optional()
+        })
+        .await?;
     if let Some(res) = res {
         let requested_at = from_str_to_utc(&res.requested_at);
         let expired = !less_than_ago_s(requested_at, expiration_len);
@@ -86,23 +104,29 @@ pub async fn assert_valid_token_and_find_did(
     }
 }
 
-pub async fn delete_email_token(did: &String, purpose: EmailTokenPurpose) -> Result<()> {
+pub async fn delete_email_token(did: &str, purpose: EmailTokenPurpose, db: &DbConn) -> Result<()> {
     use crate::schema::pds::email_token::dsl as EmailTokenSchema;
-    let conn = &mut establish_connection()?;
-
-    delete(EmailTokenSchema::email_token)
-        .filter(EmailTokenSchema::did.eq(did))
-        .filter(EmailTokenSchema::purpose.eq(purpose))
-        .execute(conn)?;
+    let did = did.to_owned();
+    db.run(move |conn| {
+        delete(EmailTokenSchema::email_token)
+            .filter(EmailTokenSchema::did.eq(did))
+            .filter(EmailTokenSchema::purpose.eq(purpose))
+            .execute(conn)
+    })
+    .await?;
     Ok(())
 }
 
-pub async fn delete_all_email_tokens(did: &String) -> Result<()> {
+pub async fn delete_all_email_tokens(did: &str, db: &DbConn) -> Result<()> {
     use crate::schema::pds::email_token::dsl as EmailTokenSchema;
-    let conn = &mut establish_connection()?;
 
-    delete(EmailTokenSchema::email_token)
-        .filter(EmailTokenSchema::did.eq(did))
-        .execute(conn)?;
+    let did = did.to_owned();
+    db.run(move |conn| {
+        delete(EmailTokenSchema::email_token)
+            .filter(EmailTokenSchema::did.eq(did))
+            .execute(conn)
+    })
+    .await?;
+
     Ok(())
 }

--- a/rsky-pds/src/account_manager/helpers/invite.rs
+++ b/rsky-pds/src/account_manager/helpers/invite.rs
@@ -1,5 +1,5 @@
 use crate::account_manager::DisableInviteCodesOpts;
-use crate::db::{establish_connection, DbConn};
+use crate::db::DbConn;
 use crate::models::models;
 use anyhow::{bail, Result};
 use diesel::*;
@@ -13,40 +13,6 @@ use std::mem;
 
 pub type CodeUse = LexiconInviteCodeUse;
 pub type CodeDetail = LexiconInviteCode;
-
-#[deprecated]
-pub async fn ensure_invite_is_available_legacy(invite_code: String) -> Result<()> {
-    use crate::schema::pds::actor::dsl as ActorSchema;
-    use crate::schema::pds::invite_code::dsl as InviteCodeSchema;
-    use crate::schema::pds::invite_code_use::dsl as InviteCodeUseSchema;
-
-    let conn = &mut establish_connection()?;
-
-    let invite: Option<models::InviteCode> = InviteCodeSchema::invite_code
-        .left_join(
-            ActorSchema::actor.on(InviteCodeSchema::forAccount
-                .eq(ActorSchema::did)
-                .and(ActorSchema::takedownRef.is_null())),
-        )
-        .filter(InviteCodeSchema::code.eq(&invite_code))
-        .select(models::InviteCode::as_select())
-        .first(conn)
-        .optional()?;
-
-    if invite.is_none() || invite.clone().unwrap().disabled > 0 {
-        bail!("InvalidInviteCode: None or disabled. Provided invite code not available `{invite_code:?}`")
-    }
-
-    let uses: i64 = InviteCodeUseSchema::invite_code_use
-        .count()
-        .filter(InviteCodeUseSchema::code.eq(&invite_code))
-        .first(conn)?;
-
-    if invite.unwrap().available_uses as i64 <= uses {
-        bail!("InvalidInviteCode: Not enough uses. Provided invite code not available `{invite_code:?}`")
-    }
-    Ok(())
-}
 
 pub async fn ensure_invite_is_available(invite_code: String, db: &DbConn) -> Result<()> {
     use crate::schema::pds::actor::dsl as ActorSchema;
@@ -80,28 +46,6 @@ pub async fn ensure_invite_is_available(invite_code: String, db: &DbConn) -> Res
         Ok(())
     }).await?;
 
-    Ok(())
-}
-
-#[deprecated]
-pub async fn record_invite_use_legacy(
-    did: String,
-    invite_code: Option<String>,
-    now: String,
-) -> Result<()> {
-    if let Some(invite_code) = invite_code {
-        use crate::schema::pds::invite_code_use::dsl as InviteCodeUseSchema;
-
-        let conn = &mut establish_connection()?;
-
-        insert_into(InviteCodeUseSchema::invite_code_use)
-            .values((
-                InviteCodeUseSchema::code.eq(invite_code),
-                InviteCodeUseSchema::usedBy.eq(did),
-                InviteCodeUseSchema::usedAt.eq(now),
-            ))
-            .execute(conn)?;
-    }
     Ok(())
 }
 
@@ -146,7 +90,7 @@ pub async fn create_invite_codes(
                     .iter()
                     .map(|code| models::InviteCode {
                         code: code.clone(),
-                        available_uses: use_count.clone(),
+                        available_uses: use_count,
                         disabled: 0,
                         for_account: for_account.clone(),
                         created_by: "admin".to_owned(),
@@ -164,65 +108,74 @@ pub async fn create_invite_codes(
 }
 
 pub async fn create_account_invite_codes(
-    for_account: &String,
+    for_account: &str,
     codes: Vec<String>,
     expected_total: usize,
     disabled: bool,
+    db: &DbConn,
 ) -> Result<Vec<CodeDetail>> {
     use crate::schema::pds::invite_code::dsl as InviteCodeSchema;
-    let conn = &mut establish_connection()?;
 
-    let now = rsky_common::now();
+    let for_account = for_account.to_owned();
+    let rows = db
+        .run(move |conn| {
+            let now = rsky_common::now();
 
-    let rows: Vec<models::InviteCode> = codes
-        .into_iter()
-        .map(|code| models::InviteCode {
-            code,
-            available_uses: 1,
-            disabled: if disabled { 1 } else { 0 },
-            for_account: for_account.clone(),
-            created_by: for_account.clone(),
-            created_at: now.clone(),
+            let rows: Vec<models::InviteCode> = codes
+                .into_iter()
+                .map(|code| models::InviteCode {
+                    code,
+                    available_uses: 1,
+                    disabled: if disabled { 1 } else { 0 },
+                    for_account: for_account.clone(),
+                    created_by: for_account.clone(),
+                    created_at: now.clone(),
+                })
+                .collect();
+
+            insert_into(InviteCodeSchema::invite_code)
+                .values(&rows)
+                .execute(conn)?;
+
+            let final_routine_invite_codes: Vec<models::InviteCode> = InviteCodeSchema::invite_code
+                .filter(InviteCodeSchema::forAccount.eq(for_account))
+                .filter(InviteCodeSchema::createdBy.ne("admin")) // don't count admin-gifted codes against the user
+                .select(models::InviteCode::as_select())
+                .get_results(conn)?;
+
+            if final_routine_invite_codes.len() > expected_total {
+                bail!("DuplicateCreate: attempted to create additional codes in another request")
+            }
+
+            Ok(rows.into_iter().map(|row| CodeDetail {
+                code: row.code,
+                available: 1,
+                disabled: row.disabled == 1,
+                for_account: row.for_account,
+                created_by: row.created_by,
+                created_at: row.created_at,
+                uses: Vec::new(),
+            }))
         })
-        .collect();
-
-    insert_into(InviteCodeSchema::invite_code)
-        .values(&rows)
-        .execute(conn)?;
-
-    let final_routine_invite_codes: Vec<models::InviteCode> = InviteCodeSchema::invite_code
-        .filter(InviteCodeSchema::forAccount.eq(for_account))
-        .filter(InviteCodeSchema::createdBy.ne("admin")) // don't count admin-gifted codes against the user
-        .select(models::InviteCode::as_select())
-        .get_results(conn)?;
-    if final_routine_invite_codes.len() > expected_total {
-        bail!("DuplicateCreate: attempted to create additional codes in another request")
-    }
-
-    Ok(rows
-        .into_iter()
-        .map(|row| CodeDetail {
-            code: row.code,
-            available: 1,
-            disabled: row.disabled == 1,
-            for_account: row.for_account,
-            created_by: row.created_by,
-            created_at: row.created_at,
-            uses: Vec::new(),
-        })
-        .collect())
+        .await?;
+    Ok(rows.collect())
 }
 
-pub async fn get_account_invite_codes(did: &String) -> Result<Vec<CodeDetail>> {
+pub async fn get_account_invite_codes(did: &str, db: &DbConn) -> Result<Vec<CodeDetail>> {
     use crate::schema::pds::invite_code::dsl as InviteCodeSchema;
-    let conn = &mut establish_connection()?;
 
-    let res: Vec<models::InviteCode> = InviteCodeSchema::invite_code
-        .filter(InviteCodeSchema::forAccount.eq(did))
-        .select(models::InviteCode::as_select())
-        .get_results(conn)?;
+    let did = did.to_owned();
+    let res: Vec<models::InviteCode> = db
+        .run(move |conn| {
+            InviteCodeSchema::invite_code
+                .filter(InviteCodeSchema::forAccount.eq(did))
+                .select(models::InviteCode::as_select())
+                .get_results(conn)
+        })
+        .await?;
+
     let codes: Vec<String> = res.iter().map(|row| row.code.clone()).collect();
-    let mut uses = get_invite_codes_uses(codes).await?;
+    let mut uses = get_invite_codes_uses_v2(codes, db).await?;
     Ok(res
         .into_iter()
         .map(|row| CodeDetail {
@@ -237,17 +190,23 @@ pub async fn get_account_invite_codes(did: &String) -> Result<Vec<CodeDetail>> {
         .collect::<Vec<CodeDetail>>())
 }
 
-pub async fn get_invite_codes_uses(codes: Vec<String>) -> Result<BTreeMap<String, Vec<CodeUse>>> {
+pub async fn get_invite_codes_uses_v2(
+    codes: Vec<String>,
+    db: &DbConn,
+) -> Result<BTreeMap<String, Vec<CodeUse>>> {
     use crate::schema::pds::invite_code_use::dsl as InviteCodeUseSchema;
-    let conn = &mut establish_connection()?;
 
     let mut uses: BTreeMap<String, Vec<CodeUse>> = BTreeMap::new();
-    if codes.len() > 0 {
-        let uses_res: Vec<models::InviteCodeUse> = InviteCodeUseSchema::invite_code_use
-            .filter(InviteCodeUseSchema::code.eq_any(codes))
-            .order_by(InviteCodeUseSchema::usedAt.desc())
-            .select(models::InviteCodeUse::as_select())
-            .get_results(conn)?;
+    if !codes.is_empty() {
+        let uses_res: Vec<models::InviteCodeUse> = db
+            .run(|conn| {
+                InviteCodeUseSchema::invite_code_use
+                    .filter(InviteCodeUseSchema::code.eq_any(codes))
+                    .order_by(InviteCodeUseSchema::usedAt.desc())
+                    .select(models::InviteCodeUse::as_select())
+                    .get_results(conn)
+            })
+            .await?;
         for invite_code_use in uses_res {
             let models::InviteCodeUse {
                 code,
@@ -266,28 +225,33 @@ pub async fn get_invite_codes_uses(codes: Vec<String>) -> Result<BTreeMap<String
 }
 
 pub async fn get_invited_by_for_accounts(
-    dids: Vec<&String>,
+    dids: Vec<String>,
+    db: &DbConn,
 ) -> Result<BTreeMap<String, CodeDetail>> {
-    if dids.len() < 1 {
+    if dids.is_empty() {
         return Ok(BTreeMap::new());
     }
     use crate::schema::pds::invite_code::dsl as InviteCodeSchema;
     use crate::schema::pds::invite_code_use::dsl as InviteCodeUseSchema;
-    let conn = &mut establish_connection()?;
 
-    let res: Vec<models::InviteCode> = InviteCodeSchema::invite_code
-        .filter(
-            InviteCodeSchema::forAccount.eq_any(
-                InviteCodeUseSchema::invite_code_use
-                    .filter(InviteCodeUseSchema::usedBy.eq_any(dids))
-                    .select(InviteCodeUseSchema::code)
-                    .distinct(),
-            ),
-        )
-        .select(models::InviteCode::as_select())
-        .get_results(conn)?;
+    let dids = dids.clone();
+    let res: Vec<models::InviteCode> = db
+        .run(|conn| {
+            InviteCodeSchema::invite_code
+                .filter(
+                    InviteCodeSchema::forAccount.eq_any(
+                        InviteCodeUseSchema::invite_code_use
+                            .filter(InviteCodeUseSchema::usedBy.eq_any(dids))
+                            .select(InviteCodeUseSchema::code)
+                            .distinct(),
+                    ),
+                )
+                .select(models::InviteCode::as_select())
+                .get_results(conn)
+        })
+        .await?;
     let codes: Vec<String> = res.iter().map(|row| row.code.clone()).collect();
-    let mut uses = get_invite_codes_uses(codes).await?;
+    let mut uses = get_invite_codes_uses_v2(codes, db).await?;
 
     let code_details = res
         .into_iter()
@@ -313,34 +277,42 @@ pub async fn get_invited_by_for_accounts(
     ))
 }
 
-pub async fn set_account_invites_disabled(did: &String, disabled: bool) -> Result<()> {
+pub async fn set_account_invites_disabled(did: &str, disabled: bool, db: &DbConn) -> Result<()> {
     use crate::schema::pds::account::dsl as AccountSchema;
-    let conn = &mut establish_connection()?;
 
     let disabled: i16 = if disabled { 1 } else { 0 };
-    update(AccountSchema::account)
-        .filter(AccountSchema::did.eq(did))
-        .set((AccountSchema::invitesDisabled.eq(disabled),))
-        .execute(conn)?;
+    let did = did.to_owned();
+    db.run(move |conn| {
+        update(AccountSchema::account)
+            .filter(AccountSchema::did.eq(did))
+            .set((AccountSchema::invitesDisabled.eq(disabled),))
+            .execute(conn)
+    })
+    .await?;
     Ok(())
 }
 
-pub async fn disable_invite_codes(opts: DisableInviteCodesOpts) -> Result<()> {
+pub async fn disable_invite_codes(opts: DisableInviteCodesOpts, db: &DbConn) -> Result<()> {
     use crate::schema::pds::invite_code::dsl as InviteCodeSchema;
-    let conn = &mut establish_connection()?;
 
     let DisableInviteCodesOpts { codes, accounts } = opts;
-    if codes.len() > 0 {
-        update(InviteCodeSchema::invite_code)
-            .filter(InviteCodeSchema::code.eq_any(&codes))
-            .set((InviteCodeSchema::disabled.eq(1),))
-            .execute(conn)?;
+    if !codes.is_empty() {
+        db.run(move |conn| {
+            update(InviteCodeSchema::invite_code)
+                .filter(InviteCodeSchema::code.eq_any(&codes))
+                .set((InviteCodeSchema::disabled.eq(1),))
+                .execute(conn)
+        })
+        .await?;
     }
-    if accounts.len() > 0 {
-        update(InviteCodeSchema::invite_code)
-            .filter(InviteCodeSchema::forAccount.eq_any(&accounts))
-            .set((InviteCodeSchema::disabled.eq(1),))
-            .execute(conn)?;
+    if !accounts.is_empty() {
+        db.run(move |conn| {
+            update(InviteCodeSchema::invite_code)
+                .filter(InviteCodeSchema::forAccount.eq_any(&accounts))
+                .set((InviteCodeSchema::disabled.eq(1),))
+                .execute(conn)
+        })
+        .await?;
     }
     Ok(())
 }

--- a/rsky-pds/src/account_manager/helpers/repo.rs
+++ b/rsky-pds/src/account_manager/helpers/repo.rs
@@ -1,33 +1,8 @@
-use crate::db::{establish_connection, DbConn};
+use crate::db::DbConn;
 use anyhow::Result;
 use diesel::*;
 use libipld::Cid;
 use rsky_common;
-
-#[deprecated]
-pub fn update_root_legacy(did: String, cid: Cid, rev: String) -> Result<()> {
-    // @TODO balance risk of a race in the case of a long retry
-    use crate::schema::pds::repo_root::dsl as RepoRootSchema;
-    let conn = &mut establish_connection()?;
-
-    let now = rsky_common::now();
-
-    insert_into(RepoRootSchema::repo_root)
-        .values((
-            RepoRootSchema::did.eq(did),
-            RepoRootSchema::cid.eq(cid.to_string()),
-            RepoRootSchema::rev.eq(rev.clone()),
-            RepoRootSchema::indexedAt.eq(now),
-        ))
-        .on_conflict(RepoRootSchema::did)
-        .do_update()
-        .set((
-            RepoRootSchema::cid.eq(cid.to_string()),
-            RepoRootSchema::rev.eq(rev),
-        ))
-        .execute(conn)?;
-    Ok(())
-}
 
 pub async fn update_root(did: String, cid: Cid, rev: String, db: &DbConn) -> Result<()> {
     // @TODO balance risk of a race in the case of a long retry

--- a/rsky-pds/src/account_manager/mod.rs
+++ b/rsky-pds/src/account_manager/mod.rs
@@ -4,7 +4,7 @@ use crate::account_manager::helpers::account::{
 use crate::account_manager::helpers::auth::{
     AuthHelperError, CreateTokensOpts, RefreshGracePeriodOpts,
 };
-use crate::account_manager::helpers::invite::{CodeDetail, CodeUse};
+use crate::account_manager::helpers::invite::CodeDetail;
 use crate::account_manager::helpers::password::UpdateUserPasswordOpts;
 use crate::account_manager::helpers::repo;
 use crate::auth_verifier::AuthScope;
@@ -16,6 +16,9 @@ use chrono::DateTime;
 use futures::try_join;
 use helpers::{account, auth, email_token, invite, password};
 use libipld::Cid;
+use rocket::http::Status;
+use rocket::request::{FromRequest, Outcome};
+use rocket::Request;
 use rsky_common;
 use rsky_common::time::{from_micros_to_str, from_str_to_micros, HOUR};
 use rsky_common::RFC3339_VARIANT;
@@ -24,7 +27,9 @@ use rsky_lexicon::com::atproto::server::{AccountCodes, CreateAppPasswordOutput};
 use secp256k1::{Keypair, Secp256k1, SecretKey};
 use std::collections::BTreeMap;
 use std::env;
+use std::sync::Arc;
 use std::time::SystemTime;
+use tokio::sync::RwLock;
 
 /// Helps with readability when calling create_account()
 pub struct CreateAccountOpts {
@@ -63,51 +68,50 @@ pub struct DisableInviteCodesOpts {
     pub accounts: Vec<String>,
 }
 
-#[derive(Clone)]
-pub struct AccountManager {}
+#[derive(Clone, Debug)]
+pub struct AccountManager {
+    pub db: Arc<DbConn>,
+}
+
+pub type AccountManagerCreator = Box<dyn Fn(Arc<DbConn>) -> AccountManager + Send + Sync>;
 
 impl AccountManager {
-    #[deprecated]
-    pub async fn get_account_legacy(
-        handle_or_did: &String,
-        flags: Option<AvailabilityFlags>,
-    ) -> Result<Option<ActorAccount>> {
-        account::get_account_legacy(handle_or_did, flags).await
+    pub fn new(db: Arc<DbConn>) -> Self {
+        Self { db }
+    }
+
+    pub fn creator() -> AccountManagerCreator {
+        Box::new(move |db: Arc<DbConn>| -> AccountManager { AccountManager::new(db) })
     }
 
     pub async fn get_account(
-        handle_or_did: &String,
-        flags: Option<AvailabilityFlags>,
-        db: &DbConn,
-    ) -> Result<Option<ActorAccount>> {
-        account::get_account(handle_or_did, flags, db).await
-    }
-
-    #[deprecated]
-    pub async fn get_account_by_email_legacy(
-        email: &String,
+        &self,
+        handle_or_did: &str,
         flags: Option<AvailabilityFlags>,
     ) -> Result<Option<ActorAccount>> {
-        account::get_account_by_email_legacy(email, flags).await
+        let db = self.db.clone();
+        account::get_account(handle_or_did, flags, db.as_ref()).await
     }
 
     pub async fn get_account_by_email(
-        email: &String,
+        &self,
+        email: &str,
         flags: Option<AvailabilityFlags>,
-        db: &DbConn,
     ) -> Result<Option<ActorAccount>> {
-        account::get_account_by_email(email, flags, db).await
+        let db = self.db.clone();
+        account::get_account_by_email(email, flags, db.as_ref()).await
     }
 
-    pub async fn is_account_activated(did: &String) -> Result<bool> {
-        let account = Self::get_account_legacy(
-            did,
-            Some(AvailabilityFlags {
-                include_taken_down: None,
-                include_deactivated: Some(true),
-            }),
-        )
-        .await?;
+    pub async fn is_account_activated(&self, did: &str) -> Result<bool> {
+        let account = self
+            .get_account(
+                did,
+                Some(AvailabilityFlags {
+                    include_taken_down: None,
+                    include_deactivated: Some(true),
+                }),
+            )
+            .await?;
         if let Some(account) = account {
             Ok(account.deactivated_at.is_none())
         } else {
@@ -116,16 +120,18 @@ impl AccountManager {
     }
 
     pub async fn get_did_for_actor(
-        handle_or_did: &String,
+        &self,
+        handle_or_did: &str,
         flags: Option<AvailabilityFlags>,
     ) -> Result<Option<String>> {
-        match Self::get_account_legacy(handle_or_did, flags).await {
+        match self.get_account(handle_or_did, flags).await {
             Ok(Some(got)) => Ok(Some(got.did)),
             _ => Ok(None),
         }
     }
 
-    pub async fn create_account(opts: CreateAccountOpts, db: &DbConn) -> Result<(String, String)> {
+    pub async fn create_account(&self, opts: CreateAccountOpts) -> Result<(String, String)> {
+        let db = self.db.clone();
         let CreateAccountOpts {
             did,
             handle,
@@ -142,11 +148,11 @@ impl AccountManager {
         };
         // Should be a global var so this only happens once
         let secp = Secp256k1::new();
-        let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX").unwrap();
+        let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX")?;
         let secret_key =
-            SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
+            SecretKey::from_slice(&Result::unwrap(hex::decode(private_key.as_bytes())))?;
         let jwt_key = Keypair::from_secret_key(&secp, &secret_key);
-        let (access_jwt, refresh_jwt) = auth::create_tokens(auth::CreateTokensOpts {
+        let (access_jwt, refresh_jwt) = auth::create_tokens(CreateTokensOpts {
             did: did.clone(),
             jwt_key,
             service_did: env::var("PDS_SERVICE_DID").unwrap(),
@@ -158,65 +164,67 @@ impl AccountManager {
         let now = rsky_common::now();
 
         if let Some(invite_code) = invite_code.clone() {
-            invite::ensure_invite_is_available(invite_code, db).await?;
+            invite::ensure_invite_is_available(invite_code, db.as_ref()).await?;
         }
-        account::register_actor(did.clone(), handle, deactivated, db).await?;
+        account::register_actor(did.clone(), handle, deactivated, db.as_ref()).await?;
         if let (Some(email), Some(password_encrypted)) = (email, password_encrypted) {
-            account::register_account(did.clone(), email, password_encrypted, db).await?;
+            account::register_account(did.clone(), email, password_encrypted, db.as_ref()).await?;
         }
-        invite::record_invite_use(did.clone(), invite_code, now, db).await?;
-        auth::store_refresh_token(refresh_payload, None, db).await?;
-        repo::update_root(did, repo_cid, repo_rev, db).await?;
+        invite::record_invite_use(did.clone(), invite_code, now, db.as_ref()).await?;
+        auth::store_refresh_token(refresh_payload, None, db.as_ref()).await?;
+        repo::update_root(did, repo_cid, repo_rev, db.as_ref()).await?;
         Ok((access_jwt, refresh_jwt))
     }
 
     pub async fn get_account_admin_status(
-        did: &String,
+        &self,
+        did: &str,
     ) -> Result<Option<GetAccountAdminStatusOutput>> {
-        account::get_account_admin_status(did).await
+        let db = self.db.clone();
+        account::get_account_admin_status(did, db.as_ref()).await
     }
 
-    #[deprecated]
-    pub fn update_repo_root_legacy(did: String, cid: Cid, rev: String) -> Result<()> {
-        Ok(repo::update_root_legacy(did, cid, rev)?)
+    pub async fn update_repo_root(&self, did: String, cid: Cid, rev: String) -> Result<()> {
+        let db = self.db.clone();
+        repo::update_root(did, cid, rev, db.as_ref()).await
     }
 
-    pub async fn update_repo_root(did: String, cid: Cid, rev: String, db: &DbConn) -> Result<()> {
-        Ok(repo::update_root(did, cid, rev, db).await?)
+    pub async fn delete_account(&self, did: &str) -> Result<()> {
+        let db = self.db.clone();
+        account::delete_account(did, db.as_ref()).await
     }
 
-    pub async fn delete_account(did: &String) -> Result<()> {
-        account::delete_account(did).await
-    }
-
-    pub async fn takedown_account(did: &String, takedown: StatusAttr) -> Result<()> {
+    pub async fn takedown_account(&self, did: &str, takedown: StatusAttr) -> Result<()> {
         (_, _) = try_join!(
-            account::update_account_takedown_status(did, takedown),
-            auth::revoke_refresh_tokens_by_did(did)
+            account::update_account_takedown_status(did, takedown, self.db.as_ref()),
+            auth::revoke_refresh_tokens_by_did(did, self.db.as_ref())
         )?;
         Ok(())
     }
 
     // @NOTE should always be paired with a sequenceHandle().
-    pub async fn update_handle(did: &String, handle: &String) -> Result<()> {
-        account::update_handle(did, handle).await
+    pub async fn update_handle(&self, did: &str, handle: &str) -> Result<()> {
+        let db = self.db.clone();
+        account::update_handle(did, handle, db.as_ref()).await
     }
 
-    pub async fn deactivate_account(did: &String, delete_after: Option<String>) -> Result<()> {
-        account::deactivate_account(did, delete_after).await
+    pub async fn deactivate_account(&self, did: &str, delete_after: Option<String>) -> Result<()> {
+        account::deactivate_account(did, delete_after, self.db.as_ref()).await
     }
 
-    pub async fn activate_account(did: &String) -> Result<()> {
-        account::activate_account(did).await
+    pub async fn activate_account(&self, did: &str) -> Result<()> {
+        let db = self.db.clone();
+        account::activate_account(did, db.as_ref()).await
     }
 
-    pub async fn get_account_status(handle_or_did: &String) -> Result<AccountStatus> {
-        let got = account::get_account_legacy(
+    pub async fn get_account_status(&self, handle_or_did: &str) -> Result<AccountStatus> {
+        let got = account::get_account(
             handle_or_did,
             Some(AvailabilityFlags {
                 include_deactivated: Some(true),
                 include_taken_down: Some(true),
             }),
+            self.db.as_ref(),
         )
         .await?;
         let res = account::format_account_status(got);
@@ -228,43 +236,15 @@ impl AccountManager {
 
     // Auth
     // ----------
-    #[deprecated]
-    pub async fn create_session_legacy(
-        did: String,
-        app_password_name: Option<String>,
-    ) -> Result<(String, String)> {
-        let secp = Secp256k1::new();
-        let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-        let secret_key =
-            SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
-        let jwt_key = Keypair::from_secret_key(&secp, &secret_key);
-        let scope = if app_password_name.is_none() {
-            AuthScope::Access
-        } else {
-            AuthScope::AppPass
-        };
-        let (access_jwt, refresh_jwt) = auth::create_tokens(CreateTokensOpts {
-            did,
-            jwt_key,
-            service_did: env::var("PDS_SERVICE_DID").unwrap(),
-            scope: Some(scope),
-            jti: None,
-            expires_in: None,
-        })?;
-        let refresh_payload = auth::decode_refresh_token(refresh_jwt.clone(), jwt_key)?;
-        auth::store_refresh_token_legacy(refresh_payload, app_password_name).await?;
-        Ok((access_jwt, refresh_jwt))
-    }
-
     pub async fn create_session(
+        &self,
         did: String,
         app_password_name: Option<String>,
-        db: &DbConn,
     ) -> Result<(String, String)> {
+        let db = self.db.clone();
         let secp = Secp256k1::new();
-        let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-        let secret_key =
-            SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
+        let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX")?;
+        let secret_key = SecretKey::from_slice(&hex::decode(private_key.as_bytes())?)?;
         let jwt_key = Keypair::from_secret_key(&secp, &secret_key);
         let scope = if app_password_name.is_none() {
             AuthScope::Access
@@ -280,12 +260,12 @@ impl AccountManager {
             expires_in: None,
         })?;
         let refresh_payload = auth::decode_refresh_token(refresh_jwt.clone(), jwt_key)?;
-        auth::store_refresh_token(refresh_payload, app_password_name, db).await?;
+        auth::store_refresh_token(refresh_payload, app_password_name, db.as_ref()).await?;
         Ok((access_jwt, refresh_jwt))
     }
 
-    pub async fn rotate_refresh_token(id: &String) -> Result<Option<(String, String)>> {
-        let token = auth::get_refresh_token(id).await?;
+    pub async fn rotate_refresh_token(&self, id: &String) -> Result<Option<(String, String)>> {
+        let token = auth::get_refresh_token(id, self.db.as_ref()).await?;
         if let Some(token) = token {
             let system_time = SystemTime::now();
             let dt: DateTime<UtcOffset> = system_time.into();
@@ -293,7 +273,7 @@ impl AccountManager {
 
             // take the chance to tidy all of a user's expired tokens
             // does not need to be transactional since this is just best-effort
-            auth::delete_expired_refresh_tokens(&token.did, now).await?;
+            auth::delete_expired_refresh_tokens(&token.did, now, self.db.as_ref()).await?;
 
             // Shorten the refresh token lifespan down from its
             // original expiration time to its revocation grace period.
@@ -314,9 +294,7 @@ impl AccountManager {
 
             // Determine the next refresh token id: upon refresh token
             // reuse you always receive a refresh token with the same id.
-            let next_id = token
-                .next_id
-                .unwrap_or_else(|| auth::get_refresh_token_id());
+            let next_id = token.next_id.unwrap_or_else(auth::get_refresh_token_id);
 
             let secp = Secp256k1::new();
             let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX").unwrap();
@@ -338,17 +316,24 @@ impl AccountManager {
             })?;
             let refresh_payload = auth::decode_refresh_token(refresh_jwt.clone(), jwt_key)?;
             match try_join!(
-                auth::add_refresh_grace_period(RefreshGracePeriodOpts {
-                    id: id.clone(),
-                    expires_at: from_micros_to_str(expires_at),
-                    next_id
-                }),
-                auth::store_refresh_token_legacy(refresh_payload, token.app_password_name)
+                auth::add_refresh_grace_period(
+                    RefreshGracePeriodOpts {
+                        id: id.clone(),
+                        expires_at: from_micros_to_str(expires_at),
+                        next_id
+                    },
+                    self.db.as_ref()
+                ),
+                auth::store_refresh_token(
+                    refresh_payload,
+                    token.app_password_name,
+                    self.db.as_ref()
+                )
             ) {
                 Ok(_) => Ok(Some((access_jwt, refresh_jwt))),
                 Err(e) => match e.downcast_ref() {
                     Some(AuthHelperError::ConcurrentRefresh) => {
-                        Box::pin(Self::rotate_refresh_token(id)).await
+                        Box::pin(self.rotate_refresh_token(id)).await
                     }
                     _ => Err(e),
                 },
@@ -358,178 +343,212 @@ impl AccountManager {
         }
     }
 
-    pub async fn revoke_refresh_token(id: String) -> Result<bool> {
-        auth::revoke_refresh_token(id).await
+    pub async fn revoke_refresh_token(&self, id: String) -> Result<bool> {
+        auth::revoke_refresh_token(id, self.db.as_ref()).await
     }
+
     // Invites
     // ----------
 
-    pub async fn ensure_invite_is_available(code: String) -> Result<()> {
-        invite::ensure_invite_is_available_legacy(code).await
-    }
-
     pub async fn create_invite_codes(
+        &self,
         to_create: Vec<AccountCodes>,
         use_count: i32,
-        db: &DbConn,
     ) -> Result<()> {
-        invite::create_invite_codes(to_create, use_count, db).await
+        let db = self.db.clone();
+        invite::create_invite_codes(to_create, use_count, db.as_ref()).await
     }
 
     pub async fn create_account_invite_codes(
-        for_account: &String,
+        &self,
+        for_account: &str,
         codes: Vec<String>,
         expected_total: usize,
         disabled: bool,
     ) -> Result<Vec<CodeDetail>> {
-        invite::create_account_invite_codes(for_account, codes, expected_total, disabled).await
+        invite::create_account_invite_codes(
+            for_account,
+            codes,
+            expected_total,
+            disabled,
+            self.db.as_ref(),
+        )
+        .await
     }
 
-    pub async fn get_account_invite_codes(did: &String) -> Result<Vec<CodeDetail>> {
-        invite::get_account_invite_codes(did).await
+    pub async fn get_account_invite_codes(&self, did: &str) -> Result<Vec<CodeDetail>> {
+        let db = self.db.clone();
+        invite::get_account_invite_codes(did, db.as_ref()).await
     }
 
     pub async fn get_invited_by_for_accounts(
-        dids: Vec<&String>,
+        &self,
+        dids: Vec<String>,
     ) -> Result<BTreeMap<String, CodeDetail>> {
-        invite::get_invited_by_for_accounts(dids).await
+        let db = self.db.clone();
+        invite::get_invited_by_for_accounts(dids, db.as_ref()).await
     }
 
-    pub async fn get_invite_codes_uses(
-        codes: Vec<String>,
-    ) -> Result<BTreeMap<String, Vec<CodeUse>>> {
-        invite::get_invite_codes_uses(codes).await
+    pub async fn set_account_invites_disabled(&self, did: &str, disabled: bool) -> Result<()> {
+        invite::set_account_invites_disabled(did, disabled, self.db.as_ref()).await
     }
 
-    pub async fn set_account_invites_disabled(did: &String, disabled: bool) -> Result<()> {
-        invite::set_account_invites_disabled(did, disabled).await
-    }
-
-    pub async fn disable_invite_codes(opts: DisableInviteCodesOpts) -> Result<()> {
-        invite::disable_invite_codes(opts).await
+    pub async fn disable_invite_codes(&self, opts: DisableInviteCodesOpts) -> Result<()> {
+        invite::disable_invite_codes(opts, self.db.as_ref()).await
     }
 
     // Passwords
     // ----------
 
-    pub async fn create_app_password(did: String, name: String) -> Result<CreateAppPasswordOutput> {
-        password::create_app_password(did, name).await
+    pub async fn create_app_password(
+        &self,
+        did: String,
+        name: String,
+    ) -> Result<CreateAppPasswordOutput> {
+        password::create_app_password(did, name, self.db.as_ref()).await
     }
 
-    pub async fn list_app_passwords(did: &String) -> Result<Vec<(String, String)>> {
-        password::list_app_passwords(did).await
+    pub async fn list_app_passwords(&self, did: &str) -> Result<Vec<(String, String)>> {
+        password::list_app_passwords(did, self.db.as_ref()).await
     }
 
-    #[deprecated]
-    pub async fn verify_account_password_legacy(
-        did: &String,
-        password_str: &String,
-    ) -> Result<bool> {
-        password::verify_account_password_legacy(did, password_str).await
-    }
-
-    pub async fn verify_account_password(
-        did: &String,
-        password_str: &String,
-        db: &DbConn,
-    ) -> Result<bool> {
-        password::verify_account_password(did, password_str, db).await
-    }
-
-    #[deprecated]
-    pub async fn verify_app_password_legacy(
-        did: &String,
-        password_str: &String,
-    ) -> Result<Option<String>> {
-        password::verify_app_password_legacy(did, password_str).await
+    pub async fn verify_account_password(&self, did: &str, password_str: &String) -> Result<bool> {
+        let db = self.db.clone();
+        password::verify_account_password(did, password_str, db.as_ref()).await
     }
 
     pub async fn verify_app_password(
-        did: &String,
-        password_str: &String,
-        db: &DbConn,
+        &self,
+        did: &str,
+        password_str: &str,
     ) -> Result<Option<String>> {
-        password::verify_app_password(did, password_str, db).await
+        let db = self.db.clone();
+        password::verify_app_password(did, password_str, db.as_ref()).await
     }
 
-    pub async fn reset_password(opts: ResetPasswordOpts) -> Result<()> {
+    pub async fn reset_password(&self, opts: ResetPasswordOpts) -> Result<()> {
+        let db = self.db.clone();
         let did = email_token::assert_valid_token_and_find_did(
             EmailTokenPurpose::ResetPassword,
             &opts.token,
             None,
+            db.as_ref(),
         )
         .await?;
-        Self::update_account_password(UpdateAccountPasswordOpts {
+        self.update_account_password(UpdateAccountPasswordOpts {
             did,
             password: opts.password,
         })
         .await
     }
 
-    pub async fn update_account_password(opts: UpdateAccountPasswordOpts) -> Result<()> {
+    pub async fn update_account_password(&self, opts: UpdateAccountPasswordOpts) -> Result<()> {
+        let db = self.db.clone();
         let UpdateAccountPasswordOpts { did, .. } = opts;
         let password_encrypted = password::gen_salt_and_hash(opts.password)?;
         try_join!(
-            password::update_user_password(UpdateUserPasswordOpts {
-                did: did.clone(),
-                password_encrypted
-            }),
-            email_token::delete_email_token(&did, EmailTokenPurpose::ResetPassword),
-            auth::revoke_refresh_tokens_by_did(&did)
+            password::update_user_password(
+                UpdateUserPasswordOpts {
+                    did: did.clone(),
+                    password_encrypted
+                },
+                self.db.as_ref()
+            ),
+            email_token::delete_email_token(&did, EmailTokenPurpose::ResetPassword, db.as_ref()),
+            auth::revoke_refresh_tokens_by_did(&did, self.db.as_ref())
         )?;
         Ok(())
     }
 
-    pub async fn revoke_app_password(did: String, name: String) -> Result<()> {
+    pub async fn revoke_app_password(&self, did: String, name: String) -> Result<()> {
         try_join!(
-            password::delete_app_password(&did, &name),
-            auth::revoke_app_password_refresh_token(&did, &name)
+            password::delete_app_password(&did, &name, self.db.as_ref()),
+            auth::revoke_app_password_refresh_token(&did, &name, self.db.as_ref())
         )?;
         Ok(())
     }
 
     // Email Tokens
     // ----------
-    pub async fn confirm_email<'em>(opts: ConfirmEmailOpts<'em>) -> Result<()> {
+    pub async fn confirm_email<'em>(&self, opts: ConfirmEmailOpts<'em>) -> Result<()> {
+        let db = self.db.clone();
         let ConfirmEmailOpts { did, token } = opts;
-        email_token::assert_valid_token(did, EmailTokenPurpose::ConfirmEmail, token, None).await?;
+        email_token::assert_valid_token(
+            did,
+            EmailTokenPurpose::ConfirmEmail,
+            token,
+            None,
+            db.as_ref(),
+        )
+        .await?;
         let now = rsky_common::now();
         try_join!(
-            email_token::delete_email_token(did, EmailTokenPurpose::ConfirmEmail),
-            account::set_email_confirmed_at(did, now)
+            email_token::delete_email_token(did, EmailTokenPurpose::ConfirmEmail, db.as_ref()),
+            account::set_email_confirmed_at(did, now, self.db.as_ref())
         )?;
         Ok(())
     }
 
-    pub async fn update_email(opts: UpdateEmailOpts) -> Result<()> {
+    pub async fn update_email(&self, opts: UpdateEmailOpts) -> Result<()> {
+        let db = self.db.clone();
         let UpdateEmailOpts { did, email } = opts;
         try_join!(
-            account::update_email(&did, &email),
-            email_token::delete_all_email_tokens(&did)
+            account::update_email(&did, &email, db.as_ref()),
+            email_token::delete_all_email_tokens(&did, db.as_ref())
         )?;
         Ok(())
     }
 
     pub async fn assert_valid_email_token(
-        did: &String,
+        &self,
+        did: &str,
         purpose: EmailTokenPurpose,
-        token: &String,
+        token: &str,
     ) -> Result<()> {
-        email_token::assert_valid_token(did, purpose, token, None).await
+        let db = self.db.clone();
+        email_token::assert_valid_token(did, purpose, token, None, db.as_ref()).await
     }
 
     pub async fn assert_valid_email_token_and_cleanup(
-        did: &String,
+        &self,
+        did: &str,
         purpose: EmailTokenPurpose,
-        token: &String,
+        token: &str,
     ) -> Result<()> {
-        email_token::assert_valid_token(did, purpose, token, None).await?;
-        email_token::delete_email_token(did, purpose).await
+        let db = self.db.clone();
+        email_token::assert_valid_token(did, purpose, token, None, db.as_ref()).await?;
+        email_token::delete_email_token(did, purpose, db.as_ref()).await
     }
 
-    pub async fn create_email_token(did: &String, purpose: EmailTokenPurpose) -> Result<String> {
-        email_token::create_email_token(did, purpose).await
+    pub async fn create_email_token(
+        &self,
+        did: &str,
+        purpose: EmailTokenPurpose,
+    ) -> Result<String> {
+        let db = self.db.clone();
+        email_token::create_email_token(did, purpose, db.as_ref()).await
     }
 }
 
 pub mod helpers;
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for AccountManager {
+    type Error = ();
+
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        match req.rocket().state::<SharedAccountManager>() {
+            None => Outcome::Error((Status::InternalServerError, ())),
+            Some(shared_account_manager) => {
+                let db = req.guard::<DbConn>().await.unwrap();
+                let account_manager_creator = shared_account_manager.account_manager.read().await;
+                let account_manager = account_manager_creator(Arc::new(db));
+                Outcome::Success(account_manager)
+            }
+        }
+    }
+}
+
+pub struct SharedAccountManager {
+    pub account_manager: RwLock<AccountManagerCreator>,
+}

--- a/rsky-pds/src/actor_store/preference/mod.rs
+++ b/rsky-pds/src/actor_store/preference/mod.rs
@@ -1,19 +1,21 @@
 use crate::actor_store::preference::util::pref_in_scope;
 use crate::auth_verifier::AuthScope;
-use crate::db::establish_connection;
+use crate::db::DbConn;
 use crate::models;
 use crate::models::AccountPref;
 use anyhow::{bail, Result};
 use diesel::*;
 use rsky_lexicon::app::bsky::actor::RefPreferences;
+use std::sync::Arc;
 
 pub struct PreferenceReader {
     pub did: String,
+    pub db: Arc<DbConn>,
 }
 
 impl PreferenceReader {
-    pub fn new(did: String) -> Self {
-        PreferenceReader { did }
+    pub fn new(did: String, db: Arc<DbConn>) -> Self {
+        PreferenceReader { did, db }
     }
 
     pub async fn get_preferences(
@@ -22,32 +24,36 @@ impl PreferenceReader {
         scope: AuthScope,
     ) -> Result<Vec<RefPreferences>> {
         use crate::schema::pds::account_pref::dsl as AccountPrefSchema;
-        let conn = &mut establish_connection()?;
 
-        let prefs_res = AccountPrefSchema::account_pref
-            .filter(AccountPrefSchema::did.eq(&self.did))
-            .select(models::AccountPref::as_select())
-            .order(AccountPrefSchema::id.asc())
-            .load(conn)?;
-        let account_prefs = prefs_res
-            .into_iter()
-            .filter(|pref| match &namespace {
-                None => true,
-                Some(namespace) => pref_match_namespace(&namespace, &pref.name),
+        let did = self.did.clone();
+        self.db
+            .run(move |conn| {
+                let prefs_res = AccountPrefSchema::account_pref
+                    .filter(AccountPrefSchema::did.eq(&did))
+                    .select(AccountPref::as_select())
+                    .order(AccountPrefSchema::id.asc())
+                    .load(conn)?;
+                let account_prefs = prefs_res
+                    .into_iter()
+                    .filter(|pref| match &namespace {
+                        None => true,
+                        Some(namespace) => pref_match_namespace(namespace, &pref.name),
+                    })
+                    .filter(|pref| pref_in_scope(scope.clone(), pref.name.clone()))
+                    .map(|pref| {
+                        let value_json_res = match pref.value_json {
+                            None => bail!("preferences json null for {}", pref.name),
+                            Some(value_json) => serde_json::from_str::<RefPreferences>(&value_json),
+                        };
+                        match value_json_res {
+                            Err(error) => bail!(error.to_string()),
+                            Ok(value_json) => Ok(value_json),
+                        }
+                    })
+                    .collect::<Result<Vec<RefPreferences>>>()?;
+                Ok(account_prefs)
             })
-            .filter(|pref| pref_in_scope(scope.clone(), pref.name.clone()))
-            .map(|pref| {
-                let value_json_res = match pref.value_json {
-                    None => bail!("preferences json null for {}", pref.name),
-                    Some(value_json) => serde_json::from_str::<RefPreferences>(&value_json),
-                };
-                match value_json_res {
-                    Err(error) => bail!(error.to_string()),
-                    Ok(value_json) => Ok(value_json),
-                }
-            })
-            .collect::<Result<Vec<RefPreferences>>>()?;
-        Ok(account_prefs)
+            .await
     }
 
     #[tracing::instrument(skip_all)]
@@ -57,73 +63,77 @@ impl PreferenceReader {
         namespace: String,
         scope: AuthScope,
     ) -> Result<()> {
-        match values
-            .iter()
-            .all(|value| pref_match_namespace(&namespace, &value.get_type()))
-        {
-            false => bail!("Some preferences are not in the {namespace} namespace"),
-            true => {
-                let not_in_scope = values
+        let did = self.did.clone();
+        self.db
+            .run(move |conn| {
+                match values
                     .iter()
-                    .filter(|value| !pref_in_scope(scope.clone(), value.get_type()))
-                    .collect::<Vec<&RefPreferences>>();
-                if not_in_scope.len() > 0 {
-                    tracing::info!(
+                    .all(|value| pref_match_namespace(&namespace, &value.get_type()))
+                {
+                    false => bail!("Some preferences are not in the {namespace} namespace"),
+                    true => {
+                        let not_in_scope = values
+                            .iter()
+                            .filter(|value| !pref_in_scope(scope.clone(), value.get_type()))
+                            .collect::<Vec<&RefPreferences>>();
+                        if !not_in_scope.is_empty() {
+                            tracing::info!(
                         "@LOG: PreferenceReader::put_preferences() debug scope: {:?}, values: {:?}",
                         scope,
                         values
                     );
-                    bail!("Do not have authorization to set preferences.");
-                }
-                // get all current prefs for user and prep new pref rows
-                use crate::schema::pds::account_pref::dsl as AccountPrefSchema;
-                let conn = &mut establish_connection()?;
-                let all_prefs = AccountPrefSchema::account_pref
-                    .filter(AccountPrefSchema::did.eq(&self.did))
-                    .select(models::AccountPref::as_select())
-                    .load(conn)?;
-                let put_prefs = values
-                    .into_iter()
-                    .map(|value| {
-                        Ok(AccountPref {
-                            id: 0,
-                            name: value.get_type(),
-                            value_json: Some(serde_json::to_string(&value)?),
-                        })
-                    })
-                    .collect::<Result<Vec<AccountPref>>>()?;
-
-                let all_pref_ids_in_namespace = all_prefs
-                    .iter()
-                    .filter(|pref| pref_match_namespace(&namespace, &pref.name))
-                    .filter(|pref| pref_in_scope(scope.clone(), pref.name.clone()))
-                    .map(|pref| pref.id)
-                    .collect::<Vec<i32>>();
-                // replace all prefs in given namespace
-                if all_pref_ids_in_namespace.len() > 0 {
-                    delete(AccountPrefSchema::account_pref)
-                        .filter(AccountPrefSchema::id.eq_any(all_pref_ids_in_namespace))
-                        .execute(conn)?;
-                }
-                if put_prefs.len() > 0 {
-                    insert_into(AccountPrefSchema::account_pref)
-                        .values(
-                            put_prefs
-                                .into_iter()
-                                .map(|pref| {
-                                    (
-                                        AccountPrefSchema::did.eq(&self.did),
-                                        AccountPrefSchema::name.eq(pref.name),
-                                        AccountPrefSchema::valueJson.eq(pref.value_json),
-                                    )
+                            bail!("Do not have authorization to set preferences.");
+                        }
+                        // get all current prefs for user and prep new pref rows
+                        use crate::schema::pds::account_pref::dsl as AccountPrefSchema;
+                        let all_prefs = AccountPrefSchema::account_pref
+                            .filter(AccountPrefSchema::did.eq(&did))
+                            .select(models::AccountPref::as_select())
+                            .load(conn)?;
+                        let put_prefs = values
+                            .into_iter()
+                            .map(|value| {
+                                Ok(AccountPref {
+                                    id: 0,
+                                    name: value.get_type(),
+                                    value_json: Some(serde_json::to_string(&value)?),
                                 })
-                                .collect::<Vec<_>>(),
-                        )
-                        .execute(conn)?;
+                            })
+                            .collect::<Result<Vec<AccountPref>>>()?;
+
+                        let all_pref_ids_in_namespace = all_prefs
+                            .iter()
+                            .filter(|pref| pref_match_namespace(&namespace, &pref.name))
+                            .filter(|pref| pref_in_scope(scope.clone(), pref.name.clone()))
+                            .map(|pref| pref.id)
+                            .collect::<Vec<i32>>();
+                        // replace all prefs in given namespace
+                        if !all_pref_ids_in_namespace.is_empty() {
+                            delete(AccountPrefSchema::account_pref)
+                                .filter(AccountPrefSchema::id.eq_any(all_pref_ids_in_namespace))
+                                .execute(conn)?;
+                        }
+                        if !put_prefs.is_empty() {
+                            insert_into(AccountPrefSchema::account_pref)
+                                .values(
+                                    put_prefs
+                                        .into_iter()
+                                        .map(|pref| {
+                                            (
+                                                AccountPrefSchema::did.eq(&did),
+                                                AccountPrefSchema::name.eq(pref.name),
+                                                AccountPrefSchema::valueJson.eq(pref.value_json),
+                                            )
+                                        })
+                                        .collect::<Vec<_>>(),
+                                )
+                                .execute(conn)?;
+                        }
+                        Ok(())
+                    }
                 }
-                Ok(())
-            }
-        }
+            })
+            .await
     }
 }
 

--- a/rsky-pds/src/actor_store/preference/util.rs
+++ b/rsky-pds/src/actor_store/preference/util.rs
@@ -1,10 +1,10 @@
 use crate::auth_verifier::AuthScope;
 
-const FULL_ACCESS_ONLY_PREFS: [&'static str; 1] = ["app.bsky.actor.defs#personalDetailsPref"];
+const FULL_ACCESS_ONLY_PREFS: [&str; 1] = ["app.bsky.actor.defs#personalDetailsPref"];
 
 pub fn pref_in_scope(scope: AuthScope, pref_type: String) -> bool {
     if scope == AuthScope::Access {
         return true;
     }
-    return !FULL_ACCESS_ONLY_PREFS.contains(&&*pref_type);
+    !FULL_ACCESS_ONLY_PREFS.contains(&&*pref_type)
 }

--- a/rsky-pds/src/apis/app/bsky/actor/get_profile.rs
+++ b/rsky-pds/src/apis/app/bsky/actor/get_profile.rs
@@ -1,3 +1,4 @@
+use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandard;
 use crate::config::ServerConfig;
@@ -22,6 +23,7 @@ pub async fn inner_get_profile(
     s3_config: &State<SdkConfig>,
     state_local_viewer: &State<SharedLocalViewer>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<ProfileViewDetailed>, ApiError> {
     let requester: Option<String> = match auth.access.credentials {
         None => None,
@@ -38,6 +40,7 @@ pub async fn inner_get_profile(
                 s3_config,
                 state_local_viewer,
                 db,
+                account_manager,
             )
             .await?;
             Ok(read_afer_write_response)
@@ -58,11 +61,22 @@ pub async fn get_profile(
     state_local_viewer: &State<SharedLocalViewer>,
     cfg: &State<ServerConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<ProfileViewDetailed>, ApiError> {
     match cfg.bsky_app_view {
         None => Err(ApiError::AccountNotFound),
         Some(_) => {
-            match inner_get_profile(actor, auth, res, s3_config, state_local_viewer, db).await {
+            match inner_get_profile(
+                actor,
+                auth,
+                res,
+                s3_config,
+                state_local_viewer,
+                db,
+                account_manager,
+            )
+            .await
+            {
                 Ok(response) => Ok(response),
                 Err(error) => Err(error),
             }

--- a/rsky-pds/src/apis/app/bsky/actor/get_profiles.rs
+++ b/rsky-pds/src/apis/app/bsky/actor/get_profiles.rs
@@ -1,3 +1,4 @@
+use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandard;
 use crate::config::ServerConfig;
@@ -21,6 +22,7 @@ pub async fn inner_get_profiles(
     s3_config: &State<SdkConfig>,
     state_local_viewer: &State<SharedLocalViewer>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<GetProfilesOutput>, ApiError> {
     let requester: String = match auth.access.credentials {
         None => "".to_string(),
@@ -34,6 +36,7 @@ pub async fn inner_get_profiles(
         s3_config,
         state_local_viewer,
         db,
+        account_manager,
     )
     .await?;
     Ok(read_afer_write_response)
@@ -50,11 +53,22 @@ pub async fn get_profiles(
     state_local_viewer: &State<SharedLocalViewer>,
     cfg: &State<ServerConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<GetProfilesOutput>, ApiError> {
     match cfg.bsky_app_view {
         None => Err(ApiError::AccountNotFound),
         Some(_) => {
-            match inner_get_profiles(actors, auth, res, s3_config, state_local_viewer, db).await {
+            match inner_get_profiles(
+                actors,
+                auth,
+                res,
+                s3_config,
+                state_local_viewer,
+                db,
+                account_manager,
+            )
+            .await
+            {
                 Ok(response) => Ok(response),
                 Err(error) => Err(error),
             }

--- a/rsky-pds/src/apis/app/bsky/feed/get_actor_likes.rs
+++ b/rsky-pds/src/apis/app/bsky/feed/get_actor_likes.rs
@@ -1,3 +1,4 @@
+use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandard;
 use crate::config::ServerConfig;
@@ -23,6 +24,7 @@ pub async fn inner_get_actor_likes(
     s3_config: &State<SdkConfig>,
     state_local_viewer: &State<SharedLocalViewer>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<AuthorFeed>> {
     let requester: Option<String> = match auth.access.credentials {
         None => None,
@@ -39,6 +41,7 @@ pub async fn inner_get_actor_likes(
                 s3_config,
                 state_local_viewer,
                 db,
+                account_manager,
             )
             .await?;
             Ok(read_afer_write_response)
@@ -59,6 +62,7 @@ pub async fn get_actor_likes(
     state_local_viewer: &State<SharedLocalViewer>,
     cfg: &State<ServerConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<AuthorFeed>, ApiError> {
     if let Some(limit) = limit {
         if limit > 100 {
@@ -76,6 +80,7 @@ pub async fn get_actor_likes(
             s3_config,
             state_local_viewer,
             db,
+            account_manager,
         )
         .await
         {

--- a/rsky-pds/src/apis/app/bsky/feed/get_author_feed.rs
+++ b/rsky-pds/src/apis/app/bsky/feed/get_author_feed.rs
@@ -1,3 +1,4 @@
+use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandard;
 use crate::config::ServerConfig;
@@ -25,6 +26,7 @@ pub async fn inner_get_author_feed(
     s3_config: &State<SdkConfig>,
     state_local_viewer: &State<SharedLocalViewer>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<AuthorFeed>> {
     let requester: Option<String> = match auth.access.credentials {
         None => None,
@@ -41,6 +43,7 @@ pub async fn inner_get_author_feed(
                 s3_config,
                 state_local_viewer,
                 db,
+                account_manager,
             )
             .await?;
             Ok(read_afer_write_response)
@@ -62,6 +65,7 @@ pub async fn get_author_feed(
     state_local_viewer: &State<SharedLocalViewer>,
     cfg: &State<ServerConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<AuthorFeed>, ApiError> {
     if let Some(limit) = limit {
         if limit > 100 {
@@ -103,6 +107,7 @@ pub async fn get_author_feed(
             s3_config,
             state_local_viewer,
             db,
+            account_manager,
         )
         .await
         {

--- a/rsky-pds/src/apis/app/bsky/feed/get_timeline.rs
+++ b/rsky-pds/src/apis/app/bsky/feed/get_timeline.rs
@@ -1,3 +1,4 @@
+use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandard;
 use crate::config::ServerConfig;
@@ -23,6 +24,7 @@ pub async fn inner_get_timeline(
     s3_config: &State<SdkConfig>,
     state_local_viewer: &State<SharedLocalViewer>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<AuthorFeed>> {
     let requester: Option<String> = match auth.access.credentials {
         None => None,
@@ -39,6 +41,7 @@ pub async fn inner_get_timeline(
                 s3_config,
                 state_local_viewer,
                 db,
+                account_manager,
             )
             .await?;
             Ok(read_afer_write_response)
@@ -60,6 +63,7 @@ pub async fn get_timeline(
     state_local_viewer: &State<SharedLocalViewer>,
     cfg: &State<ServerConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<AuthorFeed>, ApiError> {
     if let Some(limit) = limit {
         if limit > 100 || limit < 1 {
@@ -77,6 +81,7 @@ pub async fn get_timeline(
             s3_config,
             state_local_viewer,
             db,
+            account_manager,
         )
         .await
         {

--- a/rsky-pds/src/apis/app/bsky/notification/register_push.rs
+++ b/rsky-pds/src/apis/app/bsky/notification/register_push.rs
@@ -51,7 +51,7 @@ pub async fn inner_register_push(
 
     if let Some(ref bsky_app_view) = cfg.bsky_app_view {
         if bsky_app_view.did == service_did {
-            let _ = agent
+            agent
                 .service
                 .app
                 .bsky
@@ -81,7 +81,7 @@ pub async fn inner_register_push(
         )
         .build();
     let agent = AtpServiceClient::new(client);
-    let _ = agent
+    agent
         .service
         .app
         .bsky
@@ -111,7 +111,7 @@ pub async fn register_push(
     cfg: &State<ServerConfig>,
     id_resolver: &State<SharedIdResolver>,
 ) -> Result<(), ApiError> {
-    if !vec!["ios", "android", "web"].contains(&body.platform.as_str()) {
+    if !["ios", "android", "web"].contains(&body.platform.as_str()) {
         return Err(ApiError::InvalidRequest("invalid platform".to_string()));
     }
     match &cfg.bsky_app_view {

--- a/rsky-pds/src/apis/com/atproto/admin/delete_account.rs
+++ b/rsky-pds/src/apis/com/atproto/admin/delete_account.rs
@@ -17,13 +17,14 @@ async fn inner_delete_account(
     sequencer: &State<SharedSequencer>,
     s3_config: &State<SdkConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<()> {
     let DeleteAccountInput { did } = body.into_inner();
 
     let mut actor_store =
         ActorStore::new(did.clone(), S3BlobStore::new(did.clone(), s3_config), db);
     actor_store.destroy().await?;
-    AccountManager::delete_account(&did).await?;
+    account_manager.delete_account(&did).await?;
     let mut lock = sequencer.sequencer.write().await;
     let tombstone_seq = lock.sequence_tombstone(did.clone()).await?;
     let account_seq = lock
@@ -46,8 +47,9 @@ pub async fn delete_account(
     s3_config: &State<SdkConfig>,
     _auth: AdminToken,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<(), ApiError> {
-    match inner_delete_account(body, sequencer, s3_config, db).await {
+    match inner_delete_account(body, sequencer, s3_config, db, account_manager).await {
         Ok(_) => Ok(()),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/admin/disable_account_invites.rs
+++ b/rsky-pds/src/apis/com/atproto/admin/disable_account_invites.rs
@@ -14,9 +14,13 @@ use rsky_lexicon::com::atproto::admin::DisableAccountInvitesInput;
 pub async fn disable_account_invites(
     body: Json<DisableAccountInvitesInput>,
     _auth: Moderator,
+    account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     let DisableAccountInvitesInput { account, .. } = body.into_inner();
-    match AccountManager::set_account_invites_disabled(&account, true).await {
+    match account_manager
+        .set_account_invites_disabled(&account, true)
+        .await
+    {
         Ok(_) => Ok(()),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/admin/disable_invite_codes.rs
+++ b/rsky-pds/src/apis/com/atproto/admin/disable_invite_codes.rs
@@ -5,16 +5,21 @@ use anyhow::{bail, Result};
 use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::admin::DisableInviteCodesInput;
 
-async fn inner_disable_invite_codes(body: Json<DisableInviteCodesInput>) -> Result<()> {
+async fn inner_disable_invite_codes(
+    body: Json<DisableInviteCodesInput>,
+    account_manager: AccountManager,
+) -> Result<()> {
     let DisableInviteCodesInput { codes, accounts } = body.into_inner();
-    let codes: Vec<String> = codes.unwrap_or_else(|| vec![]);
-    let accounts: Vec<String> = accounts.unwrap_or_else(|| vec![]);
+    let codes: Vec<String> = codes.unwrap_or_else(Vec::new);
+    let accounts: Vec<String> = accounts.unwrap_or_else(Vec::new);
 
     if accounts.contains(&"admin".to_string()) {
         bail!("cannot disable admin invite codes")
     }
 
-    AccountManager::disable_invite_codes(DisableInviteCodesOpts { codes, accounts }).await
+    account_manager
+        .disable_invite_codes(DisableInviteCodesOpts { codes, accounts })
+        .await
 }
 
 #[tracing::instrument(skip_all)]
@@ -26,8 +31,9 @@ async fn inner_disable_invite_codes(body: Json<DisableInviteCodesInput>) -> Resu
 pub async fn disable_invite_codes(
     body: Json<DisableInviteCodesInput>,
     _auth: Moderator,
+    account_manager: AccountManager,
 ) -> Result<(), ApiError> {
-    match inner_disable_invite_codes(body).await {
+    match inner_disable_invite_codes(body, account_manager).await {
         Ok(_) => Ok(()),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/admin/enable_account_invites.rs
+++ b/rsky-pds/src/apis/com/atproto/admin/enable_account_invites.rs
@@ -14,9 +14,13 @@ use rsky_lexicon::com::atproto::admin::EnableAccountInvitesInput;
 pub async fn enable_account_invites(
     body: Json<EnableAccountInvitesInput>,
     _auth: Moderator,
+    account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     let EnableAccountInvitesInput { account, .. } = body.into_inner();
-    match AccountManager::set_account_invites_disabled(&account, false).await {
+    match account_manager
+        .set_account_invites_disabled(&account, false)
+        .await
+    {
         Ok(_) => Ok(()),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/admin/update_account_email.rs
+++ b/rsky-pds/src/apis/com/atproto/admin/update_account_email.rs
@@ -6,23 +6,28 @@ use anyhow::{bail, Result};
 use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::admin::UpdateAccountEmailInput;
 
-async fn inner_update_account_email(body: Json<UpdateAccountEmailInput>) -> Result<()> {
-    let account = AccountManager::get_account_legacy(
-        &body.account,
-        Some(AvailabilityFlags {
-            include_deactivated: Some(true),
-            include_taken_down: Some(true),
-        }),
-    )
-    .await?;
+async fn inner_update_account_email(
+    body: Json<UpdateAccountEmailInput>,
+    account_manager: AccountManager,
+) -> Result<()> {
+    let account = account_manager
+        .get_account(
+            &body.account,
+            Some(AvailabilityFlags {
+                include_deactivated: Some(true),
+                include_taken_down: Some(true),
+            }),
+        )
+        .await?;
     match account {
         None => bail!("Account does not exist: {}", body.account),
         Some(account) => {
-            AccountManager::update_email(UpdateEmailOpts {
-                did: account.did,
-                email: body.email.clone(),
-            })
-            .await
+            account_manager
+                .update_email(UpdateEmailOpts {
+                    did: account.did,
+                    email: body.email.clone(),
+                })
+                .await
         }
     }
 }
@@ -36,8 +41,9 @@ async fn inner_update_account_email(body: Json<UpdateAccountEmailInput>) -> Resu
 pub async fn update_account_email(
     body: Json<UpdateAccountEmailInput>,
     _auth: AdminToken,
+    account_manager: AccountManager,
 ) -> Result<(), ApiError> {
-    match inner_update_account_email(body).await {
+    match inner_update_account_email(body, account_manager).await {
         Ok(_) => Ok(()),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/admin/update_account_handle.rs
+++ b/rsky-pds/src/apis/com/atproto/admin/update_account_handle.rs
@@ -18,6 +18,7 @@ async fn inner_update_account_handle(
     sequencer: &State<SharedSequencer>,
     server_config: &State<ServerConfig>,
     id_resolver: &State<SharedIdResolver>,
+    account_manager: AccountManager,
 ) -> Result<()> {
     let UpdateAccountHandleInput { did, handle } = body.into_inner();
 
@@ -32,14 +33,15 @@ async fn inner_update_account_handle(
     };
     let handle = normalize_and_validate_handle(opts, validation_ctx).await?;
 
-    let account = AccountManager::get_account_legacy(
-        &handle,
-        Some(AvailabilityFlags {
-            include_deactivated: Some(true),
-            include_taken_down: Some(true),
-        }),
-    )
-    .await?;
+    let account = account_manager
+        .get_account(
+            &handle,
+            Some(AvailabilityFlags {
+                include_deactivated: Some(true),
+                include_taken_down: Some(true),
+            }),
+        )
+        .await?;
 
     match account {
         Some(account) if account.did != did => bail!("Handle already taken: {handle}"),
@@ -52,7 +54,7 @@ async fn inner_update_account_handle(
             plc_client
                 .update_handle(&did, &signing_key, &handle)
                 .await?;
-            AccountManager::update_handle(&did, &handle).await?;
+            account_manager.update_handle(&did, &handle).await?;
         }
     }
     let mut lock = sequencer.sequencer.write().await;
@@ -75,8 +77,11 @@ pub async fn update_account_handle(
     server_config: &State<ServerConfig>,
     id_resolver: &State<SharedIdResolver>,
     _auth: AdminToken,
+    account_manager: AccountManager,
 ) -> Result<(), ApiError> {
-    match inner_update_account_handle(body, sequencer, server_config, id_resolver).await {
+    match inner_update_account_handle(body, sequencer, server_config, id_resolver, account_manager)
+        .await
+    {
         Ok(_) => Ok(()),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/admin/update_account_password.rs
+++ b/rsky-pds/src/apis/com/atproto/admin/update_account_password.rs
@@ -14,9 +14,12 @@ use rsky_lexicon::com::atproto::admin::UpdateAccountPasswordInput;
 pub async fn update_account_password(
     body: Json<UpdateAccountPasswordInput>,
     _auth: AdminToken,
+    account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     let UpdateAccountPasswordInput { did, password } = body.into_inner();
-    match AccountManager::update_account_password(UpdateAccountPasswordOpts { did, password }).await
+    match account_manager
+        .update_account_password(UpdateAccountPasswordOpts { did, password })
+        .await
     {
         Ok(_) => Ok(()),
         Err(error) => {

--- a/rsky-pds/src/apis/com/atproto/identity/get_recommended_did_credentials.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/get_recommended_did_credentials.rs
@@ -16,13 +16,15 @@ use std::env;
 pub async fn get_recommended_did_credentials(
     auth: AccessStandard,
     cfg: &State<ServerConfig>,
+    account_manager: AccountManager,
 ) -> Result<Json<GetRecommendedDidCredentialsResponse>, ApiError> {
     let requester = auth.access.credentials.unwrap().did.unwrap();
     let availability_flags = AvailabilityFlags {
         include_taken_down: Some(true),
         include_deactivated: Some(true),
     };
-    let account = AccountManager::get_account_legacy(&requester, Some(availability_flags))
+    let account = account_manager
+        .get_account(&requester, Some(availability_flags))
         .await?
         .expect("Account not found despite valid access");
 

--- a/rsky-pds/src/apis/com/atproto/identity/sign_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/sign_plc_operation.rs
@@ -20,6 +20,7 @@ use std::collections::BTreeMap;
 pub async fn sign_plc_operation(
     body: Json<SignPlcOperationRequest>,
     auth: AccessFull,
+    account_manager: AccountManager,
 ) -> Result<Json<Operation>, ApiError> {
     let did = auth.access.credentials.unwrap().did.unwrap();
     let request = body.into_inner();
@@ -30,12 +31,9 @@ pub async fn sign_plc_operation(
             "email confirmation token required to sign PLC operations".to_string(),
         ));
     }
-    AccountManager::assert_valid_email_token_and_cleanup(
-        &did,
-        EmailTokenPurpose::PlcOperation,
-        &token,
-    )
-    .await?;
+    account_manager
+        .assert_valid_email_token_and_cleanup(&did, EmailTokenPurpose::PlcOperation, &token)
+        .await?;
 
     let plc_url = env_str("PDS_DID_PLC_URL").unwrap_or("https://plc.directory".to_owned());
     let plc_client = plc::Client::new(plc_url);

--- a/rsky-pds/src/apis/com/atproto/repo/create_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/create_record.rs
@@ -23,6 +23,7 @@ async fn inner_create_record(
     sequencer: &State<SharedSequencer>,
     s3_config: &State<SdkConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<CreateRecordOutput> {
     let CreateRecordInput {
         repo,
@@ -32,14 +33,15 @@ async fn inner_create_record(
         validate,
         swap_commit,
     } = body.into_inner();
-    let account = AccountManager::get_account_legacy(
-        &repo,
-        Some(AvailabilityFlags {
-            include_deactivated: Some(true),
-            include_taken_down: None,
-        }),
-    )
-    .await?;
+    let account = account_manager
+        .get_account(
+            &repo,
+            Some(AvailabilityFlags {
+                include_deactivated: Some(true),
+                include_taken_down: None,
+            }),
+        )
+        .await?;
     if let Some(account) = account {
         if account.deactivated_at.is_some() {
             bail!("Account is deactivated")
@@ -97,7 +99,9 @@ async fn inner_create_record(
         let mut lock = sequencer.sequencer.write().await;
         lock.sequence_commit(did.clone(), commit.clone(), writes)
             .await?;
-        AccountManager::update_repo_root_legacy(did, commit.cid, commit.rev)?;
+        account_manager
+            .update_repo_root(did, commit.cid, commit.rev)
+            .await?;
 
         Ok(CreateRecordOutput {
             uri: write.uri.clone(),
@@ -120,9 +124,10 @@ pub async fn create_record(
     sequencer: &State<SharedSequencer>,
     s3_config: &State<SdkConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<Json<CreateRecordOutput>, ApiError> {
     tracing::debug!("@LOG: debug create_record {body:#?}");
-    match inner_create_record(body, auth, sequencer, s3_config, db).await {
+    match inner_create_record(body, auth, sequencer, s3_config, db, account_manager).await {
         Ok(res) => Ok(Json(res)),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/repo/delete_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/delete_record.rs
@@ -23,6 +23,7 @@ async fn inner_delete_record(
     sequencer: &State<SharedSequencer>,
     s3_config: &State<SdkConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<()> {
     let DeleteRecordInput {
         repo,
@@ -31,14 +32,15 @@ async fn inner_delete_record(
         swap_record,
         swap_commit,
     } = body.into_inner();
-    let account = AccountManager::get_account_legacy(
-        &repo,
-        Some(AvailabilityFlags {
-            include_deactivated: Some(true),
-            include_taken_down: None,
-        }),
-    )
-    .await?;
+    let account = account_manager
+        .get_account(
+            &repo,
+            Some(AvailabilityFlags {
+                include_deactivated: Some(true),
+                include_taken_down: None,
+            }),
+        )
+        .await?;
     match account {
         None => bail!("Could not find repo: `{repo}`"),
         Some(account) if account.deactivated_at.is_some() => bail!("Account is deactivated"),
@@ -86,7 +88,9 @@ async fn inner_delete_record(
                 vec![PreparedWrite::Delete(write)],
             )
             .await?;
-            AccountManager::update_repo_root_legacy(did, commit.cid, commit.rev)?;
+            account_manager
+                .update_repo_root(did, commit.cid, commit.rev)
+                .await?;
 
             Ok(())
         }
@@ -105,8 +109,9 @@ pub async fn delete_record(
     sequencer: &State<SharedSequencer>,
     s3_config: &State<SdkConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<(), ApiError> {
-    match inner_delete_record(body, auth, sequencer, s3_config, db).await {
+    match inner_delete_record(body, auth, sequencer, s3_config, db, account_manager).await {
         Ok(()) => Ok(()),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/repo/get_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/get_record.rs
@@ -20,8 +20,9 @@ async fn inner_get_record(
     s3_config: &State<SdkConfig>,
     db: DbConn,
     req: ProxyRequest<'_>,
+    account_manager: AccountManager,
 ) -> Result<GetRecordOutput> {
-    let did = AccountManager::get_did_for_actor(&repo, None).await?;
+    let did = account_manager.get_did_for_actor(&repo, None).await?;
 
     // fetch from pds if available, if not then fetch from appview
     if let Some(did) = did {
@@ -74,8 +75,20 @@ pub async fn get_record(
     s3_config: &State<SdkConfig>,
     db: DbConn,
     req: ProxyRequest<'_>,
+    account_manager: AccountManager,
 ) -> Result<Json<GetRecordOutput>, ApiError> {
-    match inner_get_record(repo, collection, rkey, cid, s3_config, db, req).await {
+    match inner_get_record(
+        repo,
+        collection,
+        rkey,
+        cid,
+        s3_config,
+        db,
+        req,
+        account_manager,
+    )
+    .await
+    {
         Ok(res) => Ok(Json(res)),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/repo/list_records.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/list_records.rs
@@ -27,11 +27,12 @@ async fn inner_list_records(
     reverse: bool,
     s3_config: &State<SdkConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<ListRecordsOutput> {
     if limit > 100 {
         bail!("Error: limit can not be greater than 100")
     }
-    let did = AccountManager::get_did_for_actor(&repo, None).await?;
+    let did = account_manager.get_did_for_actor(&repo, None).await?;
     if let Some(did) = did {
         let mut actor_store =
             ActorStore::new(did.clone(), S3BlobStore::new(did.clone(), s3_config), db);
@@ -91,12 +92,22 @@ pub async fn list_records(
     reverse: Option<bool>,
     s3_config: &State<SdkConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<Json<ListRecordsOutput>, ApiError> {
     let limit = limit.unwrap_or(50);
     let reverse = reverse.unwrap_or(false);
 
     match inner_list_records(
-        repo, collection, limit, cursor, rkeyStart, rkeyEnd, reverse, s3_config, db,
+        repo,
+        collection,
+        limit,
+        cursor,
+        rkeyStart,
+        rkeyEnd,
+        reverse,
+        s3_config,
+        db,
+        account_manager,
     )
     .await
     {

--- a/rsky-pds/src/apis/com/atproto/repo/mod.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/mod.rs
@@ -5,15 +5,17 @@ use anyhow::{bail, Result};
 pub async fn assert_repo_availability(
     did: &String,
     is_admin_of_self: bool,
+    account_manager: &AccountManager,
 ) -> Result<ActorAccount> {
-    let account = AccountManager::get_account_legacy(
-        did,
-        Some(AvailabilityFlags {
-            include_deactivated: Some(true),
-            include_taken_down: Some(true),
-        }),
-    )
-    .await?;
+    let account = account_manager
+        .get_account(
+            did,
+            Some(AvailabilityFlags {
+                include_deactivated: Some(true),
+                include_taken_down: Some(true),
+            }),
+        )
+        .await?;
     match account {
         None => bail!("RepoNotFound: Could not find repo for DID: {did}"),
         Some(account) => {

--- a/rsky-pds/src/apis/com/atproto/repo/upload_blob.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/upload_blob.rs
@@ -67,7 +67,7 @@ async fn inner_upload_blob(
     if !records_for_blob.is_empty() {
         actor_store
             .blob
-            .verify_blob_and_make_permanent_legacy(PreparedBlobRef {
+            .verify_blob_and_make_permanent(PreparedBlobRef {
                 cid: blobref.get_cid()?,
                 mime_type: blobref.get_mime_type().to_string(),
                 constraints: BlobConstraint {

--- a/rsky-pds/src/apis/com/atproto/server/check_account_status.rs
+++ b/rsky-pds/src/apis/com/atproto/server/check_account_status.rs
@@ -16,6 +16,7 @@ async fn inner_check_account_status(
     auth: AccessFull,
     s3_config: &State<SdkConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<CheckAccountStatusOutput> {
     let requester = auth.access.credentials.unwrap().did.unwrap();
 
@@ -39,7 +40,7 @@ async fn inner_check_account_status(
     )?;
 
     let (activated, valid_did) = try_join!(
-        AccountManager::is_account_activated(&requester),
+        account_manager.is_account_activated(&requester),
         is_valid_did_doc_for_service(requester.clone())
     )?;
 
@@ -62,8 +63,9 @@ pub async fn check_account_status(
     auth: AccessFull,
     s3_config: &State<SdkConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<Json<CheckAccountStatusOutput>, ApiError> {
-    match inner_check_account_status(auth, s3_config, db).await {
+    match inner_check_account_status(auth, s3_config, db, account_manager).await {
         Ok(res) => Ok(Json(res)),
         Err(error) => {
             tracing::error!("Internal Error: {error}");

--- a/rsky-pds/src/apis/com/atproto/server/create_app_password.rs
+++ b/rsky-pds/src/apis/com/atproto/server/create_app_password.rs
@@ -13,9 +13,11 @@ use rsky_lexicon::com::atproto::server::{CreateAppPasswordInput, CreateAppPasswo
 pub async fn create_app_password(
     body: Json<CreateAppPasswordInput>,
     auth: AccessFull,
+    account_manager: AccountManager,
 ) -> Result<Json<CreateAppPasswordOutput>, ApiError> {
     let CreateAppPasswordInput { name } = body.into_inner();
-    match AccountManager::create_app_password(auth.access.credentials.unwrap().did.unwrap(), name)
+    match account_manager
+        .create_app_password(auth.access.credentials.unwrap().did.unwrap(), name)
         .await
     {
         Ok(app_password) => Ok(Json(app_password)),

--- a/rsky-pds/src/apis/com/atproto/server/create_invite_codes.rs
+++ b/rsky-pds/src/apis/com/atproto/server/create_invite_codes.rs
@@ -1,7 +1,6 @@
 use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
 use crate::auth_verifier::AdminToken;
-use crate::db::DbConn;
 use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::server::{
     AccountCodes, CreateInviteCodesInput, CreateInviteCodesOutput,
@@ -16,7 +15,7 @@ use rsky_lexicon::com::atproto::server::{
 pub async fn create_invite_codes(
     body: Json<CreateInviteCodesInput>,
     _auth: AdminToken,
-    db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<Json<CreateInviteCodesOutput>, ApiError> {
     // @TODO: verify admin auth token
     let CreateInviteCodesInput {
@@ -32,7 +31,10 @@ pub async fn create_invite_codes(
         account_codes.push(AccountCodes { account, codes });
     }
 
-    match AccountManager::create_invite_codes(account_codes.clone(), use_count, &db).await {
+    match account_manager
+        .create_invite_codes(account_codes.clone(), use_count)
+        .await
+    {
         Ok(_) => Ok(Json(CreateInviteCodesOutput {
             codes: account_codes,
         })),

--- a/rsky-pds/src/apis/com/atproto/server/deactivate_account.rs
+++ b/rsky-pds/src/apis/com/atproto/server/deactivate_account.rs
@@ -14,10 +14,11 @@ use rsky_lexicon::com::atproto::server::DeactivateAccountInput;
 pub async fn deactivate_account(
     body: Json<DeactivateAccountInput>,
     auth: AccessFull,
+    account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     let did = auth.access.credentials.unwrap().did.unwrap();
     let DeactivateAccountInput { delete_after } = body.into_inner();
-    match AccountManager::deactivate_account(&did, delete_after).await {
+    match account_manager.deactivate_account(&did, delete_after).await {
         Ok(()) => Ok(()),
         Err(error) => {
             tracing::error!("Internal Error: {error}");

--- a/rsky-pds/src/apis/com/atproto/server/delete_account.rs
+++ b/rsky-pds/src/apis/com/atproto/server/delete_account.rs
@@ -19,36 +19,37 @@ async fn inner_delete_account(
     sequencer: &State<SharedSequencer>,
     s3_config: &State<SdkConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     let DeleteAccountInput {
         did,
         password,
         token,
     } = body.into_inner();
-    let account = AccountManager::get_account_legacy(
-        &did,
-        Some(AvailabilityFlags {
-            include_deactivated: Some(true),
-            include_taken_down: Some(true),
-        }),
-    )
-    .await?;
-    if let Some(_) = account {
-        let valid_pass = AccountManager::verify_account_password_legacy(&did, &password).await?;
+    let account = account_manager
+        .get_account(
+            &did,
+            Some(AvailabilityFlags {
+                include_deactivated: Some(true),
+                include_taken_down: Some(true),
+            }),
+        )
+        .await?;
+    if account.is_some() {
+        let valid_pass = account_manager
+            .verify_account_password(&did, &password)
+            .await?;
         if !valid_pass {
             return Err(ApiError::InvalidLogin);
         }
-        AccountManager::assert_valid_email_token(
-            &did,
-            EmailTokenPurpose::from_str("delete_account")?,
-            &token,
-        )
-        .await?;
+        account_manager
+            .assert_valid_email_token(&did, EmailTokenPurpose::from_str("delete_account")?, &token)
+            .await?;
 
         let mut actor_store =
             ActorStore::new(did.clone(), S3BlobStore::new(did.clone(), s3_config), db);
         actor_store.destroy().await?;
-        AccountManager::delete_account(&did).await?;
+        account_manager.delete_account(&did).await?;
         let mut lock = sequencer.sequencer.write().await;
         let account_seq = lock
             .sequence_account_evt(did.clone(), AccountStatus::Deleted)
@@ -75,8 +76,9 @@ pub async fn delete_account(
     s3_config: &State<SdkConfig>,
     db: DbConn,
     _auth: AdminToken,
+    account_manager: AccountManager,
 ) -> Result<(), ApiError> {
-    match inner_delete_account(body, sequencer, s3_config, db).await {
+    match inner_delete_account(body, sequencer, s3_config, db, account_manager).await {
         Ok(_) => Ok(()),
         Err(error) => Err(error),
     }

--- a/rsky-pds/src/apis/com/atproto/server/delete_session.rs
+++ b/rsky-pds/src/apis/com/atproto/server/delete_session.rs
@@ -4,8 +4,11 @@ use crate::auth_verifier::RevokeRefreshToken;
 
 #[tracing::instrument(skip_all)]
 #[rocket::post("/xrpc/com.atproto.server.deleteSession")]
-pub async fn delete_session(auth: RevokeRefreshToken) -> Result<(), ApiError> {
-    match AccountManager::revoke_refresh_token(auth.id).await {
+pub async fn delete_session(
+    auth: RevokeRefreshToken,
+    account_manager: AccountManager,
+) -> Result<(), ApiError> {
+    match account_manager.revoke_refresh_token(auth.id).await {
         Ok(_) => Ok(()),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/server/get_session.rs
+++ b/rsky-pds/src/apis/com/atproto/server/get_session.rs
@@ -7,9 +7,12 @@ use rsky_syntax::handle::INVALID_HANDLE;
 
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/com.atproto.server.getSession")]
-pub async fn get_session(auth: AccessStandard) -> Result<Json<GetSessionOutput>, ApiError> {
+pub async fn get_session(
+    auth: AccessStandard,
+    account_manager: AccountManager,
+) -> Result<Json<GetSessionOutput>, ApiError> {
     let did = auth.access.credentials.unwrap().did.unwrap();
-    match AccountManager::get_account_legacy(&did, None).await {
+    match account_manager.get_account(&did, None).await {
         Ok(Some(user)) => Ok(Json(GetSessionOutput {
             handle: user.handle.unwrap_or(INVALID_HANDLE.to_string()),
             did: user.did,

--- a/rsky-pds/src/apis/com/atproto/server/list_app_passwords.rs
+++ b/rsky-pds/src/apis/com/atproto/server/list_app_passwords.rs
@@ -8,9 +8,10 @@ use rsky_lexicon::com::atproto::server::{AppPassword, ListAppPasswordsOutput};
 #[rocket::get("/xrpc/com.atproto.server.listAppPasswords")]
 pub async fn list_app_passwords(
     auth: AccessFull,
+    account_manager: AccountManager,
 ) -> Result<Json<ListAppPasswordsOutput>, ApiError> {
     let did = auth.access.credentials.unwrap().did.unwrap();
-    match AccountManager::list_app_passwords(&did).await {
+    match account_manager.list_app_passwords(&did).await {
         Ok(passwords) => {
             let passwords: Vec<AppPassword> = passwords
                 .into_iter()

--- a/rsky-pds/src/apis/com/atproto/server/refresh_session.rs
+++ b/rsky-pds/src/apis/com/atproto/server/refresh_session.rs
@@ -7,24 +7,28 @@ use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::server::RefreshSessionOutput;
 use rsky_syntax::handle::INVALID_HANDLE;
 
-async fn inner_refresh_session(auth: Refresh) -> Result<RefreshSessionOutput, ApiError> {
+async fn inner_refresh_session(
+    auth: Refresh,
+    account_manager: AccountManager,
+) -> Result<RefreshSessionOutput, ApiError> {
     let Credentials { did, token_id, .. } = auth.access.credentials.unwrap();
     let did = did.unwrap();
     let token_id = token_id.unwrap();
-    let user = AccountManager::get_account_legacy(
-        &did,
-        Some(AvailabilityFlags {
-            include_deactivated: Some(true),
-            include_taken_down: Some(true),
-        }),
-    )
-    .await?;
+    let user = account_manager
+        .get_account(
+            &did,
+            Some(AvailabilityFlags {
+                include_deactivated: Some(true),
+                include_taken_down: Some(true),
+            }),
+        )
+        .await?;
 
     if let Some(user) = user {
         if user.takedown_ref.is_some() {
             return Err(ApiError::AccountTakendown);
         }
-        let rotated = AccountManager::rotate_refresh_token(&token_id).await?;
+        let rotated = account_manager.rotate_refresh_token(&token_id).await?;
         if let Some(rotated) = rotated {
             Ok(RefreshSessionOutput {
                 handle: user.handle.unwrap_or(INVALID_HANDLE.to_string()),
@@ -43,8 +47,11 @@ async fn inner_refresh_session(auth: Refresh) -> Result<RefreshSessionOutput, Ap
 
 #[tracing::instrument(skip_all)]
 #[rocket::post("/xrpc/com.atproto.server.refreshSession")]
-pub async fn refresh_session(auth: Refresh) -> Result<Json<RefreshSessionOutput>, ApiError> {
-    match inner_refresh_session(auth).await {
+pub async fn refresh_session(
+    auth: Refresh,
+    account_manager: AccountManager,
+) -> Result<Json<RefreshSessionOutput>, ApiError> {
+    match inner_refresh_session(auth, account_manager).await {
         Ok(res) => Ok(Json(res)),
         Err(error) => Err(error),
     }

--- a/rsky-pds/src/apis/com/atproto/server/request_account_delete.rs
+++ b/rsky-pds/src/apis/com/atproto/server/request_account_delete.rs
@@ -7,20 +7,25 @@ use crate::mailer::TokenParam;
 use crate::models::models::EmailTokenPurpose;
 use anyhow::{bail, Result};
 
-async fn inner_request_account_delete(auth: AccessStandardIncludeChecks) -> Result<()> {
+async fn inner_request_account_delete(
+    auth: AccessStandardIncludeChecks,
+    account_manager: AccountManager,
+) -> Result<()> {
     let did = auth.access.credentials.unwrap().did.unwrap();
-    let account = AccountManager::get_account_legacy(
-        &did,
-        Some(AvailabilityFlags {
-            include_deactivated: Some(true),
-            include_taken_down: Some(true),
-        }),
-    )
-    .await?;
+    let account = account_manager
+        .get_account(
+            &did,
+            Some(AvailabilityFlags {
+                include_deactivated: Some(true),
+                include_taken_down: Some(true),
+            }),
+        )
+        .await?;
     if let Some(account) = account {
         if let Some(email) = account.email {
-            let token =
-                AccountManager::create_email_token(&did, EmailTokenPurpose::DeleteAccount).await?;
+            let token = account_manager
+                .create_email_token(&did, EmailTokenPurpose::DeleteAccount)
+                .await?;
             mailer::send_account_delete(email, TokenParam { token }).await?;
             Ok(())
         } else {
@@ -33,8 +38,11 @@ async fn inner_request_account_delete(auth: AccessStandardIncludeChecks) -> Resu
 
 #[tracing::instrument(skip_all)]
 #[rocket::post("/xrpc/com.atproto.server.requestAccountDelete")]
-pub async fn request_account_delete(auth: AccessStandardIncludeChecks) -> Result<(), ApiError> {
-    match inner_request_account_delete(auth).await {
+pub async fn request_account_delete(
+    auth: AccessStandardIncludeChecks,
+    account_manager: AccountManager,
+) -> Result<(), ApiError> {
+    match inner_request_account_delete(auth, account_manager).await {
         Ok(_) => Ok(()),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/server/request_email_confirmation.rs
+++ b/rsky-pds/src/apis/com/atproto/server/request_email_confirmation.rs
@@ -7,20 +7,25 @@ use crate::mailer::TokenParam;
 use crate::models::models::EmailTokenPurpose;
 use anyhow::{bail, Result};
 
-async fn inner_request_email_confirmation(auth: AccessStandardIncludeChecks) -> Result<()> {
+async fn inner_request_email_confirmation(
+    auth: AccessStandardIncludeChecks,
+    account_manager: AccountManager,
+) -> Result<()> {
     let did = auth.access.credentials.unwrap().did.unwrap();
-    let account = AccountManager::get_account_legacy(
-        &did,
-        Some(AvailabilityFlags {
-            include_deactivated: Some(true),
-            include_taken_down: Some(true),
-        }),
-    )
-    .await?;
+    let account = account_manager
+        .get_account(
+            &did,
+            Some(AvailabilityFlags {
+                include_deactivated: Some(true),
+                include_taken_down: Some(true),
+            }),
+        )
+        .await?;
     if let Some(account) = account {
         if let Some(email) = account.email {
-            let token =
-                AccountManager::create_email_token(&did, EmailTokenPurpose::ConfirmEmail).await?;
+            let token = account_manager
+                .create_email_token(&did, EmailTokenPurpose::ConfirmEmail)
+                .await?;
             mailer::send_confirm_email(email, TokenParam { token }).await?;
             Ok(())
         } else {
@@ -33,8 +38,11 @@ async fn inner_request_email_confirmation(auth: AccessStandardIncludeChecks) -> 
 
 #[tracing::instrument(skip_all)]
 #[rocket::post("/xrpc/com.atproto.server.requestEmailConfirmation")]
-pub async fn request_email_confirmation(auth: AccessStandardIncludeChecks) -> Result<(), ApiError> {
-    match inner_request_email_confirmation(auth).await {
+pub async fn request_email_confirmation(
+    auth: AccessStandardIncludeChecks,
+    account_manager: AccountManager,
+) -> Result<(), ApiError> {
+    match inner_request_email_confirmation(auth, account_manager).await {
         Ok(_) => Ok(()),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/server/request_email_update.rs
+++ b/rsky-pds/src/apis/com/atproto/server/request_email_update.rs
@@ -11,23 +11,25 @@ use rsky_lexicon::com::atproto::server::RequestEmailUpdateOutput;
 
 async fn inner_request_email_update(
     auth: AccessStandardIncludeChecks,
+    account_manager: AccountManager,
 ) -> Result<RequestEmailUpdateOutput> {
     let did = auth.access.credentials.unwrap().did.unwrap();
-    let account = AccountManager::get_account_legacy(
-        &did,
-        Some(AvailabilityFlags {
-            include_deactivated: Some(true),
-            include_taken_down: Some(true),
-        }),
-    )
-    .await?;
+    let account = account_manager
+        .get_account(
+            &did,
+            Some(AvailabilityFlags {
+                include_deactivated: Some(true),
+                include_taken_down: Some(true),
+            }),
+        )
+        .await?;
     if let Some(account) = account {
         if let Some(email) = account.email {
             let token_required = account.email_confirmed_at.is_some();
             if token_required {
-                let token =
-                    AccountManager::create_email_token(&did, EmailTokenPurpose::UpdateEmail)
-                        .await?;
+                let token = account_manager
+                    .create_email_token(&did, EmailTokenPurpose::UpdateEmail)
+                    .await?;
                 mailer::send_update_email(email, TokenParam { token }).await?;
             }
 
@@ -44,8 +46,9 @@ async fn inner_request_email_update(
 #[rocket::post("/xrpc/com.atproto.server.requestEmailUpdate")]
 pub async fn request_email_update(
     auth: AccessStandardIncludeChecks,
+    account_manager: AccountManager,
 ) -> Result<Json<RequestEmailUpdateOutput>, ApiError> {
-    match inner_request_email_update(auth).await {
+    match inner_request_email_update(auth, account_manager).await {
         Ok(res) => Ok(Json(res)),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/server/reset_password.rs
+++ b/rsky-pds/src/apis/com/atproto/server/reset_password.rs
@@ -9,9 +9,15 @@ use rsky_lexicon::com::atproto::server::ResetPasswordInput;
     format = "json",
     data = "<body>"
 )]
-pub async fn reset_password(body: Json<ResetPasswordInput>) -> Result<(), ApiError> {
+pub async fn reset_password(
+    body: Json<ResetPasswordInput>,
+    account_manager: AccountManager,
+) -> Result<(), ApiError> {
     let ResetPasswordInput { token, password } = body.into_inner();
-    match AccountManager::reset_password(ResetPasswordOpts { token, password }).await {
+    match account_manager
+        .reset_password(ResetPasswordOpts { token, password })
+        .await
+    {
         Ok(_) => Ok(()),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/server/revoke_app_password.rs
+++ b/rsky-pds/src/apis/com/atproto/server/revoke_app_password.rs
@@ -13,11 +13,12 @@ use rsky_lexicon::com::atproto::server::RevokeAppPasswordInput;
 pub async fn revoke_app_password(
     body: Json<RevokeAppPasswordInput>,
     auth: AccessFull,
+    account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     let RevokeAppPasswordInput { name } = body.into_inner();
     let requester = auth.access.credentials.unwrap().did.unwrap();
 
-    match AccountManager::revoke_app_password(requester, name).await {
+    match account_manager.revoke_app_password(requester, name).await {
         Ok(_) => Ok(()),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/server/update_email.rs
+++ b/rsky-pds/src/apis/com/atproto/server/update_email.rs
@@ -7,36 +7,41 @@ use anyhow::{bail, Result};
 use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::server::UpdateEmailInput;
 
-async fn inner_update_email(body: Json<UpdateEmailInput>, auth: AccessFull) -> Result<()> {
+async fn inner_update_email(
+    body: Json<UpdateEmailInput>,
+    auth: AccessFull,
+    account_manager: AccountManager,
+) -> Result<()> {
     let did = auth.access.credentials.unwrap().did.unwrap();
     let UpdateEmailInput { email, token } = body.into_inner();
     if !mailchecker::is_valid(&email) {
         bail!("This email address is not supported, please use a different email.")
     }
-    let account = AccountManager::get_account_legacy(
-        &did,
-        Some(AvailabilityFlags {
-            include_deactivated: Some(true),
-            include_taken_down: None,
-        }),
-    )
-    .await?;
+    let account = account_manager
+        .get_account(
+            &did,
+            Some(AvailabilityFlags {
+                include_deactivated: Some(true),
+                include_taken_down: None,
+            }),
+        )
+        .await?;
 
     if let Some(account) = account {
         // require valid token if account email is confirmed
-        if let Some(_) = account.email_confirmed_at {
+        if account.email_confirmed_at.is_some() {
             if let Some(token) = token {
-                AccountManager::assert_valid_email_token(
-                    &did,
-                    EmailTokenPurpose::UpdateEmail,
-                    &token,
-                )
-                .await?;
+                account_manager
+                    .assert_valid_email_token(&did, EmailTokenPurpose::UpdateEmail, &token)
+                    .await?;
             } else {
                 bail!("Confirmation token required")
             }
         }
-        match AccountManager::update_email(UpdateEmailOpts { did, email }).await {
+        match account_manager
+            .update_email(UpdateEmailOpts { did, email })
+            .await
+        {
             Ok(_) => Ok(()),
             Err(e) => match e.downcast_ref() {
                 Some(AccountHelperError::UserAlreadyExistsError) => {
@@ -56,8 +61,12 @@ async fn inner_update_email(body: Json<UpdateEmailInput>, auth: AccessFull) -> R
     format = "json",
     data = "<body>"
 )]
-pub async fn update_email(body: Json<UpdateEmailInput>, auth: AccessFull) -> Result<(), ApiError> {
-    match inner_update_email(body, auth).await {
+pub async fn update_email(
+    body: Json<UpdateEmailInput>,
+    auth: AccessFull,
+    account_manager: AccountManager,
+) -> Result<(), ApiError> {
+    match inner_update_email(body, auth, account_manager).await {
         Ok(_) => Ok(()),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/sync/get_blob.rs
+++ b/rsky-pds/src/apis/com/atproto/sync/get_blob.rs
@@ -1,3 +1,4 @@
+use crate::account_manager::AccountManager;
 use crate::actor_store::aws::s3::S3BlobStore;
 use crate::actor_store::ActorStore;
 use crate::apis::com::atproto::repo::assert_repo_availability;
@@ -24,13 +25,14 @@ async fn inner_get_blob(
     s3_config: &State<SdkConfig>,
     auth: OptionalAccessOrAdminToken,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<(Vec<u8>, Option<String>)> {
     let is_user_or_admin = if let Some(access) = auth.access {
         auth_verifier::is_user_or_admin(access, &did)
     } else {
         false
     };
-    let _ = assert_repo_availability(&did, is_user_or_admin).await?;
+    let _ = assert_repo_availability(&did, is_user_or_admin, &account_manager).await?;
 
     let cid = Cid::from_str(&cid)?;
     let actor_store = ActorStore::new(did.clone(), S3BlobStore::new(did.clone(), s3_config), db);
@@ -50,8 +52,9 @@ pub async fn get_blob(
     s3_config: &State<SdkConfig>,
     auth: OptionalAccessOrAdminToken,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<BlobResponder, ApiError> {
-    match inner_get_blob(did, cid, s3_config, auth, db).await {
+    match inner_get_blob(did, cid, s3_config, auth, db, account_manager).await {
         Ok(res) => {
             let (bytes, mime_type) = res;
             Ok(BlobResponder(

--- a/rsky-pds/src/apis/com/atproto/sync/get_latest_commit.rs
+++ b/rsky-pds/src/apis/com/atproto/sync/get_latest_commit.rs
@@ -1,3 +1,4 @@
+use crate::account_manager::AccountManager;
 use crate::actor_store::aws::s3::S3BlobStore;
 use crate::actor_store::ActorStore;
 use crate::apis::com::atproto::repo::assert_repo_availability;
@@ -16,13 +17,14 @@ async fn inner_get_latest_commit(
     s3_config: &State<SdkConfig>,
     auth: OptionalAccessOrAdminToken,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<GetLatestCommitOutput> {
     let is_user_or_admin = if let Some(access) = auth.access {
         auth_verifier::is_user_or_admin(access, &did)
     } else {
         false
     };
-    let _ = assert_repo_availability(&did, is_user_or_admin).await?;
+    let _ = assert_repo_availability(&did, is_user_or_admin, &account_manager).await?;
 
     let actor_store = ActorStore::new(did.clone(), S3BlobStore::new(did.clone(), s3_config), db);
     let storage_guard = actor_store.storage.read().await;
@@ -42,8 +44,9 @@ pub async fn get_latest_commit(
     s3_config: &State<SdkConfig>,
     auth: OptionalAccessOrAdminToken,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<Json<GetLatestCommitOutput>, ApiError> {
-    match inner_get_latest_commit(did, s3_config, auth, db).await {
+    match inner_get_latest_commit(did, s3_config, auth, db, account_manager).await {
         Ok(res) => Ok(Json(res)),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/sync/get_repo_status.rs
+++ b/rsky-pds/src/apis/com/atproto/sync/get_repo_status.rs
@@ -1,6 +1,7 @@
 use crate::account_manager::helpers::account::{
     format_account_status, AccountStatus, FormattedAccountStatus,
 };
+use crate::account_manager::AccountManager;
 use crate::actor_store::aws::s3::S3BlobStore;
 use crate::actor_store::ActorStore;
 use crate::apis::com::atproto::repo::assert_repo_availability;
@@ -16,8 +17,9 @@ async fn inner_get_repo(
     did: String,
     s3_config: &State<SdkConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<GetRepoStatusOutput> {
-    let account = assert_repo_availability(&did, true).await?;
+    let account = assert_repo_availability(&did, true, &account_manager).await?;
     let FormattedAccountStatus { active, status } = format_account_status(Some(account));
 
     let mut rev: Option<String> = None;
@@ -54,8 +56,9 @@ pub async fn get_repo_status(
     did: String,
     s3_config: &State<SdkConfig>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<Json<GetRepoStatusOutput>, ApiError> {
-    match inner_get_repo(did, s3_config, db).await {
+    match inner_get_repo(did, s3_config, db, account_manager).await {
         Ok(res) => Ok(Json(res)),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/sync/list_blobs.rs
+++ b/rsky-pds/src/apis/com/atproto/sync/list_blobs.rs
@@ -1,3 +1,4 @@
+use crate::account_manager::AccountManager;
 use crate::actor_store::aws::s3::S3BlobStore;
 use crate::actor_store::blob::ListBlobsOpts;
 use crate::actor_store::ActorStore;
@@ -20,13 +21,14 @@ async fn inner_list_blobs(
     s3_config: &State<SdkConfig>,
     auth: OptionalAccessOrAdminToken,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<ListBlobsOutput> {
     let is_user_or_admin = if let Some(access) = auth.access {
         auth_verifier::is_user_or_admin(access, &did)
     } else {
         false
     };
-    let _ = assert_repo_availability(&did, is_user_or_admin).await?;
+    let _ = assert_repo_availability(&did, is_user_or_admin, &account_manager).await?;
 
     let actor_store = ActorStore::new(did.clone(), S3BlobStore::new(did.clone(), s3_config), db);
     let blob_cids = actor_store
@@ -60,8 +62,20 @@ pub async fn list_blobs(
     s3_config: &State<SdkConfig>,
     auth: OptionalAccessOrAdminToken,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<Json<ListBlobsOutput>, ApiError> {
-    match inner_list_blobs(did, since, limit, cursor, s3_config, auth, db).await {
+    match inner_list_blobs(
+        did,
+        since,
+        limit,
+        cursor,
+        s3_config,
+        auth,
+        db,
+        account_manager,
+    )
+    .await
+    {
         Ok(res) => Ok(Json(res)),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/com/atproto/sync/list_repos.rs
+++ b/rsky-pds/src/apis/com/atproto/sync/list_repos.rs
@@ -2,7 +2,7 @@ use crate::account_manager::helpers::account::{
     format_account_status, AccountStatus, ActorAccount, FormattedAccountStatus,
 };
 use crate::apis::ApiError;
-use crate::db::establish_connection;
+use crate::db::DbConn;
 use anyhow::{anyhow, bail, Result};
 use diesel::dsl::sql;
 use diesel::prelude::*;
@@ -112,7 +112,7 @@ impl TimeDidKeySet {
             None => Ok(None),
             Some(cursor_str) => {
                 let result = cursor_str.split("::").collect::<Vec<&str>>();
-                match (result.get(0), result.get(1), result.get(2)) {
+                match (result.first(), result.get(1), result.get(2)) {
                     (Some(primary), Some(secondary), None) => Ok(Some(Cursor {
                         primary: primary.to_string(),
                         secondary: secondary.to_string(),
@@ -126,6 +126,7 @@ impl TimeDidKeySet {
     pub async fn paginate(
         &self,
         opts: KeySetPaginateOpts,
+        db: &DbConn,
     ) -> Result<
         Vec<(
             String,
@@ -145,7 +146,6 @@ impl TimeDidKeySet {
 
         use crate::schema::pds::actor::dsl as ActorSchema;
         use crate::schema::pds::repo_root::dsl as RepoRootSchema;
-        let conn = &mut establish_connection()?;
 
         let labeled = self.unpack(cursor)?;
 
@@ -196,26 +196,37 @@ impl TimeDidKeySet {
             }
         }
 
-        let res = builder.load::<(
-            String,
-            String,
-            String,
-            String,
-            Option<String>,
-            Option<String>,
-        )>(conn)?;
+        let res = db
+            .run(move |conn| {
+                builder.load::<(
+                    String,
+                    String,
+                    String,
+                    String,
+                    Option<String>,
+                    Option<String>,
+                )>(conn)
+            })
+            .await?;
         Ok(res)
     }
 }
 
-async fn inner_list_repos(limit: Option<i64>, cursor: Option<String>) -> Result<ListReposOutput> {
+async fn inner_list_repos(
+    limit: Option<i64>,
+    cursor: Option<String>,
+    db: &DbConn,
+) -> Result<ListReposOutput> {
     let keyset = TimeDidKeySet::new();
     let result = keyset
-        .paginate(KeySetPaginateOpts {
-            limit: limit.unwrap_or(500),
-            cursor,
-            direction: Some("asc".to_string()),
-        })
+        .paginate(
+            KeySetPaginateOpts {
+                limit: limit.unwrap_or(500),
+                cursor,
+                direction: Some("asc".to_string()),
+            },
+            db,
+        )
         .await?;
     let time_did_results = result
         .iter()
@@ -268,8 +279,9 @@ async fn inner_list_repos(limit: Option<i64>, cursor: Option<String>) -> Result<
 pub async fn list_repos(
     limit: Option<i64>,
     cursor: Option<String>,
+    db: DbConn,
 ) -> Result<Json<ListReposOutput>, ApiError> {
-    match inner_list_repos(limit, cursor).await {
+    match inner_list_repos(limit, cursor, &db).await {
         Ok(res) => Ok(Json(res)),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");

--- a/rsky-pds/src/apis/mod.rs
+++ b/rsky-pds/src/apis/mod.rs
@@ -62,10 +62,10 @@ pub async fn bsky_api_get_forwarder(
     }
 }
 
-#[rocket::post("/xrpc/<nsid>", data = "<body>", rank = 2)]
+#[rocket::post("/xrpc/<_nsid>", data = "<body>", rank = 2)]
 pub async fn bsky_api_post_forwarder(
     body: Data<'_>,
-    nsid: Nsid,
+    _nsid: Nsid,
     auth: AccessStandard,
     req: ProxyRequest<'_>,
 ) -> Result<ProxyResponder, ApiError> {

--- a/rsky-pds/src/config/mod.rs
+++ b/rsky-pds/src/config/mod.rs
@@ -89,12 +89,10 @@ pub fn env_to_cfg() -> ServerConfig {
     let service_handle_domains: Vec<String>;
     if env_list("PDS_SERVICE_HANDLE_DOMAINS").len() > 0 {
         service_handle_domains = env_list("PDS_SERVICE_HANDLE_DOMAINS");
+    } else if hostname == "localhost" {
+        service_handle_domains = vec![".test".to_string()];
     } else {
-        if hostname == "localhost" {
-            service_handle_domains = vec![".test".to_string()];
-        } else {
-            service_handle_domains = vec![format!(".{hostname}")];
-        }
+        service_handle_domains = vec![format!(".{hostname}")];
     }
     let identity_cfg: IdentityConfig = IdentityConfig {
         plc_url: env_str("PDS_DID_PLC_URL").unwrap_or("https://plc.directory".to_string()),

--- a/rsky-pds/src/context.rs
+++ b/rsky-pds/src/context.rs
@@ -5,14 +5,14 @@ use reqwest::header::HeaderMap;
 use secp256k1::SecretKey;
 use std::env;
 
-pub async fn service_auth_headers(did: &String, aud: &String, lxm: &String) -> Result<HeaderMap> {
-    let private_key = env::var("PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-    let keypair = SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
+pub async fn service_auth_headers(did: &str, aud: &str, lxm: &str) -> Result<HeaderMap> {
+    let private_key = env::var("PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX")?;
+    let keypair = SecretKey::from_slice(&hex::decode(private_key.as_bytes())?)?;
     create_service_auth_headers(ServiceJwtParams {
-        iss: did.clone(),
-        aud: aud.clone(),
+        iss: did.to_owned(),
+        aud: aud.to_owned(),
         exp: None,
-        lxm: Some(lxm.clone()),
+        lxm: Some(lxm.to_owned()),
         jti: None,
         keypair,
     })

--- a/rsky-pds/src/crawlers.rs
+++ b/rsky-pds/src/crawlers.rs
@@ -32,7 +32,7 @@ impl Crawlers {
             .duration_since(SystemTime::UNIX_EPOCH)
             .expect("timestamp in micros since UNIX epoch")
             .as_micros() as usize;
-        if now - &self.last_notified < NOTIFY_THRESHOLD as usize {
+        if now - self.last_notified < NOTIFY_THRESHOLD as usize {
             return Ok(());
         }
         let _ = stream::iter(self.crawlers.clone())

--- a/rsky-pds/src/db/mod.rs
+++ b/rsky-pds/src/db/mod.rs
@@ -15,11 +15,10 @@ impl Debug for DbConn {
     }
 }
 
-// @TODO: Deprecate and replace with DbConn
 #[tracing::instrument(skip_all)]
-pub fn establish_connection() -> Result<PgConnection> {
+pub fn establish_connection_for_sequencer() -> Result<PgConnection> {
     dotenv().ok();
-    tracing::debug!("Establishing database connection");
+    tracing::debug!("Establishing database connection for Sequencer");
     let database_url = env::var("DATABASE_URL").unwrap_or("".into());
     let result = PgConnection::establish(&database_url).map_err(|error| {
         let context = format!("Error connecting to {database_url:?}");

--- a/rsky-pds/src/image/mod.rs
+++ b/rsky-pds/src/image/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use image::io::Reader as ImageReader;
+use image::ImageReader;
 use image::{guess_format, GenericImageView};
 use std::io::Cursor;
 
@@ -33,8 +33,8 @@ pub async fn maybe_get_info(bytes: Vec<u8>) -> Result<Option<ImageInfo>> {
         }))
     };
 
-    return match process_image() {
+    match process_image() {
         Ok(info) => Ok(info),
         Err(_) => Ok(None),
-    };
+    }
 }

--- a/rsky-pds/src/lib.rs
+++ b/rsky-pds/src/lib.rs
@@ -29,7 +29,7 @@ pub mod schema;
 pub mod sequencer;
 pub mod well_known;
 pub mod xrpc_server;
-use crate::account_manager::AccountManager;
+use crate::account_manager::{AccountManager, SharedAccountManager};
 use crate::config::env_to_cfg;
 use crate::crawlers::Crawlers;
 use crate::db::DbConn;
@@ -67,12 +67,10 @@ lazy_static! {
     pub static ref EVENT_EMITTER: RwLock<EventEmitter> = RwLock::new(EventEmitter::new());
 }
 
-#[macro_use]
 extern crate rocket;
 use crate::apis::{app, bsky_api_get_forwarder, bsky_api_post_forwarder, com, ApiError};
 use atrium_api::client::AtpServiceClient;
 use atrium_xrpc_client::reqwest::ReqwestClientBuilder;
-use diesel::prelude::*;
 use diesel::sql_types::Int4;
 use dotenvy::dotenv;
 use rocket::data::{Limits, ToByteUnit};
@@ -83,7 +81,6 @@ use rocket::figment::{
 };
 use rocket::http::Header;
 use rocket::http::Status;
-use rocket::request::local_cache;
 use rocket::response::status;
 use rocket::serde::json::Json;
 use rocket::shield::{NoSniff, Shield};
@@ -264,7 +261,6 @@ pub async fn build_rocket(cfg: Option<RocketConfig>) -> Rocket<Build> {
     };
     let local_viewer = SharedLocalViewer {
         local_viewer: RwLock::new(LocalViewer::creator(LocalViewerCreatorParams {
-            account_manager: AccountManager {},
             pds_hostname: cfg.service.hostname.clone(),
             appview_agent: match cfg.bsky_app_view {
                 None => None,
@@ -279,6 +275,9 @@ pub async fn build_rocket(cfg: Option<RocketConfig>) -> Rocket<Build> {
                 Some(ref bsky_app_view) => bsky_app_view.cdn_url_pattern.clone(),
             },
         })),
+    };
+    let account_manager = SharedAccountManager {
+        account_manager: RwLock::new(AccountManager::creator()),
     };
 
     let shield = Shield::default().enable(NoSniff::Enable);
@@ -378,4 +377,5 @@ pub async fn build_rocket(cfg: Option<RocketConfig>) -> Rocket<Build> {
         .manage(cfg)
         .manage(local_viewer)
         .manage(app_view_agent)
+        .manage(account_manager)
 }

--- a/rsky-pds/src/pipethrough.rs
+++ b/rsky-pds/src/pipethrough.rs
@@ -228,7 +228,7 @@ pub async fn pipethrough_procedure_post<'r>(
 // Request setup/formatting
 // -------------------
 
-const REQ_HEADERS_TO_FORWARD: [&'static str; 4] = [
+const REQ_HEADERS_TO_FORWARD: [&str; 4] = [
     "accept-language",
     "content-type",
     "atproto-accept-labelers",
@@ -462,7 +462,7 @@ pub async fn make_request(req_init: RequestBuilder) -> Result<Response> {
 // Response parsing/forwarding
 // -------------------
 
-const RES_HEADERS_TO_FORWARD: [&'static str; 4] = [
+const RES_HEADERS_TO_FORWARD: [&str; 4] = [
     "content-type",
     "content-language",
     "atproto-repo-rev",
@@ -476,7 +476,7 @@ pub async fn parse_proxy_res(res: Response) -> Result<HandlerPipeThrough> {
     };
     // Release borrow
     let encoding = encoding.to_string();
-    let res_headers = RES_HEADERS_TO_FORWARD.clone().into_iter().fold(
+    let res_headers = RES_HEADERS_TO_FORWARD.into_iter().fold(
         BTreeMap::new(),
         |mut acc: BTreeMap<String, String>, cur| {
             let _ = match res.headers().get(cur) {
@@ -546,10 +546,7 @@ lazy_static! {
 
 }
 
-pub async fn default_service<'r>(
-    req: &'r ProxyRequest<'_>,
-    nsid: &String,
-) -> Option<ServiceConfig> {
+pub async fn default_service<'r>(req: &'r ProxyRequest<'_>, nsid: &str) -> Option<ServiceConfig> {
     let cfg = req.cfg;
     match Ids::from_str(nsid) {
         Ok(Ids::ToolsOzoneTeamAddMember) => cfg.mod_service.clone(),

--- a/rsky-pds/src/plc/mod.rs
+++ b/rsky-pds/src/plc/mod.rs
@@ -96,7 +96,7 @@ impl Client {
         &self,
         did: &String,
         signer: &SecretKey,
-        handle: &String,
+        handle: &str,
     ) -> Result<()> {
         let last_op: CompatibleOp = match self.ensure_last_op(did).await? {
             CompatibleOpOrTombstone::CreateOpV1(last_op) => CompatibleOp::CreateOpV1(last_op),
@@ -105,8 +105,8 @@ impl Client {
                 panic!("ensure_last_op() didn't prevent tombstone")
             }
         };
-        let op = update_handle_op(last_op, signer, handle.clone()).await?;
-        self.send_operation(&did, &OpOrTombstone::Operation(op))
+        let op = update_handle_op(last_op, signer, handle.to_owned()).await?;
+        self.send_operation(did, &OpOrTombstone::Operation(op))
             .await
     }
 }

--- a/rsky-pds/src/plc/types.rs
+++ b/rsky-pds/src/plc/types.rs
@@ -69,7 +69,7 @@ pub enum CompatibleOpOrTombstone {
 }
 
 impl CompatibleOpOrTombstone {
-    pub fn set_sig(&mut self, sig: String) -> () {
+    pub fn set_sig(&mut self, sig: String) {
         match self {
             Self::CreateOpV1(create) => create.sig = Some(sig),
             Self::Operation(op) => op.sig = Some(sig),
@@ -94,7 +94,7 @@ pub enum CompatibleOp {
 }
 
 impl CompatibleOp {
-    pub fn set_sig(&mut self, sig: String) -> () {
+    pub fn set_sig(&mut self, sig: String) {
         match self {
             Self::CreateOpV1(create) => create.sig = Some(sig),
             Self::Operation(op) => op.sig = Some(sig),
@@ -117,7 +117,7 @@ pub enum OpOrTombstone {
 }
 
 impl OpOrTombstone {
-    pub fn set_sig(&mut self, sig: String) -> () {
+    pub fn set_sig(&mut self, sig: String) {
         match self {
             Self::Operation(op) => op.sig = Some(sig),
             Self::Tombstone(tombstone) => tombstone.sig = Some(sig),

--- a/rsky-pds/src/read_after_write/util.rs
+++ b/rsky-pds/src/read_after_write/util.rs
@@ -1,3 +1,4 @@
+use crate::account_manager::AccountManager;
 use crate::actor_store::aws::s3::S3BlobStore;
 use crate::actor_store::ActorStore;
 use crate::db::DbConn;
@@ -21,7 +22,7 @@ use std::collections::BTreeMap;
 use std::io::Cursor;
 use std::time::SystemTime;
 
-const REPO_REV_HEADER: &'static str = "atproto-repo-rev";
+const REPO_REV_HEADER: &str = "atproto-repo-rev";
 
 pub type MungeFn<T> = fn(LocalViewer, T, LocalRecords, String) -> Result<T>;
 
@@ -76,10 +77,7 @@ impl<'r, T: Serialize> Responder<'r, 'static> for ReadAfterWriteResponse<T> {
 }
 
 pub fn get_repo_rev(headers: &BTreeMap<String, String>) -> Option<String> {
-    match headers.get(REPO_REV_HEADER) {
-        None => None,
-        Some(value) => Some(value.clone()),
-    }
+    headers.get(REPO_REV_HEADER).map(|value| value.clone())
 }
 
 pub fn get_local_lag(local: &LocalRecords) -> Result<Option<usize>> {
@@ -116,6 +114,7 @@ pub async fn handle_read_after_write<T: DeserializeOwned + serde::Serialize>(
     s3_config: &State<SdkConfig>,
     state_local_viewer: &State<SharedLocalViewer>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<T>> {
     match read_after_write_internal(
         nsid,
@@ -125,6 +124,7 @@ pub async fn handle_read_after_write<T: DeserializeOwned + serde::Serialize>(
         s3_config,
         state_local_viewer,
         db,
+        account_manager,
     )
     .await
     {
@@ -148,8 +148,9 @@ pub async fn read_after_write_internal<T: DeserializeOwned + serde::Serialize>(
     s3_config: &State<SdkConfig>,
     state_local_viewer: &State<SharedLocalViewer>,
     db: DbConn,
+    account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<T>> {
-    let headers = &res.headers.clone().unwrap_or_else(|| BTreeMap::new());
+    let headers = &res.headers.clone().unwrap_or_else(BTreeMap::new);
     let rev = get_repo_rev(headers);
     match rev {
         None => Ok(ReadAfterWriteResponse::HandlerPipeThrough(res)),
@@ -164,7 +165,7 @@ pub async fn read_after_write_internal<T: DeserializeOwned + serde::Serialize>(
                 return Ok(ReadAfterWriteResponse::HandlerPipeThrough(res));
             }
             let local_viewer_lock = state_local_viewer.local_viewer.read().await;
-            let local_viewer = local_viewer_lock(actor_store);
+            let local_viewer = local_viewer_lock(actor_store, account_manager);
             let parse_res = parse_res(nsid, res)?;
             let data = munge(local_viewer, parse_res, local.clone(), requester)?;
             Ok(ReadAfterWriteResponse::HandlerResponse(

--- a/rsky-pds/src/read_after_write/viewer.rs
+++ b/rsky-pds/src/read_after_write/viewer.rs
@@ -1,7 +1,6 @@
 use crate::account_manager::helpers::auth::ServiceJwtParams;
 use crate::account_manager::AccountManager;
 use crate::actor_store::ActorStore;
-use crate::db::establish_connection;
 use crate::models::models;
 use crate::read_after_write::types::{LocalRecords, RecordDescript};
 use crate::read_after_write::util;
@@ -51,10 +50,9 @@ use std::str::FromStr;
 
 pub type Agent = AtpServiceClient<ReqwestClient>;
 
-pub type LocalViewerCreator = Box<dyn Fn(ActorStore) -> LocalViewer + Send + Sync>;
+pub type LocalViewerCreator = Box<dyn Fn(ActorStore, AccountManager) -> LocalViewer + Send + Sync>;
 
 pub struct LocalViewerCreatorParams {
-    pub account_manager: AccountManager,
     pub pds_hostname: String,
     pub appview_agent: Option<String>,
     pub appview_did: Option<String>,
@@ -62,6 +60,7 @@ pub struct LocalViewerCreatorParams {
 }
 
 pub struct LocalViewer {
+    pub account_manager: AccountManager,
     pub did: String,
     pub actor_store: ActorStore,
     pub pds_hostname: String,
@@ -74,6 +73,7 @@ pub struct LocalViewer {
 impl LocalViewer {
     pub fn new(
         actor_store: ActorStore,
+        account_manager: AccountManager,
         pds_hostname: String,
         appview_agent: Option<Agent>,
         appview_agent_str: Option<String>,
@@ -83,6 +83,7 @@ impl LocalViewer {
         LocalViewer {
             did: actor_store.did.clone(),
             actor_store,
+            account_manager,
             pds_hostname,
             appview_agent,
             appview_agent_str,
@@ -92,33 +93,36 @@ impl LocalViewer {
     }
 
     pub fn creator(params: LocalViewerCreatorParams) -> LocalViewerCreator {
-        return Box::new(move |actor_store: ActorStore| -> LocalViewer {
-            LocalViewer::new(
-                actor_store,
-                params.pds_hostname.clone(),
-                match params.appview_agent {
-                    None => None,
-                    Some(ref bsky_app_view_url) => {
-                        let client = ReqwestClientBuilder::new(bsky_app_view_url.clone())
-                            .client(
-                                reqwest::ClientBuilder::new()
-                                    .user_agent(APP_USER_AGENT)
-                                    .timeout(std::time::Duration::from_millis(1000))
-                                    .build()
-                                    .unwrap(),
-                            )
-                            .build();
-                        Some(AtpServiceClient::new(client))
-                    }
-                },
-                match params.appview_agent {
-                    None => None,
-                    Some(ref bsky_app_view_url) => Some(bsky_app_view_url.clone()),
-                },
-                params.appview_did.clone(),
-                params.appview_cdn_url_pattern.clone(),
-            )
-        });
+        Box::new(
+            move |actor_store: ActorStore, account_manager: AccountManager| -> LocalViewer {
+                LocalViewer::new(
+                    actor_store,
+                    account_manager,
+                    params.pds_hostname.clone(),
+                    match params.appview_agent {
+                        None => None,
+                        Some(ref bsky_app_view_url) => {
+                            let client = ReqwestClientBuilder::new(bsky_app_view_url.clone())
+                                .client(
+                                    reqwest::ClientBuilder::new()
+                                        .user_agent(APP_USER_AGENT)
+                                        .timeout(std::time::Duration::from_millis(1000))
+                                        .build()
+                                        .unwrap(),
+                                )
+                                .build();
+                            Some(AtpServiceClient::new(client))
+                        }
+                    },
+                    match params.appview_agent {
+                        None => None,
+                        Some(ref bsky_app_view_url) => Some(bsky_app_view_url.clone()),
+                    },
+                    params.appview_did.clone(),
+                    params.appview_cdn_url_pattern.clone(),
+                )
+            },
+        )
     }
 
     pub fn get_image_url(&self, pattern: String, cid: String) -> String {
@@ -136,7 +140,7 @@ impl LocalViewer {
         }
     }
 
-    pub async fn service_auth_headers(&self, did: &String, lxm: &String) -> Result<HeaderMap> {
+    pub async fn service_auth_headers(&self, did: &str, lxm: &str) -> Result<HeaderMap> {
         match &self.appview_did {
             None => bail!("Could not find bsky appview did"),
             Some(appview_did) => {
@@ -144,10 +148,10 @@ impl LocalViewer {
                 let keypair =
                     SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
                 create_service_auth_headers(ServiceJwtParams {
-                    iss: did.clone(),
+                    iss: did.to_owned(),
                     aud: appview_did.clone(),
                     exp: None,
-                    lxm: Some(lxm.clone()),
+                    lxm: Some(lxm.to_owned()),
                     jti: None,
                     keypair,
                 })
@@ -163,20 +167,27 @@ impl LocalViewer {
     pub async fn get_profile_basic(&self) -> Result<Option<ProfileViewBasic>> {
         use crate::schema::pds::record::dsl as RecordSchema;
         use crate::schema::pds::repo_block::dsl as RepoBlockSchema;
-        let conn = &mut establish_connection()?;
 
-        let profile_res: Option<(models::Record, Option<models::RepoBlock>)> = RecordSchema::record
-            .left_join(RepoBlockSchema::repo_block.on(RepoBlockSchema::cid.eq(RecordSchema::cid)))
-            .select((
-                models::Record::as_select(),
-                Option::<models::RepoBlock>::as_select(),
-            ))
-            .filter(RecordSchema::did.eq(&self.actor_store.did))
-            .filter(RecordSchema::collection.eq(Ids::AppBskyActorProfile.as_str()))
-            .filter(RecordSchema::rkey.eq("self"))
-            .first(conn)
-            .optional()?;
-        let account_res = AccountManager::get_account_legacy(&self.did, None).await?;
+        let db = self.actor_store.record.db.clone();
+        let did = self.actor_store.did.clone();
+        let profile_res: Option<(models::Record, Option<models::RepoBlock>)> = db
+            .run(move |conn| {
+                RecordSchema::record
+                    .left_join(
+                        RepoBlockSchema::repo_block.on(RepoBlockSchema::cid.eq(RecordSchema::cid)),
+                    )
+                    .select((
+                        models::Record::as_select(),
+                        Option::<models::RepoBlock>::as_select(),
+                    ))
+                    .filter(RecordSchema::did.eq(&did))
+                    .filter(RecordSchema::collection.eq(Ids::AppBskyActorProfile.as_str()))
+                    .filter(RecordSchema::rkey.eq("self"))
+                    .first(conn)
+                    .optional()
+            })
+            .await?;
+        let account_res = self.account_manager.get_account(&self.did, None).await?;
         match account_res {
             None => Ok(None),
             Some(account_res) => {
@@ -224,7 +235,7 @@ impl LocalViewer {
         mut feed: Vec<FeedViewPost>,
         posts: Vec<RecordDescript<Post>>,
     ) -> Result<Vec<FeedViewPost>> {
-        if posts.len() == 0 {
+        if posts.is_empty() {
             return Ok(feed);
         }
         let last_time: String = match feed.last() {
@@ -645,27 +656,43 @@ impl LocalViewer {
 pub async fn get_records_since_rev(actor_store: &ActorStore, rev: String) -> Result<LocalRecords> {
     use crate::schema::pds::record::dsl as RecordSchema;
     use crate::schema::pds::repo_block::dsl as RepoBlockSchema;
-    let conn = &mut establish_connection()?;
 
-    let res: Vec<(models::Record, models::RepoBlock)> = RecordSchema::record
-        .inner_join(RepoBlockSchema::repo_block.on(RepoBlockSchema::cid.eq(RecordSchema::cid)))
-        .select((models::Record::as_select(), models::RepoBlock::as_select()))
-        .filter(RecordSchema::did.eq(&actor_store.did))
-        .filter(RecordSchema::repoRev.gt(&rev))
-        .limit(10)
-        .order_by(RecordSchema::repoRev.asc())
-        .get_results(conn)?;
+    let did = actor_store.did.clone();
+    let did_1 = did.clone();
+    let rev_1 = rev.clone();
+    let res: Vec<(models::Record, models::RepoBlock)> = actor_store
+        .record
+        .db
+        .run(move |conn| {
+            RecordSchema::record
+                .inner_join(
+                    RepoBlockSchema::repo_block.on(RepoBlockSchema::cid.eq(RecordSchema::cid)),
+                )
+                .select((models::Record::as_select(), models::RepoBlock::as_select()))
+                .filter(RecordSchema::did.eq(did_1))
+                .filter(RecordSchema::repoRev.gt(rev_1))
+                .limit(10)
+                .order_by(RecordSchema::repoRev.asc())
+                .get_results(conn)
+        })
+        .await?;
 
     // sanity check to ensure that the clock received is not before _all_ local records
     // (for instance in case of account migration)
-    if res.len() > 0 {
-        let sanity_checks = RecordSchema::record
-            .select(models::Record::as_select())
-            .filter(RecordSchema::did.eq(&actor_store.did))
-            .filter(RecordSchema::repoRev.le(&rev))
-            .limit(1)
-            .first(conn)
-            .optional()?;
+    if !res.is_empty() {
+        let sanity_checks = actor_store
+            .record
+            .db
+            .run(move |conn| {
+                RecordSchema::record
+                    .select(models::Record::as_select())
+                    .filter(RecordSchema::did.eq(&did))
+                    .filter(RecordSchema::repoRev.le(&rev))
+                    .limit(1)
+                    .first(conn)
+                    .optional()
+            })
+            .await?;
         if sanity_checks.is_none() {
             return Ok(LocalRecords {
                 count: 0,

--- a/rsky-pds/src/repo/prepare.rs
+++ b/rsky-pds/src/repo/prepare.rs
@@ -85,8 +85,8 @@ pub fn blobs_for_write(record: RepoRecord, validate: bool) -> anyhow::Result<Vec
 }
 
 pub fn find_blob_refs(val: Lex, path: Option<Vec<String>>, layer: Option<u8>) -> Vec<FoundBlobRef> {
-    let layer = layer.unwrap_or_else(|| 0);
-    let path = path.unwrap_or_else(|| vec![]);
+    let layer = layer.unwrap_or(0);
+    let path = path.unwrap_or_else(std::vec::Vec::new);
     if layer > 32 {
         return vec![];
     }
@@ -149,7 +149,7 @@ pub fn set_collection_name(
     mut record: RepoRecord,
     validate: bool,
 ) -> anyhow::Result<RepoRecord> {
-    if record.get("$type").is_none() {
+    if !record.contains_key("$type") {
         record.insert(
             "$type".to_string(),
             Lex::Ipld(Ipld::Json(JsonValue::String(collection.clone()))),
@@ -180,7 +180,7 @@ pub async fn prepare_create(opts: PrepareCreateOpts) -> anyhow::Result<PreparedC
         validate,
         ..
     } = opts;
-    let validate = validate.unwrap_or_else(|| true);
+    let validate = validate.unwrap_or(true);
 
     let record = set_collection_name(&collection, opts.record, validate)?;
     if validate {
@@ -210,7 +210,7 @@ pub async fn prepare_update(opts: PrepareUpdateOpts) -> anyhow::Result<PreparedC
         validate,
         ..
     } = opts;
-    let validate = validate.unwrap_or_else(|| true);
+    let validate = validate.unwrap_or(true);
 
     let record = set_collection_name(&collection, opts.record, validate)?;
     if validate {

--- a/rsky-pds/src/sequencer/mod.rs
+++ b/rsky-pds/src/sequencer/mod.rs
@@ -1,6 +1,6 @@
 use crate::account_manager::helpers::account::AccountStatus;
 use crate::crawlers::Crawlers;
-use crate::db::establish_connection;
+use crate::db::establish_connection_for_sequencer;
 use crate::models;
 use crate::sequencer::events::{
     format_seq_account_evt, format_seq_commit, format_seq_handle_update, format_seq_identity_evt,
@@ -50,9 +50,7 @@ impl Sequencer {
         self.last_seen = Some(curr.unwrap_or(0));
         if self.waker.is_none() {
             loop {
-                while let Some(_) = self.next().await {
-                    ()
-                }
+                while let Some(_) = self.next().await {}
             }
         }
         Ok(())
@@ -68,7 +66,7 @@ impl Sequencer {
 
     pub async fn curr(&self) -> Result<Option<i64>> {
         use crate::schema::pds::repo_seq::dsl as RepoSeqSchema;
-        let conn = &mut establish_connection()?;
+        let conn = &mut establish_connection_for_sequencer()?;
 
         let got = RepoSeqSchema::repo_seq
             .select(models::RepoSeq::as_select())
@@ -83,7 +81,7 @@ impl Sequencer {
 
     pub async fn next_seq(&self, cursor: i64) -> Result<Option<models::RepoSeq>> {
         use crate::schema::pds::repo_seq::dsl as RepoSeqSchema;
-        let conn = &mut establish_connection()?;
+        let conn = &mut establish_connection_for_sequencer()?;
 
         let got = RepoSeqSchema::repo_seq
             .filter(RepoSeqSchema::seq.gt(cursor))
@@ -96,7 +94,7 @@ impl Sequencer {
 
     pub async fn earliest_after_time(&self, time: String) -> Result<Option<models::RepoSeq>> {
         use crate::schema::pds::repo_seq::dsl as RepoSeqSchema;
-        let conn = &mut establish_connection()?;
+        let conn = &mut establish_connection_for_sequencer()?;
 
         let got = RepoSeqSchema::repo_seq
             .filter(RepoSeqSchema::sequencedAt.ge(time))
@@ -109,7 +107,7 @@ impl Sequencer {
 
     pub async fn request_seq_range(&self, opts: RequestSeqRangeOpts) -> Result<Vec<SeqEvt>> {
         use crate::schema::pds::repo_seq::dsl as RepoSeqSchema;
-        let conn = &mut establish_connection()?;
+        let conn = &mut establish_connection_for_sequencer()?;
 
         let RequestSeqRangeOpts {
             earliest_seq,
@@ -189,7 +187,7 @@ impl Sequencer {
         Ok(seq_evts)
     }
 
-    async fn exponential_backoff(&mut self) -> () {
+    async fn exponential_backoff(&mut self) {
         self.tries_with_no_results += 1;
         let wait_time = cmp::min(
             2u64.checked_pow(self.tries_with_no_results).unwrap_or(2),
@@ -203,7 +201,7 @@ impl Sequencer {
 
     pub async fn sequence_evt(&mut self, evt: models::RepoSeq) -> Result<i64> {
         use crate::schema::pds::repo_seq::dsl as RepoSeqSchema;
-        let conn = &mut establish_connection()?;
+        let conn = &mut establish_connection_for_sequencer()?;
 
         let res = insert_into(RepoSeqSchema::repo_seq)
             .values((
@@ -308,7 +306,7 @@ impl Stream for Sequencer {
 
 pub async fn delete_all_for_user(did: &String, excluding_seqs: Option<Vec<i64>>) -> Result<()> {
     use crate::schema::pds::repo_seq::dsl as RepoSeqSchema;
-    let conn = &mut establish_connection()?;
+    let conn = &mut establish_connection_for_sequencer()?;
     let excluding_seqs = excluding_seqs.unwrap_or_else(|| vec![]);
 
     let mut builder = delete(RepoSeqSchema::repo_seq)

--- a/rsky-pds/src/well_known.rs
+++ b/rsky-pds/src/well_known.rs
@@ -24,21 +24,21 @@ impl<'r> FromRequest<'r> for HostHeader {
 pub async fn well_known(
     host: HostHeader,
     cfg: &State<ServerConfig>,
+    account_manager: AccountManager,
 ) -> Result<String, status::Custom<String>> {
     let handle = host.0;
     let supported_handle = cfg
         .identity
         .service_handle_domains
         .iter()
-        .find(|host| handle.ends_with(host.as_str()) || handle == host[1..])
-        .is_some();
+        .any(|host| handle.ends_with(host.as_str()) || handle == host[1..]);
     if !supported_handle {
         return Err(status::Custom(
             Status::NotFound,
             "User not found".to_string(),
         ));
     }
-    match AccountManager::get_account_legacy(&handle, None).await {
+    match account_manager.get_account(&handle, None).await {
         Ok(user) => {
             let did: Option<String> = match user {
                 Some(user) => Some(user.did),

--- a/rsky-pds/src/xrpc_server/auth.rs
+++ b/rsky-pds/src/xrpc_server/auth.rs
@@ -51,7 +51,7 @@ where
     G: Fn(String, bool) -> Result<String>,
 {
     let parts = jwt_str.split(".").collect::<Vec<&str>>();
-    match (parts.get(0), parts.get(1), parts.get(2)) {
+    match (parts.first(), parts.get(1), parts.get(2)) {
         (Some(_), Some(parts_1), Some(sig)) if parts.len() == 3 => {
             let parts_1 = *parts_1;
             let sig = *sig;

--- a/rsky-pds/src/xrpc_server/stream/frames.rs
+++ b/rsky-pds/src/xrpc_server/stream/frames.rs
@@ -47,10 +47,7 @@ impl<T> MessageFrame<T> {
     }
 
     pub fn get_type(&self) -> Option<&String> {
-        match self.header.t {
-            None => None,
-            Some(ref t) => Some(t),
-        }
+        self.header.t.as_ref()
     }
 }
 
@@ -93,10 +90,7 @@ impl ErrorFrame {
     }
 
     pub fn get_message(&self) -> Option<&String> {
-        match self.body.message {
-            None => None,
-            Some(ref message) => Some(message),
-        }
+        self.body.message.as_ref()
     }
 }
 


### PR DESCRIPTION
## Summary
- AccountManager implementation changed to use DB Connection passed to it on its creation
- AccountManager RequestGuard added
- BlobReader and PreferenceReader now receive Arc<DBConn> from ActorStore
- ActorStore now receives Arc<DBConn>
- deprecrated functions for establish_connection removed. Newly named establish_connection_for_sequencer remains as the sequencer is a background task not exclusively owned by Rocket

## Related Issues
[OAuth](https://github.com/blacksky-algorithms/rsky/issues/60) - Needed to incorporate AccountManager into the OAuthProvider

## Changes
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [x] Other (please specify): Refactor to remove establish_connection dependency, and instead use Rocket's managed DB connections

## Checklist
- [x] I have tested the changes (including writing unit tests).
- [x] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [x] I have updated relevant documentation.
- [x] I have formatted my code correctly
- [x] I have provided examples for how this code works or will be used