### PR TITLE
feat: add feedgen text search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,9 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.1.5"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fc05c17098f21b89bc7d98fe1dd3cce2c11c2ad8e145f2a44fe08ed28eb559"
+checksum = "35b696af9ff4c0d2a507db2c5faafa8aa0205e297e5f11e203a24226d5355e7a"
 dependencies = [
  "bitflags 2.9.2",
  "byteorder",
@@ -2297,21 +2297,31 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.1.4"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14701062d6bed917b5c7103bdffaee1e4609279e240488ad24e7bd979ca6866c"
+checksum = "1b96984c469425cb577bf6f17121ecb3e4fe1e81de5d8f780dd372802858d756"
 dependencies = [
  "diesel_table_macro_syntax",
+ "dsl_auto_type",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
 ]
 
 [[package]]
-name = "diesel_migrations"
-version = "2.1.0"
+name = "diesel_full_text_search"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6036b3f0120c5961381b570ee20a02432d7e2d27ea60de9578799cf9156914ac"
+checksum = "e28f8f872592a5283c3876a85c230dab8ddcc093c83660b96830c272257d03c9"
+dependencies = [
+ "diesel",
+]
+
+[[package]]
+name = "diesel_migrations"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a73ce704bad4231f001bff3314d91dce4aba0770cee8b233991859abc15c1f6"
 dependencies = [
  "diesel",
  "migrations_internals",
@@ -2320,9 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_table_macro_syntax"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
  "syn 2.0.106",
 ]
@@ -2848,6 +2858,20 @@ name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "dsl_auto_type"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ae9aca7527f85f26dd76483eb38533fd84bd571065da1739656ef71c5ff5b"
+dependencies = [
+ "darling 0.20.11",
+ "either",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "dtoa"
@@ -5457,19 +5481,19 @@ dependencies = [
 
 [[package]]
 name = "migrations_internals"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f23f71580015254b020e856feac3df5878c2c7a8812297edd6c0a485ac9dada"
+checksum = "3bda1634d70d5bd53553cf15dca9842a396e8c799982a3ad22998dc44d961f24"
 dependencies = [
  "serde",
- "toml 0.7.8",
+ "toml 0.9.6",
 ]
 
 [[package]]
 name = "migrations_macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce3325ac70e67bbab5bd837a31cae01f1a6db64e0e744a33cb03a543469ef08"
+checksum = "ffb161cc72176cb37aa47f1fc520d3ef02263d67d661f44f05d05a079e1237fd"
 dependencies = [
  "migrations_internals",
  "proc-macro2",
@@ -7525,6 +7549,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "diesel",
+ "diesel_full_text_search",
  "dotenvy",
  "moka",
  "once_cell",
@@ -8254,10 +8279,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -8301,10 +8327,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8390,6 +8425,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -9423,26 +9467,29 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
+dependencies = [
+ "indexmap 2.10.0",
+ "serde_core",
+ "serde_spanned 1.0.2",
+ "toml_datetime 0.7.2",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.12",
 ]
 
 [[package]]
@@ -9455,16 +9502,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.19.15"
+name = "toml_datetime"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
 dependencies = [
- "indexmap 2.10.0",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow 0.5.40",
+ "serde_core",
 ]
 
 [[package]]
@@ -9474,7 +9517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap 2.10.0",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
 
@@ -9486,9 +9529,18 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.10.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow 0.7.12",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
  "winnow 0.7.12",
 ]
 
@@ -9497,6 +9549,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d163a63c116ce562a22cda521fcc4d79152e7aba014456fb5eb442f6d6a10109"
 
 [[package]]
 name = "tower"

--- a/rsky-feedgen/Cargo.toml
+++ b/rsky-feedgen/Cargo.toml
@@ -20,7 +20,7 @@ serde_bytes = "0.11.9"
 serde_ipld_dagcbor = "0.3.0"
 serde_json = "1.0.96"
 serde_cbor = "0.11.2"
-diesel = { version = "=2.1.5", features = ["chrono", "postgres"] }
+diesel = { version = "=2.2.0", features = ["chrono", "postgres"] }
 dotenvy = "0.15"
 chrono = "0.4.26"
 regex = "1.8.4"
@@ -29,6 +29,7 @@ rand = "0.8.5"
 once_cell = "1.19.0"
 moka = { version = "0.12", features = ["future"] }
 chrono-tz = "0.10.1"
+diesel_full_text_search = "2.2.0"
 
 [dependencies.rocket_sync_db_pools]
 version = "=0.1.0"

--- a/rsky-feedgen/Dockerfile
+++ b/rsky-feedgen/Dockerfile
@@ -20,6 +20,7 @@ RUN cargo build --release --package rsky-feedgen
 COPY rsky-feedgen/src rsky-feedgen/src
 COPY rsky-feedgen/migrations rsky-feedgen/migrations
 COPY rsky-feedgen/diesel.toml rsky-feedgen/diesel.toml
+COPY rsky-feedgen/Cargo.toml rsky-feedgen/Cargo.toml
 
 RUN cargo build --release --package rsky-feedgen
 

--- a/rsky-feedgen/Dockerfile
+++ b/rsky-feedgen/Dockerfile
@@ -21,6 +21,7 @@ COPY rsky-feedgen/src rsky-feedgen/src
 COPY rsky-feedgen/migrations rsky-feedgen/migrations
 COPY rsky-feedgen/diesel.toml rsky-feedgen/diesel.toml
 COPY rsky-feedgen/Cargo.toml rsky-feedgen/Cargo.toml
+COPY rsky-pds/Cargo.toml rsky-pds/Cargo.toml
 
 RUN cargo build --release --package rsky-feedgen
 

--- a/rsky-feedgen/migrations/2025-09-25-023708-0000_tsvector_index/down.sql
+++ b/rsky-feedgen/migrations/2025-09-25-023708-0000_tsvector_index/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX post_text_tsvector_index;
+

--- a/rsky-feedgen/migrations/2025-09-25-023708-0000_tsvector_index/up.sql
+++ b/rsky-feedgen/migrations/2025-09-25-023708-0000_tsvector_index/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX post_text_tsvector_index ON public.post USING GIN (to_tsvector('simple', text));
+

--- a/rsky-feedgen/src/apis/mod.rs
+++ b/rsky-feedgen/src/apis/mod.rs
@@ -101,9 +101,9 @@ pub async fn get_posts_by_membership(
                 query = query.filter(MembershipSchema::did.is_not_null());
             } else {
                 let hashtags_formatted: Vec<String> = hashtags
-		    .iter()
-		    .map(|hashtag| format!("#{}", hashtag))
-		    .collect();
+                    .iter()
+                    .map(|hashtag| format!("#{}", hashtag))
+                    .collect();
                 let hashtag_tsquery = to_tsquery(hashtags_formatted.join(" | "));
                 query = query.filter(
                     MembershipSchema::did

--- a/rsky-feedgen/src/apis/mod.rs
+++ b/rsky-feedgen/src/apis/mod.rs
@@ -35,7 +35,6 @@ pub async fn get_posts_by_membership(
 ) -> Result<AlgoResponse, ValidationErrorMessageResponse> {
     use crate::schema::membership::dsl as MembershipSchema;
     use crate::schema::post::dsl as PostSchema;
-    use diesel::dsl::any;
 
     let show_sponsored_post = config.show_sponsored_post.clone();
     let sponsored_post_uri = config.sponsored_post_uri.clone();

--- a/rsky-feedgen/src/apis/mod.rs
+++ b/rsky-feedgen/src/apis/mod.rs
@@ -100,7 +100,11 @@ pub async fn get_posts_by_membership(
                 // No hashtags provided, include only posts where author is in the list
                 query = query.filter(MembershipSchema::did.is_not_null());
             } else {
-                let hashtag_tsquery = to_tsquery(hashtags.join(" | "));
+                let hashtags_formatted: Vec<String> = hashtags
+		    .iter()
+		    .map(|hashtag| format!("#{}", hashtag))
+		    .collect();
+                let hashtag_tsquery = to_tsquery(hashtags_formatted.join(" | "));
                 query = query.filter(
                     MembershipSchema::did
                         .is_not_null()

--- a/rsky-feedgen/src/routes.rs
+++ b/rsky-feedgen/src/routes.rs
@@ -261,7 +261,7 @@ pub async fn index(
                 cursor,
                 true,
                 "blacksky-edu".into(),
-                vec!["#blackademics".into()],
+                vec!["blackademics".into()],
                 connection,
                 config,
             )

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -24,7 +24,7 @@ base64-url = "2.0.2"
 base64ct = "1.6.0"
 chrono = "0.4.26"
 data-encoding = "2.5.0"
-diesel = { version = "=2.1.5", features = ["chrono", "postgres"] }
+diesel = { version = "=2.2.0", features = ["chrono", "postgres"] }
 dotenvy = "0.15"
 email_address = "0.2.4"
 event-emitter-rs = "0.1.4"


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes in this PR -->
Use [diesel_full_text_search](https://github.com/diesel-rs/diesel_full_text_search) for hashtag search.

SQL equivalent for hashtag query example:
```sql
SELECT * FROM public.post WHERE to_tsvector('simple', text) @@ to_tsquery('simple', '#blackskytravel | #blackademics');
```

## Related Issues
<!-- Link any relevant issues -->
https://github.com/blacksky-algorithms/rsky/issues/91

## Changes
- [X] Feature implementation
- [X] Bug fix
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [ ] I have tested the changes (including writing unit tests).
- [ ] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [ ] I have updated relevant documentation.
- [X] I have formatted my code correctly
- [X] I have provided examples for how this code works or will be used