### PR TITLE
rsky-relay: switch to file-rotate for compressed logs

### DIFF
--- a/rsky-relay/Cargo.toml
+++ b/rsky-relay/Cargo.toml
@@ -11,6 +11,7 @@ ciborium = "0.2"
 cid = { version = "0.10", features = ["serde-codec"] }
 clap = { version = "4", features = ["derive", "env"] }
 color-eyre = "0.6"
+file-rotate = "0.8"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 hashbrown = "0.15"
 httparse = "1.10"


### PR DESCRIPTION
## Summary
Use file-rotate so that the logs are compressed after rotation to save disk space.

## Changes
- [x] Feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [x] I have tested the changes (including writing unit tests).
- [x] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [ ] I have updated relevant documentation.
- [x] I have formatted my code correctly
- [ ] I have provided examples for how this code works or will be used