### PR TITLE
rsky-relay: connect to everything

### DIFF
--- a/rsky-relay/Cargo.toml
+++ b/rsky-relay/Cargo.toml
@@ -15,9 +15,11 @@ exponential-backoff = "2"
 file-rotate = "0.8"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 hashbrown = "0.15"
-httparse = "1.10"
+http = "1"
+httparse = "1"
 ipld-core = "0.4"
 k256 = "0.13"
+libc = "0.2"
 lru = "0.14"
 magnetic = "2"
 mimalloc = "0.1"
@@ -37,6 +39,7 @@ serde_json = { version = "1", features = ["raw_value"] }
 sha2 = "0.10"
 signal-hook = { version = "0.3", features = ["extended-siginfo"] }
 sled = { git = "https://github.com/spacejam/sled.git", rev = "005c023" }
+socket2 = "0.5"
 thingbuf = "0.1"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }

--- a/rsky-relay/Cargo.toml
+++ b/rsky-relay/Cargo.toml
@@ -11,6 +11,7 @@ ciborium = "0.2"
 cid = { version = "0.10", features = ["serde-codec"] }
 clap = { version = "4", features = ["derive", "env"] }
 color-eyre = "0.6"
+exponential-backoff = "2"
 file-rotate = "0.8"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 hashbrown = "0.15"

--- a/rsky-relay/src/crawler/client.rs
+++ b/rsky-relay/src/crawler/client.rs
@@ -1,0 +1,109 @@
+use std::io;
+use std::net::{TcpStream, ToSocketAddrs};
+
+use http::Uri;
+use http::request::Parts;
+use socket2::{Domain, Protocol, Socket, Type};
+use tungstenite::client::{IntoClientRequest, uri_mode};
+use tungstenite::client_tls_with_config;
+use tungstenite::error::{Error, Result, UrlError};
+use tungstenite::handshake::client::Request;
+use tungstenite::protocol::WebSocketConfig;
+use tungstenite::stream::{Mode, NoDelay};
+
+use crate::crawler::types::{DecomposeError, HandshakeResult};
+
+/// Connect to the given WebSocket in blocking mode.
+///
+/// The URL may be either ws:// or wss://.
+/// To support wss:// URLs, feature `native-tls` or `rustls-tls` must be turned on.
+///
+/// This function "just works" for those who wants a simple blocking solution
+/// similar to `std::net::TcpStream`. If you want a non-blocking or other
+/// custom stream, call `client` instead.
+///
+/// This function uses `native_tls` or `rustls` to do TLS depending on the feature flags enabled. If
+/// you want to use other TLS libraries, use `client` instead. There is no need to enable any of
+/// the `*-tls` features if you don't call `connect` since it's the only function that uses them.
+pub fn connect<Req: IntoClientRequest>(request: Req) -> HandshakeResult {
+    connect_with_config(request, None, 3)
+}
+
+// Ref: https://github.com/snapview/tungstenite-rs/blob/master/src/client.rs
+#[expect(
+    clippy::expect_used,
+    clippy::ignored_unit_patterns,
+    clippy::redundant_clone,
+    clippy::redundant_else
+)]
+pub fn connect_with_config<Req: IntoClientRequest>(
+    request: Req, config: Option<WebSocketConfig>, max_redirects: u8,
+) -> HandshakeResult {
+    fn try_client_handshake(request: Request, config: Option<WebSocketConfig>) -> HandshakeResult {
+        let uri = request.uri();
+        let mode = uri_mode(uri)?;
+
+        let host = request.uri().host().ok_or(Error::Url(UrlError::NoHostName))?;
+        let host = if host.starts_with('[') { &host[1..host.len() - 1] } else { host };
+        let port = uri.port_u16().unwrap_or(match mode {
+            Mode::Plain => 80,
+            Mode::Tls => 443,
+        });
+        let mut stream = connect_to_some((host, port), request.uri())?;
+        NoDelay::set_nodelay(&mut stream, true)?;
+
+        client_tls_with_config(request, stream, config, None).decompose()
+    }
+
+    fn create_request(parts: &Parts, uri: &Uri) -> Request {
+        let mut builder =
+            Request::builder().uri(uri.clone()).method(parts.method.clone()).version(parts.version);
+        *builder.headers_mut().expect("Failed to create `Request`") = parts.headers.clone();
+        builder.body(()).expect("Failed to create `Request`")
+    }
+
+    let (parts, _) = request.into_client_request()?.into_parts();
+    let mut uri = parts.uri.clone();
+
+    for attempt in 0..=max_redirects {
+        let request = create_request(&parts, &uri);
+
+        match try_client_handshake(request, config) {
+            Err(Error::Http(res)) if res.status().is_redirection() && attempt < max_redirects => {
+                if let Some(location) = res.headers().get("Location") {
+                    uri = location.to_str()?.parse::<Uri>()?;
+                    // debug!("Redirecting to {uri:?}");
+                    continue;
+                } else {
+                    // warn!("No `Location` found in redirect");
+                    return Err(Error::Http(res));
+                }
+            }
+            other => return other,
+        }
+    }
+
+    unreachable!("Bug in a redirect handling logic")
+}
+
+fn connect_to_some(addrs: impl ToSocketAddrs, uri: &Uri) -> Result<TcpStream> {
+    fn is_blocking_error(error: &io::Error) -> bool {
+        matches!(
+            error.kind(),
+            io::ErrorKind::Interrupted | io::ErrorKind::NotConnected | io::ErrorKind::WouldBlock
+        ) || matches!(error.raw_os_error(), Some(libc::EINPROGRESS))
+    }
+
+    for addr in addrs.to_socket_addrs()? {
+        // debug!("Trying to contact {uri} at {addr}...");
+        let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))?;
+        socket.set_nonblocking(true)?;
+        match socket.connect(&addr.into()) {
+            Ok(()) => {}
+            Err(e) if is_blocking_error(&e) => {}
+            Err(_) => continue,
+        }
+        return Ok(socket.into());
+    }
+    Err(Error::Url(UrlError::UnableToConnect(uri.to_string())))
+}

