### PR TITLE
rsky-relay: use sqlite for host state

### DIFF
--- a/rsky-relay/Cargo.toml
+++ b/rsky-relay/Cargo.toml
@@ -25,7 +25,7 @@ polling = "3"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "gzip", "hickory-dns", "http2", "json", "rustls-tls-webpki-roots-no-provider"] }
 rs-car-sync = "0.4"
 rtrb = "0.3"
-rusqlite = { version = "0.35", features = ["bundled"] }
+rusqlite = { version = "0.35", features = ["bundled", "chrono"] }
 rustls = "0.23"
 rustls-pemfile = "2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
Use a separate SQLite DB for storing host state (& later on repo state as well). This allows us to easily debug the state for different hosts & also allows us to manually change the cursor or remove an entry completely to allow it to continue from present.
TODO (later on): switch to a query builder or sqlx/diesel for this.

## Related Issues
<!-- Link any relevant issues -->

## Changes
- [x] Feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [ ] I have tested the changes (including writing unit tests).
- [ ] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [ ] I have updated relevant documentation.
- [ ] I have formatted my code correctly
- [ ] I have provided examples for how this code works or will be used