### PR TITLE
new image workflow to upload to ghcr

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,0 +1,68 @@
+name: Build and Publish Docker Images to GHCR
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'rsky-pds/**'
+      - 'rsky-jetstream-subscriber/**'
+      - 'rsky-firehose/**'
+      - '.github/workflows/ghcr.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  ORGANIZATION: blacksky-algorithms
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - name: rsky-pds
+            dockerfile: rsky-pds/Dockerfile
+          - name: rsky-jetstream-subscriber
+            dockerfile: rsky-jetstream-subscriber/Dockerfile
+          - name: rsky-firehose
+            dockerfile: rsky-firehose/Dockerfile
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/${{ matrix.service.name }}
+          tags: |
+            type=sha,format=long
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ${{ matrix.service.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/rsky-pds/Dockerfile
+++ b/rsky-pds/Dockerfile
@@ -1,13 +1,40 @@
 # Use the official Rust image.
 # https://hub.docker.com/_/rust
-FROM rust
+FROM --platform=linux/amd64 rust AS builder
 
 # Copy local code to the container image.
 WORKDIR /usr/src/rsky
-COPY . .
+COPY Cargo.toml Cargo.lock rust-toolchain ./
+COPY rsky-lexicon rsky-lexicon
+COPY rsky-identity rsky-identity
+COPY rsky-syntax rsky-syntax
+COPY rsky-pds/Cargo.toml rsky-pds/Cargo.toml
+COPY rsky-crypto rsky-crypto
+COPY rsky-feedgen rsky-feedgen
+COPY rsky-firehose rsky-firehose
+COPY rsky-common rsky-common
+COPY rsky-labeler rsky-labeler
+COPY rsky-repo rsky-repo
+COPY rsky-jetstream-subscriber rsky-jetstream-subscriber
+
+# Create an empty src directory to trick Cargo into thinking it's a valid Rust project
+RUN mkdir rsky-pds/src && echo "fn main() {}" > rsky-pds/src/main.rs
 
 # Install production dependencies and build a release artifact.
-RUN cargo build --package rsky-pds
+RUN cargo build --release --package rsky-pds
 
-# Run the web service on container startup.
-CMD ["sh", "-c", "ROCKET_PORT=$PORT ROCKET_ADDRESS=0.0.0.0 cargo run --package rsky-pds"]
+# Now copy the real source code and build the final binary
+COPY rsky-pds/src rsky-pds/src
+COPY rsky-pds/migrations rsky-pds/migrations
+COPY rsky-pds/diesel.toml rsky-pds/diesel.toml
+
+RUN cargo build --release --package rsky-pds
+
+FROM --platform=linux/amd64 rust
+
+WORKDIR /usr/src/rsky
+
+COPY --from=builder /usr/src/rsky/target/release/rsky-pds rsky-pds
+
+# Run the web service on container startup with the same environment variables
+CMD ["sh", "-c", "ROCKET_PORT=$PORT ROCKET_ADDRESS=0.0.0.0 ./rsky-pds"]


### PR DESCRIPTION
## Summary

  1. Modified rsky-pds/Dockerfile to use multi-stage builds like the jetstream subscriber, while preserving the
  environment variables in the CMD
  2. Created .github/workflows/ghcr.yml that will publish the Docker images to ghcr.io for the blacksky-algorithms
  organization

  The workflow will trigger when changes are pushed to main branch that affect any of the three services, or
  manually via workflow_dispatch. It builds and pushes each Docker image with appropriate tags based on the git
  reference.

## Related Issues

I'm trying to build an rsky-pds instance in k8s.

## Changes
- [x] Feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [ ] I have tested the changes (including writing unit tests).
- [ ] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [ ] I have updated relevant documentation.
- [ ] I have formatted my code correctly
- [ ] I have provided examples for how this code works or will be used