### PR TITLE
rsky-common: ipld-core dependency is not needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7569,7 +7569,6 @@ dependencies = [
  "cid 0.11.1",
  "futures",
  "indexmap 1.9.3",
- "ipld-core",
  "multihash 0.19.3",
  "multihash-codetable",
  "rand 0.8.5",

--- a/rsky-common/Cargo.toml
+++ b/rsky-common/Cargo.toml
@@ -27,7 +27,6 @@ rsky-identity = {workspace = true}
 base64ct = "1.6.0"
 urlencoding = "2.1.3"
 futures = "0.3.28"
-ipld-core = {workspace = true}
 multihash = "0.19"
 multihash-codetable = { version = "0.1.3",features = ["sha2"]}
 indexmap = { version = "1.9.3",features = ["serde-1"] }

--- a/rsky-common/src/ipld.rs
+++ b/rsky-common/src/ipld.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use ipld_core::codec::Codec;
 use lexicon_cid::Cid;
 use multihash::Multihash;
 use serde::Serialize;


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes in this PR -->

`ipld-core` isn't used anywhere within the `rsky-common` crate, hence remove it from the dependencies.

## Related Issues
<!-- Link any relevant issues -->

## Changes
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [X] Other (please specify): dependency removal

## Checklist
- [ ] I have tested the changes (including writing unit tests).
- [ ] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [ ] I have updated relevant documentation.
- [x] I have formatted my code correctly
- [ ] I have provided examples for how this code works or will be used