### PR TITLE
rsky-feedgen: add routes for ban from tv

### DIFF
--- a/rsky-feedgen/src/main.rs
+++ b/rsky-feedgen/src/main.rs
@@ -153,6 +153,9 @@ fn rocket() -> _ {
                 well_known,
                 get_cursor,
                 update_cursor,
+                ban_user,
+                unban_user,
+                list_banned_users,
                 all_options
             ],
         )

--- a/rsky-feedgen/src/models/banned_from_tv.rs
+++ b/rsky-feedgen/src/models/banned_from_tv.rs
@@ -1,0 +1,16 @@
+use diesel::prelude::*;
+
+#[derive(Queryable, Selectable, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[diesel(table_name = crate::schema::banned_from_tv)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct BannedFromTv {
+    #[serde(rename = "did")]
+    pub did: String,
+    #[serde(rename = "reason", skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    #[diesel(column_name = createdAt)]
+    pub created_at: Option<String>,
+    #[serde(rename = "tags", skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<Option<String>>>,
+}

--- a/rsky-feedgen/src/models/banned_from_tv_request.rs
+++ b/rsky-feedgen/src/models/banned_from_tv_request.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct BannedFromTvRequest {
+    #[serde(rename = "did")]
+    pub did: String,
+    #[serde(rename = "reason", skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(rename = "tags", skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+}

--- a/rsky-feedgen/src/models/mod.rs
+++ b/rsky-feedgen/src/models/mod.rs
@@ -31,3 +31,7 @@ pub mod known_service;
 pub use self::known_service::KnownService;
 pub mod jwt_parts;
 pub use self::jwt_parts::JwtParts;
+pub mod banned_from_tv;
+pub use self::banned_from_tv::BannedFromTv;
+pub mod banned_from_tv_request;
+pub use self::banned_from_tv_request::BannedFromTvRequest;


### PR DESCRIPTION
## Summary
This PR adds routes to add / delete / search the banned_from_tv database table given proper auth. This endpoint will be used by the safe-skies-api service to enable mods to ban users from the feed from within their existing moderation workflows.