### PR TITLE
rsky-satnav: add diff UI

### DIFF
--- a/rsky-satnav/Cargo.toml
+++ b/rsky-satnav/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = {workspace = true}
 base64 = "0.22.1"
 ipld-core = "0.4.2"
 hex = "0.4"
+cid = "0.11"
 
 [features]
 default = ["web"]


### PR DESCRIPTION
## Summary
Added diffing support to rsky-satnav. The user can open 2 car files now & see the diffs in terms of blocks & actual records. I've also added onHover handler to use blue highlight for the previous block & red highlight for the next block to make it easy to navigate. This does not check if the car files have any common history yet.

## Related Issues
<!-- Link any relevant issues -->

## Changes
- [x] Feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [x] I have tested the changes (including writing unit tests).
- [x] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [ ] I have updated relevant documentation.
- [x] I have formatted my code correctly
- [ ] I have provided examples for how this code works or will be used