### PR TITLE
rsky-relay: fix false negatives for commit verification

### DIFF
--- a/rsky-relay/src/main.rs
+++ b/rsky-relay/src/main.rs
@@ -35,7 +35,7 @@ pub struct Args {
     #[clap(short, long, requires = "certs")]
     private_key: Option<PathBuf>,
     #[clap(long)]
-    no_plc_export: (),
+    no_plc_export: bool,
 }
 
 #[tokio::main]


### PR DESCRIPTION
## Summary
Some cases, which are allowed to pass-through in the indigo relay are currently getting blocked by our relay. Update the verification behavior to bring it inline with indigo relay.

## Related Issues
<!-- Link any relevant issues -->

## Changes
- [ ] Feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [ ] I have tested the changes (including writing unit tests).
- [ ] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [ ] I have updated relevant documentation.
- [ ] I have formatted my code correctly
- [ ] I have provided examples for how this code works or will be used