### PR TITLE
Upgrade to Rust 1.86

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-01-03"
+channel = "1.86"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes in this PR -->
The aws dependencies need at least Rust 1.86, hence use that version. A nightly release is not needed, hence use this stable release instead.

## Related Issues
<!-- Link any relevant issues -->
Closes #134.

## Changes
- [ ] Feature implementation
- [X] Bug fix
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [ ] I have tested the changes (including writing unit tests).
- [ ] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [ ] I have updated relevant documentation.
- [ ] I have formatted my code correctly
- [ ] I have provided examples for how this code works or will be used