### PR TITLE
rsky-relay: handle plc export edge case; fix queue drain at start; optimize plc_directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ Rocket.toml
 **/data/
 db/
 *.db
+*.db-shm
+*.db-wal
 *.db-journal
 rsky-relay.log.*
 

--- a/rsky-relay/Cargo.toml
+++ b/rsky-relay/Cargo.toml
@@ -30,7 +30,7 @@ p256 = "0.13"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "gzip", "hickory-dns", "http2", "json", "rustls-tls-webpki-roots-no-provider"] }
 rs-car-sync = "0.4"
 rtrb = "0.3"
-rusqlite = { version = "0.35", features = ["bundled", "chrono"] }
+rusqlite = { version = "0.36", features = ["bundled", "chrono"] }
 rustls = "0.23"
 rustls-pemfile = "2"
 serde = { version = "1", features = ["derive"] }

--- a/rsky-relay/src/crawler/manager.rs
+++ b/rsky-relay/src/crawler/manager.rs
@@ -178,7 +178,7 @@ impl Manager {
     fn get_cursor(&self, host: &str) -> Result<Option<Cursor>, ManagerError> {
         let mut stmt = self.conn.prepare_cached("SELECT * FROM hosts WHERE host = ?1")?;
         Ok(stmt
-            .query_row((&host,), |row| Ok(row.get_unwrap::<_, u64>("cursor")))
+            .query_one((&host,), |row| Ok(row.get_unwrap::<_, u64>("cursor")))
             .optional()?
             .map(Into::into))
     }

--- a/rsky-relay/src/validator/event.rs
+++ b/rsky-relay/src/validator/event.rs
@@ -13,6 +13,9 @@ use rsky_common::tid::TID;
 
 use crate::types::Cursor;
 
+pub type DidEndpoint = Option<Box<str>>;
+pub type DidKey = [u8; 35];
+
 #[derive(Debug, Error)]
 pub enum ParseError {
     #[error("header error: {0}")]

--- a/rsky-relay/src/validator/resolver.rs
+++ b/rsky-relay/src/validator/resolver.rs
@@ -76,6 +76,16 @@ impl Resolver {
             "plc_directory.db",
             flag | OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )?;
+        if *DO_PLC_EXPORT {
+            match conn.execute("PRAGMA secure_delete = OFF", []) {
+                Ok(_) | Err(rusqlite::Error::ExecuteReturnedResults) => {}
+                Err(err) => Err(err)?,
+            };
+            conn.execute("PRAGMA synchronous = NORMAL", [])?;
+            conn.execute("PRAGMA temp_store = MEMORY", [])?;
+            conn.execute("PRAGMA incremental_vacuum", [])?;
+            conn.execute("PRAGMA optimize = 0x10002", [])?;
+        }
         let now = Instant::now();
         let last = now.checked_sub(EXPORT_INTERVAL).unwrap_or(now);
         let after = conn.query_one(
@@ -118,12 +128,10 @@ impl Resolver {
     }
 
     pub fn query_db(&mut self, did: &str) -> Result<bool, ResolverError> {
-        let mut stmt = self.conn.prepare_cached(
-            "SELECT * FROM plc_keys WHERE did = ?1 ORDER BY created_at DESC LIMIT 1",
-        )?;
+        let mut stmt = self.conn.prepare_cached("SELECT * FROM plc_keys WHERE did = ?1")?;
         match stmt.query_one([did], |row| {
-            let endpoint = row.get_ref("endpoint")?.as_str_or_null()?;
-            let key = row.get_ref("key")?.as_str_or_null()?;
+            let endpoint = row.get_ref("pds_endpoint")?.as_str_or_null()?;
+            let key = row.get_ref("pds_key")?.as_str_or_null()?;
             Ok(parse_key_endpoint(endpoint, key))
         }) {
             Ok(Some((pds, key))) => {
@@ -201,17 +209,16 @@ impl Resolver {
                         let mut dids = Vec::new();
                         let mut count = 0;
                         let tx = self.conn.transaction()?;
-                        let mut stmt = tx.prepare_cached("INSERT INTO plc_operations (did, cid, nullified, created_at, operation) VALUES (?1, ?2, ?3, ?4, ?5)")?;
+                        let mut stmt = tx.prepare_cached("INSERT INTO plc_operations (cid, did, created_at, nullified, operation) VALUES (?1, ?2, ?3, ?4, ?5)")?;
                         for line in bytes.reader().lines() {
                             count += 1;
                             if let Some(doc) = parse_plc_doc(&line.unwrap_or_default()) {
-                                // TODO: remove duplicates
                                 stmt.execute((
-                                    &doc.did,
                                     &doc.cid,
-                                    &doc.nullified,
+                                    &doc.did,
                                     &doc.created_at,
-                                    doc.operation.get(),
+                                    &doc.nullified,
+                                    doc.operation.get().as_bytes(),
                                 ))?;
                                 self.after = Some(doc.created_at);
                                 if self.inflight.remove(&doc.did) {


### PR DESCRIPTION
## Summary
- handle plc export edge case
  - When we send a plc export query, we set after to None to prevent duplicate inflight queries
  - Then we set after to the last row of the returned results
  - But sometimes, we don't get any results for the query & we just leave the after field empty
  - To fix this, we always set the after field to the queried value to prevent issues
  - Also cleaned up the code a bit to easily add labeler relay later on
- fix queue drain at start
  - When plc_directory is back filled externally, we won't get the pending did from `resolve()`
  - So we have to call scan_did immediately at the beginning to ensure that the queue is drained properly
- sqlite optimizations
  - Add a PRIMARY KEY ON CONFLICT REPLACE constraint to cid field to remove duplicates from the database
  - Store the operation json as a sqlite3 binary json for space efficiency
  - Add GENERATED ALWAYS STORED columns for pds/labeler endpoint/key
  - Add views for pdses & labelers
  - Add indexes to support the new views
  - Change journal_mode to WAL & synchronous to NORMAL for performance
  - Added `PRAGMA incremental_vacuum; PRAGMA optimize = 0x10002` at the start to optimize the database
  - We're now able to process data at about 33MiB/s up from about 25MiB/s 

## Related Issues
<!-- Link any relevant issues -->

## Changes
- [ ] Feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [x] I have tested the changes (including writing unit tests).
- [x] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [ ] I have updated relevant documentation.
- [x] I have formatted my code correctly
- [] I have provided examples for how this code works or will be used