### PR TITLE
rsky-relay: add labeler relay

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,21 @@
 [workspace]
-members = [ "rsky-common", "rsky-crypto","rsky-feedgen", "rsky-firehose", "rsky-identity", "rsky-labeler", "rsky-lexicon", "rsky-pds", "rsky-syntax", "rsky-jetstream-subscriber", "rsky-repo", "cypher/backend", "cypher/frontend", "rsky-satnav", "rsky-relay"]
+members = [
+  "cypher/backend",
+  "cypher/frontend",
+  "rsky-common",
+  "rsky-crypto",
+  "rsky-feedgen",
+  "rsky-firehose",
+  "rsky-identity",
+  "rsky-jetstream-subscriber",
+  "rsky-labeler",
+  "rsky-lexicon",
+  "rsky-pds",
+  "rsky-relay",
+  "rsky-repo",
+  "rsky-satnav",
+  "rsky-syntax",
+]
 resolver = "2"
 
 [workspace.dependencies]

--- a/rsky-relay/Cargo.toml
+++ b/rsky-relay/Cargo.toml
@@ -1,16 +1,18 @@
 [package]
 name = "rsky-relay"
 version = "0.1.0"
+default-run = "rsky-relay"
 edition = "2024"
 
 [dependencies]
 # external
 bytes = "1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 ciborium = "0.2"
 cid = { version = "0.10", features = ["serde-codec"] }
 clap = { version = "4", features = ["derive", "env"] }
 color-eyre = "0.6"
+derive_more = { version = "2", features = ["full"] }
 exponential-backoff = "2"
 file-rotate = "0.8"
 fjall = "2"
@@ -49,10 +51,25 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots", "url"] }
 url = "2"
 urlencoding = "2"
+vec1 = { version = "1", features = ["serde"] }
 
 # internal
 rsky-common = { workspace = true }
 rsky-identity = { workspace = true }
+
+[features]
+# external
+default = []
+labeler = [] # run a labeler relay
+
+[[bin]]
+name = "rsky-relay"
+path = "src/main.rs"
+
+[[bin]]
+name = "rsky-relay-labeler"
+path = "src/main.rs"
+required-features = ["labeler"]
 
 [package.metadata.cargo-machete]
 ignored = ["serde_bytes"]

--- a/rsky-relay/src/config.rs
+++ b/rsky-relay/src/config.rs
@@ -4,20 +4,21 @@ use std::time::Duration;
 
 // main
 pub const CAPACITY_MSGS: usize = 1 << 16;
-pub const CAPACITY_REQS: usize = 1 << 10;
+pub const CAPACITY_REQS: usize = 1 << 12;
 pub const CAPACITY_STATUS: usize = 1 << 10;
 pub const WORKERS_CRAWLERS: usize = 4;
 pub const WORKERS_PUBLISHERS: usize = 4;
 
 // server
-pub const PORT: u16 = 9000;
+pub const PORT: u16 = if cfg!(feature = "labeler") { 9001 } else { 9000 };
 pub const HOSTS_RELAY: &str = "relay1.us-west.bsky.network";
 pub const HOSTS_INTERVAL: Duration = Duration::from_secs(60 * 60);
 pub const HOSTS_MIN_ACCOUNTS: u64 = 0;
 
 // resolver
-pub static DO_PLC_EXPORT: LazyLock<bool> =
-    LazyLock::new(|| env::args().filter(|arg| arg == "--no-plc-export").count() == 0);
+pub static DO_PLC_EXPORT: LazyLock<bool> = LazyLock::new(|| {
+    !cfg!(feature = "labeler") && env::args().filter(|arg| arg == "--no-plc-export").count() == 0
+});
 pub const PLC_EXPORT_INTERVAL: Duration = Duration::from_secs(60);
 pub const CAPACITY_CACHE: usize = 1 << 18;
 
@@ -26,7 +27,11 @@ pub const HOSTS_WRITE_INTERVAL: Duration = Duration::from_secs(10);
 
 // firehose
 pub const DISK_SIZE: u64 = 320 * 1024 * 1024 * 1024; // 320 GiB
