### PR TITLE
Iss152/release profile debug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,10 @@ rsky-repo = {path = "rsky-repo", version = "0.0.2"}
 rsky-firehose = {path = "rsky-firehose", version = "0.2.1"}
 
 [profile.release]
-debug = 2  # Or any level from 0 to 2
+
+[profile.profiling]
+inherits = "release"
+debug = 2
 
 [profile.wasm-dev]
 inherits = "dev"

--- a/rsky-pds/Dockerfile
+++ b/rsky-pds/Dockerfile
@@ -18,9 +18,9 @@ RUN mkdir -p rsky-pds/src && echo "fn main() {}" > rsky-pds/src/main.rs
 RUN cargo build --release --package rsky-pds
 
 # Now copy the real source code and build the final binary
-COPY rsky-pds/src rsky-pds/src
-COPY rsky-pds/migrations rsky-pds/migrations
-COPY rsky-pds/diesel.toml rsky-pds/diesel.toml
+COPY src rsky-pds/src
+COPY migrations rsky-pds/migrations
+COPY diesel.toml rsky-pds/diesel.toml
 
 RUN cargo build --release --package rsky-pds
 


### PR DESCRIPTION
## Summary

Fixes OOM (out-of-memory) failures when building `rsky-pds` in containerized environments
(Docker/Podman). Full debug symbols in `[profile.release]` caused the linker to be killed
by the OS during the `rsky-pds` link step due to peak memory pressure from combining
`opt-level=3` and `debuginfo=2` across ~50 transitive dependencies.

Also fixes a pre-existing bug in `rsky-pds/Dockerfile` where `COPY` source paths were
incorrect for the build context, causing the second build stage to always fail.

## Related Issues

Closes #152

## Changes

- [ ] Feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist

- [x] I have tested the changes (including writing unit tests).
  - Verified `docker build .` completes successfully from `rsky-pds/` with 8 GB container
    memory after both fixes. Previously failed with `SIGKILL` (OOM) at the `rsky-pds` link
    step.
- [ ] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
  - N/A — build configuration change only, no protocol behavior affected.
- [ ] I have updated relevant documentation.
  - N/A
- [x] I have formatted my code correctly
- [ ] I have provided examples for how this code works or will be used
  - Developers needing symbolized builds for profiling (samply, perf, Instruments) can use:
    `cargo build --profile profiling -p rsky-pds`