### PR TITLE
Fix non-exhaustive pattern match in rsky-firehose binary

### DIFF
--- a/rsky-firehose/src/main.rs
+++ b/rsky-firehose/src/main.rs
@@ -268,6 +268,7 @@ async fn process(message: Vec<u8>, client: &reqwest::Client) {
                 };
             }
         }
+        Ok(None) => (),
         Err(error) => eprintln!(
             "@LOG: Error unwrapping message and header: {}",
             error.to_string()


### PR DESCRIPTION
Add missing Ok(None) arm to the match on firehose::read() in process(). The function returns Ok(None) for intentionally skipped message types (#info, #sync, unknown types) and for recoverable decode errors that the library already logs. The Err arm is preserved to catch genuine CBOR header parse failures.

Fixes #150

## Summary
Since decode errors and unknown message types are already logged and #sync and #info messages are intentionally skipped, there is no work to do in the Ok(None) branch, so implementing `Ok(None) => ()`

## Changes
- [ ] Feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [x] I have tested the changes (including writing unit tests).
- [x] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [x] I have updated relevant documentation.
- [x] I have formatted my code correctly
- [x] I have provided examples for how this code works or will be used