-pub const TTL_SECONDS: Option<u64> = Some(24 * 60 * 60); // 24 hours
+pub const TTL_SECONDS: Option<u64> = if cfg!(feature = "labeler") {
+    None
+} else {
+    Some(24 * 60 * 60) // 24 hours
+};
 
 // fjall db
 pub const CACHE_SIZE: u64 = 1024 * 1024 * 1024; // 1 GiB

--- a/rsky-relay/src/crawler/connection.rs
+++ b/rsky-relay/src/crawler/connection.rs
@@ -43,10 +43,17 @@ impl Connection {
         Self { hostname, client, message_tx }
     }
 
-    pub fn connect(hostname: &str, cursor: Option<Cursor>) -> HandshakeResult {
+    pub fn connect(hostname: &str, mut cursor: Option<Cursor>) -> HandshakeResult {
+        let path = if cfg!(feature = "labeler") {
+            if cursor.is_none() {
+                cursor = Some(0.into());
+            }
+            "com.atproto.label.subscribeLabels"
+        } else {
+            "com.atproto.sync.subscribeRepos"
+        };
         #[expect(clippy::unwrap_used)]
-        let mut url =
-            Url::parse(&format!("wss://{hostname}/xrpc/com.atproto.sync.subscribeRepos")).unwrap();
+        let mut url = Url::parse(&format!("wss://{hostname}/xrpc/{path}")).unwrap();
         if let Some(cursor) = cursor {
             url.query_pairs_mut().append_pair("cursor", &cursor.to_string());
         }

--- a/rsky-relay/src/types.rs
+++ b/rsky-relay/src/types.rs
@@ -24,6 +24,7 @@ pub static DB: LazyLock<Keyspace> = LazyLock::new(|| {
         .unwrap();
     db.open_partition("firehose", firehose_options()).unwrap();
     db.open_partition("queue", PartitionCreateOptions::default()).unwrap();
+    #[cfg(not(feature = "labeler"))]
     db.open_partition("repos", PartitionCreateOptions::default()).unwrap();
     db
 });

--- a/rsky-relay/src/validator/mod.rs
+++ b/rsky-relay/src/validator/mod.rs
@@ -1,6 +1,7 @@
 mod event;
 mod manager;
 mod resolver;
+#[cfg(not(feature = "labeler"))]
 mod types;
 mod utils;
 

--- a/rsky-relay/src/validator/types.rs
+++ b/rsky-relay/src/validator/types.rs
@@ -95,7 +95,7 @@ impl SubscribeReposEvent {
         let mut blocks = match self {
             Self::Commit(commit) => commit.blocks.as_slice(),
             Self::Sync(sync) => sync.blocks.as_slice(),
-            Self::Identity(_) | Self::Account(_) => {
+            Self::Identity(_) | Self::Account(_) | Self::Labels(_) => {
                 return Ok(None);
             }
         };

--- a/rsky-relay/src/validator/utils.rs
+++ b/rsky-relay/src/validator/utils.rs
@@ -1,10 +1,15 @@
 use std::collections::TryReserveError;
 
+#[cfg(not(feature = "labeler"))]
 use cid::Cid;
 use p256::ecdsa::signature::Verifier;
 use thiserror::Error;
 
+#[cfg(feature = "labeler")]
+use crate::validator::event::SubscribeLabel;
+#[cfg(not(feature = "labeler"))]
 use crate::validator::event::{Commit, SubscribeReposCommit};
+#[cfg(not(feature = "labeler"))]
 use crate::validator::types::RepoState;
 
 const P256_DID_PREFIX: &[u8] = &[0x80, 0x24];
@@ -18,6 +23,37 @@ pub enum VerificationError {
     Key(#[from] p256::ecdsa::Error),
 }
 
+#[cfg(feature = "labeler")]
+pub fn verify_commit_sig(
+    labels: &[SubscribeLabel], key: &[u8; 35],
+) -> Result<bool, VerificationError> {
+    let mut ret = true;
+    for label in labels {
+        if let Some(sig) = &label.sig {
+            let mut label = label.clone();
+            label.sig = None;
+            let encoded = serde_ipld_dagcbor::to_vec(&label)?;
+            match &key[0..2] {
+                P256_DID_PREFIX => {
+                    let key = p256::ecdsa::VerifyingKey::from_sec1_bytes(&key[2..])?;
+                    let sig = p256::ecdsa::Signature::from_slice(sig)?;
+                    ret &= key.verify(&encoded, &sig).is_ok();
+                }
+                K256_DID_PREFIX => {
+                    let key = k256::ecdsa::VerifyingKey::from_sec1_bytes(&key[2..])?;
+                    let sig = k256::ecdsa::Signature::from_slice(sig)?;
+                    ret &= key.verify(&encoded, &sig).is_ok();
+                }
+                _ => {
+                    unreachable!()
+                }
+            }
+        }
+    }
+    Ok(ret)
+}
+
+#[cfg(not(feature = "labeler"))]
 pub fn verify_commit_sig(commit: &Commit, key: &[u8; 35]) -> Result<bool, VerificationError> {
     let encoded = serde_ipld_dagcbor::to_vec(commit)?;
     match &key[0..2] {
@@ -37,6 +73,7 @@ pub fn verify_commit_sig(commit: &Commit, key: &[u8; 35]) -> Result<bool, Verifi
     }
 }
 
+#[cfg(not(feature = "labeler"))]
 pub fn verify_commit_event(commit: &SubscribeReposCommit, root: Cid, prev: &RepoState) -> bool {
     if !prev.rev.older_than(&commit.rev) {
         tracing::debug!(diff = %commit.rev.timestamp() - prev.rev.timestamp(), "old rev");
@@ -116,4 +153,22 @@ pub fn verify_commit_event(commit: &SubscribeReposCommit, root: Cid, prev: &Repo
     }
 
     true
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "labeler")]
+    #[test]
+    fn verify_commit() {
+        use crate::validator::event::SubscribeReposEvent;
+        use crate::validator::utils::verify_commit_sig;
+
+        const KEY: &[u8; 35] = b"\xe7\x01\x03e\xac\xdb.\x10\x1c\xb5O_\x1d\x95\x13T\x90$\x12pM\x07^^w~\xae\x94\xc2\xfe\xe4\xba\xb0\xf3\x91";
+        const MSG: &[u8] = b"\xa2atg#labelsbop\x01\xa2cseq\x1a\x00\xf2\xbb\xdfflabels\x81\xa7ccidx;bafyreiapddjgxnyaogx2gvakuawukls5rr2hdwbkrjb4nwjffwpkb4734mcctsx\x182025-06-08T20:34:56.000ZcsigX@\x99\xecj!\xd8_\x8dg\xb5G\t\x83\xdf\x90\xc64K~6%\r\x8f\xe2{\xe5r\xbf<8\x16\x0fgX9\x84n\x05j\x9d\xf0\x83\xc4b\xbe\xd7\x97\xfa3)\xedE\xb0I\xa1\xfd\xf5\x17\xd8\xccPA\xa4k\x81csrcx did:plc:ar7c4by46qjdydhdevvrndaccurixFat://did:plc:ubfdrhs4desxu3u4osnulj6b/app.bsky.feed.post/3lr4pmliavk2lcvaldporncver\x01";
+
+        let Ok(Some(SubscribeReposEvent::Labels(labels))) = SubscribeReposEvent::parse(MSG) else {
+            unreachable!()
+        };
+        assert!(verify_commit_sig(&labels.labels, KEY).unwrap_or(false));
+    }
 }


### PR DESCRIPTION
## Summary
- I've opted to use a feature flag to allow us to run a separate relay in labeler mode. It was the easiest way to implement a labeler relay, since we don't need separate book keeping for repo relay & labeler relay.
- Added out-of-spec `com.atproto.label.requestCrawl` similar to `com.atproto.sync.requestCrawl`
- It will require spinning up a separate service & using separate path on the domain or path based routing to allow running on the same domain.

## Related Issues
Closes #120 

## Changes
- [x] Feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [x] I have tested the changes (including writing unit tests).
- [x] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [ ] I have updated relevant documentation.
- [x] I have formatted my code correctly
- [ ] I have provided examples for how this code works or will be used