### PR TITLE
Increase request headers limit (browser HTTP 502s)

### DIFF
--- a/rsky-relay/src/server/server.rs
+++ b/rsky-relay/src/server/server.rs
@@ -171,7 +171,7 @@ impl Server {
         // only peek to allow tungstenite to complete the handshake
         #[expect(clippy::unwrap_used)]
         let len = stream.0.as_mut().unwrap().peek(&mut self.buf)?;
-        let mut headers = [EMPTY_HEADER; 16];
+        let mut headers = [EMPTY_HEADER; 32];
         let mut parser = httparse::Request::new(&mut headers);
         // try parsing as an HTTP request
         let res = parser.parse(&self.buf)?;


### PR DESCRIPTION
## Summary

I always get a HTTP 502 response at https://atproto.africa in Firefox, and while I can load the http page in Safari, attempting a websocket connection leads it to also recieving a 502.

In narrowing down the cause with cURL, I found that it was not any specific browser header that was problematic, but the total number of them. My install of Firefox sends more headers than Safari, explaining why it fails while Safari works, and websocket connections add two additional headers, explaining why Safari works for the HTTP request but not the websocket upgrade.

Note that the live server appears to run behind caddy, which adds at least three extra request headers by default (X-Forwarded-*).

This change upgrades the allocated request headers for parsing from 16 -> 32, which is hopefully enough to avoid problems from web browser requests.

## Related Issues
<!-- Link any relevant issues -->

## Changes
- [ ] Feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [ ] I have tested the changes (including writing unit tests).
- [ ] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [ ] I have updated relevant documentation.
- [ ] I have formatted my code correctly
- [x] I have provided examples for how this code works or will be used

<details>
<summary>cURL repro</summary>

POC successfull cURL at the limit:

```bash
curl -i 'https://atproto.africa/' \
  -H 'User-Agent: phil testing 502 from too many headers' \
  -H 'X-extra-header-1: 1' \
  -H 'X-extra-header-2: 2' \
  -H 'X-extra-header-3: 3' \
  -H 'X-extra-header-4: 4' \
  -H 'X-extra-header-5: 5' \
  -H 'X-extra-header-6: 6' \
  -H 'X-extra-header-7: 7' \
  -H 'X-extra-header-8: 8'
```

failing cURL with too many headers:

```bash
curl -vi 'https://atproto.africa/' \
  -H 'User-Agent: phil testing 502 from too many headers' \
  -H 'X-extra-header-1: 1' \
  -H 'X-extra-header-2: 2' \
  -H 'X-extra-header-3: 3' \
  -H 'X-extra-header-4: 4' \
  -H 'X-extra-header-5: 5' \
  -H 'X-extra-header-6: 6' \
  -H 'X-extra-header-7: 7' \
  -H 'X-extra-header-8: 8' \
  -H 'X-extra-header-9: 9'
```

Note: the number of headers here is less than 16: cURL is adding `Host` and `Accept` automatically, plus the three from caddy make 15. I'm not sure if the effective limit for httpparse is N-1, or if two more headers are getting added somewhere else.

</details>


