### PR TITLE
rsky-relay: fix polling interest

### DIFF
--- a/rsky-relay/src/crawler/worker.rs
+++ b/rsky-relay/src/crawler/worker.rs
@@ -84,7 +84,7 @@ impl Worker {
                         #[expect(clippy::expect_used)]
                         unsafe {
                             self.poller
-                                .add_with_mode(&conn, Event::all(idx), PollMode::Level)
+                                .add_with_mode(&conn, Event::readable(idx), PollMode::Level)
                                 .expect("unable to register");
                         }
                         self.connections[idx] = Some(conn);

--- a/rsky-relay/src/publisher/worker.rs
+++ b/rsky-relay/src/publisher/worker.rs
@@ -76,7 +76,7 @@ impl Worker {
                         #[expect(clippy::expect_used)]
                         unsafe {
                             self.poller
-                                .add_with_mode(&conn, Event::all(idx), PollMode::Level)
+                                .add_with_mode(&conn, Event::writable(idx), PollMode::Level)
                                 .expect("unable to register");
                         }
                         self.connections[idx] = Some(conn);

--- a/rsky-relay/src/validator/manager.rs
+++ b/rsky-relay/src/validator/manager.rs
@@ -174,7 +174,7 @@ impl Manager {
                         let curr: u64 = seq.into();
                         if prev >= curr {
                             if prev > curr {
-                                tracing::debug!(%prev, diff = %prev - curr, "old seq");
+                                tracing::trace!(%prev, diff = %prev - curr, "old seq");
                             }
                             continue;
                         } else if prev + 1 != curr {


### PR DESCRIPTION
## Summary
Messed up the the polling interest flags. We only need to know if the crawling connection is "readable" & the publishing connection is "writable". A connection is almost always writable, so epoll keeps waking up crawling threads for no reason. Should cut down CPU usage of crawling from 400% to 5%.

## Related Issues
<!-- Link any relevant issues -->

## Changes
- [ ] Feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [x] I have tested the changes (including writing unit tests).
- [x] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [ ] I have updated relevant documentation.
- [x] I have formatted my code correctly
- [ ] I have provided examples for how this code works or will be used