### PR TITLE
Fix image deploy

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -46,7 +46,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (tags, labels) for ${{ matrix.service.name }} Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
@@ -56,7 +56,7 @@ jobs:
             type=ref,event=branch
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push Docker image
+      - name: Build and push ${{ matrix.service.name }} Docker image 
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ cargo = { version = "0.84.0",features = ["vendored-openssl"] }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_derive = "^1.0"
 serde_ipld_dagcbor = {  version = "0.6.1" ,features = ["codec"]}
-lexicon_cid = { package = "cid", version = "0.11.1", features = ["serde-codec"] }
+lexicon_cid = { package = "cid", version = "0.10.1", features = ["serde-codec"] }
 libipld = "0.16.0"
 serde_cbor = "0.11.2"
 serde_bytes = "0.11.15"

--- a/rsky-common/Cargo.toml
+++ b/rsky-common/Cargo.toml
@@ -28,7 +28,7 @@ base64ct = "1.6.0"
 urlencoding = "2.1.3"
 futures = "0.3.28"
 libipld = {workspace = true}
-multihash = "0.19"
+multihash = "=0.18.1"  # Pin to exactly version 0.18.1
 multihash-codetable = { version = "0.1.3",features = ["sha2"]}
 indexmap = { version = "1.9.3",features = ["serde-1"] }
 secp256k1 = {workspace = true}

--- a/rsky-pds/Dockerfile
+++ b/rsky-pds/Dockerfile
@@ -1,21 +1,26 @@
 # Use the official Rust image.
 # https://hub.docker.com/_/rust
-FROM --platform=linux/amd64 rust AS builder
+# FROM --platform=linux/amd64 rust AS builder
+FROM rust as builder
 
 # Copy local code to the container image.
 WORKDIR /usr/src/rsky
 COPY Cargo.toml ./
-COPY rsky-lexicon rsky-lexicon
-COPY rsky-identity rsky-identity
-COPY rsky-syntax rsky-syntax
-COPY rsky-pds/Cargo.toml rsky-pds/Cargo.toml
+COPY cypher cypher
+COPY rsky-common rsky-common
 COPY rsky-crypto rsky-crypto
 COPY rsky-feedgen rsky-feedgen
 COPY rsky-firehose rsky-firehose
-COPY rsky-common rsky-common
-COPY rsky-labeler rsky-labeler
-COPY rsky-repo rsky-repo
+COPY rsky-identity rsky-identity
 COPY rsky-jetstream-subscriber rsky-jetstream-subscriber
+COPY rsky-labeler rsky-labeler
+COPY rsky-lexicon rsky-lexicon
+COPY rsky-relay rsky-relay
+COPY rsky-repo rsky-repo
+COPY rsky-satnav rsky-satnav
+COPY rsky-syntax rsky-syntax
+
+COPY rsky-pds/Cargo.toml rsky-pds/Cargo.toml
 
 # Create an empty src directory to trick Cargo into thinking it's a valid Rust project
 RUN mkdir rsky-pds/src && echo "fn main() {}" > rsky-pds/src/main.rs
@@ -30,7 +35,8 @@ COPY rsky-pds/diesel.toml rsky-pds/diesel.toml
 
 RUN cargo build --release --package rsky-pds
 
-FROM --platform=linux/amd64 rust
+# FROM --platform=linux/amd64 rust
+FROM rust
 
 WORKDIR /usr/src/rsky
 

--- a/rsky-pds/Dockerfile
+++ b/rsky-pds/Dockerfile
@@ -36,7 +36,8 @@ COPY rsky-pds/diesel.toml rsky-pds/diesel.toml
 RUN cargo build --release --package rsky-pds
 
 # FROM --platform=linux/amd64 rust
-FROM rust
+FROM debian:bullseye-slim
+RUN apt-get update && apt-get install -y extra-runtime-dependencies && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/rsky
 


### PR DESCRIPTION
## Summary
1. update rsky-pds dockerfile to optimize layering trick the @TheRipperoni suggested
2. update rsky-pds dockerfile to use a debian running image inspired by the [rust dockerhub](https://hub.docker.com/_/rust) documentation
3. fix the cid package dependency mismatch in firehose:
```shell
❯  cargo check -p rsky-firehose
    Checking rsky-firehose v0.2.0 (/Users/clint/src/bsky-code/rsky/rsky-firehose)
error[E0308]: mismatched types
   --> rsky-firehose/src/main.rs:146:88
    |
146 | ...                   let record_reader = Cursor::new(car_blocks.get(&cid).unwrap());
    |                                                                  --- ^^^^ expected `&CidGeneric<64>`, found `&Cid<64>`
    |                                                                  |
    |                                                                  arguments to this method are incorrect
    |
note: two different versions of crate `cid` are being used; two types coming from two different versions of the same crate are different types even if they look the same
   --> /Users/clint/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cid-0.11.1/src/cid.rs:70:1
    |
70  | pub struct Cid<const S: usize> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this is the found type `cid::cid::Cid`
    |
   ::: /Users/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cid-0.10.1/src/cid.rs:67:1
    |
67  | pub struct Cid<const S: usize> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this is the expected type `CidGeneric`
    |
   ::: rsky-firehose/src/main.rs:5:5
    |
5   | use libipld::Cid;
    |     ------- one version of crate `cid` used here, as a dependency of crate `libipld_core`
6   | use rsky_lexicon::app::bsky::feed::like::Like;
    |     ------------ one version of crate `cid` used here, as a dependency of crate `rsky_lexicon`
    = help: you can use `cargo tree` to explore your dependency tree
note: method defined here
   --> /Users/user/.rustup/toolchains/nightly-2025-01-03-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/collections/hash/map.rs:897:12
    |
897 |     pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
    |            ^^^

For more information about this error, try `rustc --explain E0308`.
error: could not compile `rsky-firehose` (bin "rsky-firehose") due to 1 previous error
```

## Changes
- [x] Feature implementation
- [x] Bug fix