--- a/rsky-relay/src/crawler/manager.rs
+++ b/rsky-relay/src/crawler/manager.rs
@@ -16,7 +16,7 @@ use crate::crawler::types::{Command, CommandSender, RequestCrawlReceiver, Status
 use crate::crawler::worker::{Worker, WorkerError};
 use crate::types::{Cursor, MessageSender};
 
-const CAPACITY: usize = 1024;
+const CAPACITY: usize = 1 << 12;
 const SLEEP: Duration = Duration::from_millis(10);
 
 #[derive(Debug, Error)]

--- a/rsky-relay/src/crawler/manager.rs
+++ b/rsky-relay/src/crawler/manager.rs
@@ -94,14 +94,11 @@ impl Manager {
             thread::sleep(SLEEP);
         }
         tracing::info!("shutting down crawler");
-        SHUTDOWN.store(true, Ordering::Relaxed);
         self.shutdown()
     }
 
-    pub fn shutdown(mut self) -> Result<(), ManagerError> {
-        for worker in &mut self.workers {
-            worker.command_tx.push(Command::Shutdown)?;
-        }
+    pub fn shutdown(self) -> Result<(), ManagerError> {
+        SHUTDOWN.store(true, Ordering::Relaxed);
         for (id, worker) in self.workers.into_iter().enumerate() {
             if let Err(err) = worker.thread_handle.join().map_err(|_| ManagerError::Join)? {
                 tracing::warn!(%id, %err, "crawler worker error");

--- a/rsky-relay/src/crawler/mod.rs
+++ b/rsky-relay/src/crawler/mod.rs
@@ -1,3 +1,4 @@
+mod client;
 mod connection;
 mod manager;
 mod types;

--- a/rsky-relay/src/crawler/types.rs
+++ b/rsky-relay/src/crawler/types.rs
@@ -22,7 +22,6 @@ pub struct RequestCrawl {
 #[derive(Debug)]
 pub enum Command {
     Connect(RequestCrawl),
-    Shutdown,
 }
 
 #[derive(Debug)]

--- a/rsky-relay/src/crawler/types.rs
+++ b/rsky-relay/src/crawler/types.rs
@@ -1,9 +1,37 @@
+use std::net::TcpStream;
+
 use magnetic::buffer::dynamic::DynamicBufferP2;
 use magnetic::mpsc::{MPSCConsumer, MPSCProducer};
 use rtrb::{Consumer, Producer};
 use serde::Deserialize;
+use tungstenite::handshake::MidHandshake;
+use tungstenite::handshake::client::Response;
+use tungstenite::stream::MaybeTlsStream;
+use tungstenite::{ClientHandshake, HandshakeError, WebSocket};
 
 use crate::types::Cursor;
+
+pub type MaybeTlsTcpStream = MaybeTlsStream<TcpStream>;
+pub type WebSocketClient = WebSocket<MaybeTlsTcpStream>;
+pub type Handshaking = MidHandshake<ClientHandshake<MaybeTlsTcpStream>>;
+pub type MaybeHandshake = Result<WebSocketClient, Handshaking>;
+pub type HandshakeResult = Result<MaybeHandshake, tungstenite::Error>;
+
+pub trait DecomposeError {
+    fn decompose(self) -> HandshakeResult;
+}
+
+impl DecomposeError
+    for Result<(WebSocketClient, Response), HandshakeError<ClientHandshake<MaybeTlsTcpStream>>>
+{
+    fn decompose(self) -> HandshakeResult {
+        match self {
+            Ok((client, _)) => Ok(Ok(client)),
+            Err(HandshakeError::Interrupted(handshaking)) => Ok(Err(handshaking)),
+            Err(HandshakeError::Failure(err)) => Err(err),
+        }
+    }
+}
 
 pub type CommandSender = Producer<Command>;
 pub type CommandReceiver = Consumer<Command>;

--- a/rsky-relay/src/crawler/types.rs
+++ b/rsky-relay/src/crawler/types.rs
@@ -27,5 +27,5 @@ pub enum Command {
 
 #[derive(Debug)]
 pub enum Status {
-    Disconnected(usize, String),
+    Disconnected { worker_id: usize, hostname: String, connected: bool },
 }

--- a/rsky-relay/src/crawler/worker.rs
+++ b/rsky-relay/src/crawler/worker.rs
@@ -1,5 +1,6 @@
+use std::collections::VecDeque;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::{io, thread};
 
 use magnetic::Producer;
@@ -8,8 +9,12 @@ use thiserror::Error;
 
 use crate::SHUTDOWN;
 use crate::crawler::connection::{Connection, ConnectionError};
-use crate::crawler::types::{Command, CommandReceiver, Status, StatusSender};
+use crate::crawler::types::{
+    Command, CommandReceiver, DecomposeError, HandshakeResult, Handshaking, Status, StatusSender,
+};
 use crate::types::MessageSender;
+
+const TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Error)]
 pub enum WorkerError {
@@ -21,6 +26,7 @@ pub enum WorkerError {
 
 pub struct Worker {
     id: usize,
+    pending: VecDeque<(Instant, String, Handshaking)>,
     connections: Vec<Option<Connection>>,
     next_idx: usize,
     message_tx: MessageSender,
@@ -38,6 +44,7 @@ impl Worker {
         let events = Events::new();
         Ok(Self {
             id,
+            pending: VecDeque::new(),
             connections: Vec::new(),
             next_idx: 0,
             message_tx,
@@ -70,41 +77,46 @@ impl Worker {
         match command {
             Command::Connect(config) => {
                 tracing::info!(host = %config.hostname, cursor = ?config.cursor, "starting crawl");
-                match Connection::connect(
-                    config.hostname.clone(),
-                    config.cursor,
-                    self.message_tx.clone(),
-                ) {
-                    Ok(conn) => {
-                        let idx = self.connections.iter().position(Option::is_none).unwrap_or_else(
-                            || {
-                                let idx = self.connections.len();
-                                self.connections.push(None);
-                                idx
-                            },
-                        );
-                        #[expect(clippy::expect_used)]
-                        unsafe {
-                            self.poller
-                                .add_with_mode(&conn, Event::readable(idx), PollMode::Level)
-                                .expect("unable to register");
-                        }
-                        self.connections[idx] = Some(conn);
-                    }
-                    Err(err) => {
-                        tracing::warn!(host = %config.hostname, cursor = ?config.cursor, %err, "unable to requestCrawl");
-                        #[expect(clippy::expect_used)]
-                        self.status_tx
-                            .push(Status::Disconnected {
-                                worker_id: self.id,
-                                hostname: config.hostname,
-                                connected: false,
-                            })
-                            .expect("unable to send status");
-                    }
-                }
+                let res = Connection::connect(&config.hostname, config.cursor);
+                self.handle_connect(Instant::now(), config.hostname, res);
             }
         }
+    }
+
+    fn handle_connect(&mut self, start: Instant, hostname: String, result: HandshakeResult) {
+        match result {
+            Ok(Ok(client)) => {
+                let idx = self.connections.iter().position(Option::is_none).unwrap_or_else(|| {
+                    let idx = self.connections.len();
+                    self.connections.push(None);
+                    idx
+                });
+                let conn = Connection::new(hostname, client, self.message_tx.clone());
+                #[expect(clippy::expect_used)]
+                unsafe {
+                    self.poller
+                        .add_with_mode(&conn, Event::readable(idx), PollMode::Level)
+                        .expect("unable to register");
+                }
+                self.connections[idx] = Some(conn);
+                return;
+            }
+            Ok(Err(handshaking)) if start.elapsed() < TIMEOUT => {
+                self.pending.push_back((Instant::now(), hostname, handshaking));
+                return;
+            }
+            Ok(Err(_)) => {
+                tracing::warn!(host = %hostname, "requestCrawl timeout");
+            }
+            Err(err) => {
+                tracing::warn!(host = %hostname, %err, "unable to requestCrawl");
+            }
+        }
+
+        #[expect(clippy::expect_used)]
+        self.status_tx
+            .push(Status::Disconnected { worker_id: self.id, hostname, connected: false })
+            .expect("unable to send status");
     }
 
     fn update(&mut self) -> bool {
@@ -113,8 +125,15 @@ impl Worker {
         }
 
         for _ in 0..32 {
-            if let Ok(command) = self.command_rx.pop() {
-                self.handle_command(command);
+            if let Some((start, hostname, handshaking)) = self.pending.pop_front() {
+                let res = handshaking.handshake().decompose();
+                self.handle_connect(start, hostname, res);
+            }
+
+            if self.pending.len() < 16 {
+                if let Ok(command) = self.command_rx.pop() {
+                    self.handle_command(command);
+                }
             }
 
             if self.message_tx.remaining() < 16 {

--- a/rsky-relay/src/main.rs
+++ b/rsky-relay/src/main.rs
@@ -24,8 +24,8 @@ use rsky_relay::{
     ValidatorManager,
 };
 
-const CAPACITY1: usize = 1 << 16;
-const CAPACITY2: usize = 1 << 10;
+const CAPACITY1: usize = 1 << 18;
+const CAPACITY2: usize = 1 << 16;
 const WORKERS: usize = 4;
 
 #[global_allocator]

--- a/rsky-relay/src/publisher/manager.rs
+++ b/rsky-relay/src/publisher/manager.rs
@@ -62,14 +62,11 @@ impl Manager {
             thread::sleep(SLEEP);
         }
         tracing::info!("shutting down publisher");
-        SHUTDOWN.store(true, Ordering::Relaxed);
         self.shutdown()
     }
 
-    pub fn shutdown(mut self) -> Result<(), ManagerError> {
-        for worker in &mut self.workers {
-            worker.command_tx.push(Command::Shutdown)?;
-        }
+    pub fn shutdown(self) -> Result<(), ManagerError> {
+        SHUTDOWN.store(true, Ordering::Relaxed);
         for (id, worker) in self.workers.into_iter().enumerate() {
             if let Err(err) = worker.thread_handle.join().map_err(|_| ManagerError::Join)? {
                 tracing::warn!(%id, %err, "publisher worker error");

--- a/rsky-relay/src/publisher/types.rs
+++ b/rsky-relay/src/publisher/types.rs
@@ -18,11 +18,9 @@ pub struct SubscribeRepos {
     pub cursor: Option<Cursor>,
 }
 
-#[expect(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum Command {
     Connect(SubscribeRepos),
-    Shutdown,
 }
 
 mod maybe_tls_stream {

--- a/rsky-relay/src/server/server.rs
+++ b/rsky-relay/src/server/server.rs
@@ -249,11 +249,10 @@ impl Server {
             }
             let url =
                 Url::parse_with_params(&format!("https://{BSKY_RELAY}/{LIST_HOSTS}"), params)?;
-            let hosts: ListHosts = client.get(url).send()?.json()?;
-            for host in hosts.hosts {
-                if host.account_count > 100
-                    && matches!(host.status, HostStatus::Active | HostStatus::Idle)
-                {
+            let mut hosts: ListHosts = client.get(url).send()?.json()?;
+            hosts.hosts.sort_unstable_by_key(|host| host.account_count);
+            for host in hosts.hosts.into_iter().rev() {
+                if matches!(host.status, HostStatus::Active | HostStatus::Idle) {
                     self.request_crawl_tx
                         .push(RequestCrawl { hostname: host.hostname, cursor: None })?;
                 }


### PR DESCRIPTION
## Summary
Added various changes to enable connecting to all PDSes:
- persisted host state on a timer
- retry on host sqlite locked error
- add connect/reconnect backoff
  - TODO: add logic to clear retry once we've a stable connection
  - TODO: persist retry state to DB
- use non-blocking connect for crawler
  - Without this, the crawler worker can get blocked while we're trying to connect & do a handshake
  - With this, we can have try connecting to new hosts without blocking everything
- increased queue sizes to accommodate more hosts

## Changes
- [x] Feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [x] I have tested the changes (including writing unit tests).
- [x] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [ ] I have updated relevant documentation.
- [x] I have formatted my code correctly
- [ ] I have provided examples for how this code works or will be used