### PR TITLE
updating first version of the dockerfile improvement

### DIFF
--- a/rsky-feedgen/Dockerfile
+++ b/rsky-feedgen/Dockerfile
@@ -4,25 +4,11 @@ FROM rust AS builder
 
 # Copy local code to the container image.
 WORKDIR /usr/src/rsky
-COPY Cargo.toml rust-toolchain ./
-
-# Copy only the Cargo.toml from our package
-COPY rsky-feedgen/Cargo.toml rsky-feedgen/Cargo.toml
-
-# Copy all workspace members except our target package
-COPY cypher cypher
-COPY rsky-common rsky-common
-COPY rsky-crypto rsky-crypto
-COPY rsky-identity rsky-identity
-COPY rsky-firehose rsky-firehose
-COPY rsky-jetstream-subscriber rsky-jetstream-subscriber
-COPY rsky-labeler rsky-labeler
-COPY rsky-lexicon rsky-lexicon
-COPY rsky-pds rsky-pds
-COPY rsky-relay rsky-relay
-COPY rsky-repo rsky-repo
-COPY rsky-satnav rsky-satnav
-COPY rsky-syntax rsky-syntax
+RUN git clone --depth 1 https://github.com/blacksky-algorithms/rsky.git .
+# We can swap the line above for the lines below once we have stronger versioning
+# per workspace member
+# RUN git clone --depth 1 https://github.com/blacksky-algorithms/rsky.git . && \
+#     git checkout <TBD when we have stronger versioning>
 
 # Create an empty src directory to trick Cargo into thinking it's a valid Rust project
 RUN mkdir -p rsky-feedgen/src && echo "fn main() {}" > rsky-feedgen/src/main.rs

--- a/rsky-firehose/Dockerfile
+++ b/rsky-firehose/Dockerfile
@@ -4,27 +4,11 @@ FROM rust AS builder
 
 # Copy local code to the container image.
 WORKDIR /usr/src/rsky
-
-# Start by copying the workspace configuration files
-COPY Cargo.toml rust-toolchain ./
-
-# Copy only the Cargo.toml from our package
-COPY rsky-firehose/Cargo.toml rsky-firehose/Cargo.toml
-
-# Copy all workspace members except our target package
-COPY cypher cypher
-COPY rsky-common rsky-common
-COPY rsky-crypto rsky-crypto
-COPY rsky-feedgen rsky-feedgen
-COPY rsky-identity rsky-identity
-COPY rsky-jetstream-subscriber rsky-jetstream-subscriber
-COPY rsky-labeler rsky-labeler
-COPY rsky-lexicon rsky-lexicon
-COPY rsky-pds rsky-pds
-COPY rsky-relay rsky-relay
-COPY rsky-repo rsky-repo
-COPY rsky-satnav rsky-satnav
-COPY rsky-syntax rsky-syntax
+RUN git clone --depth 1 https://github.com/blacksky-algorithms/rsky.git .
+# We can swap the line above for the lines below once we have stronger versioning
+# per workspace member
+# RUN git clone --depth 1 https://github.com/blacksky-algorithms/rsky.git . && \
+#     git checkout <TBD when we have stronger versioning>
 
 # Create an empty src directory to trick Cargo into thinking it's a valid Rust project
 RUN mkdir -p rsky-firehose/src && echo "fn main() {}" > rsky-firehose/src/main.rs

--- a/rsky-jetstream-subscriber/Dockerfile
+++ b/rsky-jetstream-subscriber/Dockerfile
@@ -4,25 +4,11 @@ FROM rust AS builder
 
 # Copy local code to the container image.
 WORKDIR /usr/src/rsky
-COPY Cargo.toml rust-toolchain ./
-
-# Copy only the Cargo.toml from our package
-COPY rsky-jetstream-subscriber/Cargo.toml rsky-jetstream-subscriber/Cargo.toml
-
-# Copy all workspace members except our target package
-COPY cypher cypher
-COPY rsky-common rsky-common
-COPY rsky-crypto rsky-crypto
-COPY rsky-feedgen rsky-feedgen
-COPY rsky-firehose rsky-firehose
-COPY rsky-identity rsky-identity
-COPY rsky-labeler rsky-labeler
-COPY rsky-lexicon rsky-lexicon
-COPY rsky-pds rsky-pds
-COPY rsky-relay rsky-relay
-COPY rsky-repo rsky-repo
-COPY rsky-satnav rsky-satnav
-COPY rsky-syntax rsky-syntax
+RUN git clone --depth 1 https://github.com/blacksky-algorithms/rsky.git .
+# We can swap the line above for the lines below once we have stronger versioning
+# per workspace member
+# RUN git clone --depth 1 https://github.com/blacksky-algorithms/rsky.git . && \
+#     git checkout <TBD when we have stronger versioning>
 
 # Create an empty src directory to trick Cargo into thinking it's a valid Rust project
 RUN mkdir -p rsky-jetstream-subscriber/src && echo "fn main() {}" > rsky-jetstream-subscriber/src/main.rs

--- a/rsky-pds/Dockerfile
+++ b/rsky-pds/Dockerfile
@@ -4,25 +4,12 @@ FROM rust AS builder
 
 # Copy local code to the container image.
 WORKDIR /usr/src/rsky
-COPY Cargo.toml rust-toolchain ./
+RUN git clone --depth 1 https://github.com/blacksky-algorithms/rsky.git .
+# We can swap the line above for the lines below once we have stronger versioning
+# per workspace member
+# RUN git clone --depth 1 https://github.com/blacksky-algorithms/rsky.git . && \
+#     git checkout <TBD when we have stronger versioning>
 
-# Copy only the Cargo.toml from our package
-COPY rsky-pds/Cargo.toml rsky-pds/Cargo.toml
-
-# Copy all workspace members except our target package
-COPY cypher cypher
-COPY rsky-common rsky-common
-COPY rsky-crypto rsky-crypto
-COPY rsky-feedgen rsky-feedgen
-COPY rsky-firehose rsky-firehose
-COPY rsky-identity rsky-identity
-COPY rsky-jetstream-subscriber rsky-jetstream-subscriber
-COPY rsky-labeler rsky-labeler
-COPY rsky-lexicon rsky-lexicon
-COPY rsky-relay rsky-relay
-COPY rsky-repo rsky-repo
-COPY rsky-satnav rsky-satnav
-COPY rsky-syntax rsky-syntax
 
 # Create an empty src directory to trick Cargo into thinking it's a valid Rust project
 RUN mkdir -p rsky-pds/src && echo "fn main() {}" > rsky-pds/src/main.rs


### PR DESCRIPTION
## Summary

Does a git clone instead of copying every workspace member in the dockerfile.  This prevents a brittle dockerfile specification and something agnostic towards all dockerfile implementations.

## Related Issues

Closes #126 

## Changes
- [x] Bug fix


## Checklist
- [x] I have tested the changes (including writing unit tests).
- [x] I have formatted my code correctly
