### PR TITLE
fix: service auth token handling and did:web resolution

### DIFF
--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -30,6 +30,7 @@ email_address = "0.2.4"
 event-emitter-rs = "0.1.4"
 futures = "0.3.28"
 hex = "0.4.3"
+multibase = "0.9.1"
 image = "0.25.1"
 indexmap = { version = "1.9.3", features = ["serde-1"] }
 infer = "0.15.0"

--- a/rsky-pds/src/account_manager/helpers/auth.rs
+++ b/rsky-pds/src/account_manager/helpers/auth.rs
@@ -65,7 +65,10 @@ pub struct ServiceJwtParams {
 
 #[derive(Serialize, Deserialize)]
 pub struct CustomClaimObj {
+    #[serde(default)]
     pub scope: String,
+    #[serde(default)]
+    pub lxm: Option<String>,
 }
 
 #[derive(Error, Debug)]
@@ -116,6 +119,7 @@ pub fn create_access_token(opts: CreateTokensOpts) -> Result<String> {
     let claims = Claims::with_custom_claims(
         CustomClaimObj {
             scope: scope.as_str().to_owned(),
+            lxm: None,
         },
         expires_in,
     )
@@ -141,6 +145,7 @@ pub fn create_refresh_token(opts: CreateTokensOpts) -> Result<String> {
     let claims = Claims::with_custom_claims(
         CustomClaimObj {
             scope: AuthScope::Refresh.as_str().to_owned(),
+            lxm: None,
         },
         expires_in,
     )

--- a/rsky-pds/src/auth_verifier.rs
+++ b/rsky-pds/src/auth_verifier.rs
@@ -625,6 +625,12 @@ pub struct AdminToken {
     pub access: AccessOutput,
 }
 
+fn admin_password_from_env() -> Option<String> {
+    env::var("PDS_ADMIN_PASSWORD")
+        .ok()
+        .or_else(|| env::var("PDS_ADMIN_PASS").ok())
+}
+
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for AdminToken {
     type Error = AuthError;
@@ -638,8 +644,16 @@ impl<'r> FromRequest<'r> for AdminToken {
             )),
             Some(parsed) => {
                 let BasicAuth { username, password } = parsed;
+                let expected_password = match admin_password_from_env() {
+                    Some(password) => password,
+                    None => {
+                        let error = AuthError::AuthRequired("BadAuth".to_string());
+                        req.local_cache(|| Some(ApiError::InvalidRequest(error.to_string())));
+                        return Outcome::Error((Status::BadRequest, error));
+                    }
+                };
 
-                if username != "admin" || password != env::var("PDS_ADMIN_PASS").unwrap() {
+                if username != "admin" || password != expected_password {
                     let error = AuthError::AuthRequired("BadAuth".to_string());
                     req.local_cache(|| Some(ApiError::InvalidRequest(error.to_string())));
                     Outcome::Error((Status::BadRequest, error))
@@ -742,16 +756,39 @@ pub async fn validate_bearer_token<'r>(
     let token = bearer_token_from_req(request)?;
     if let Some(token) = token {
         let secp = Secp256k1::new();
-        let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-        let secret_key =
-            SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
-        let jwt_key = Keypair::from_secret_key(&secp, &secret_key);
-        let payload = verify_jwt(token.clone(), jwt_key, verify_options).await?;
+        // Try JWT key first (for session tokens)
+        let jwt_private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX").unwrap();
+        let jwt_secret_key =
+            SecretKey::from_slice(&hex::decode(jwt_private_key.as_bytes()).unwrap()).unwrap();
+        let jwt_key = Keypair::from_secret_key(&secp, &jwt_secret_key);
+        let payload = match verify_jwt(token.clone(), jwt_key, verify_options.clone()).await {
+            Ok(payload) => payload,
+            Err(_jwt_err) => {
+                // Fall back to repo signing key (for service auth tokens
+                // that come back from external services like video.bsky.app)
+                let repo_key_hex = env::var("PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX")
+                    .unwrap_or_default();
+                if repo_key_hex.is_empty() {
+                    return Err(_jwt_err);
+                }
+                let repo_secret_key = SecretKey::from_slice(
+                    &hex::decode(repo_key_hex.as_bytes()).unwrap(),
+                ).unwrap();
+                let repo_key = Keypair::from_secret_key(&secp, &repo_secret_key);
+                verify_jwt(token.clone(), repo_key, verify_options).await?
+            }
+        };
         let JwtPayload {
             sub, aud, scope, ..
         } = payload.clone();
-        let sub = sub.unwrap();
-        let aud = aud.unwrap();
+        let sub = match sub {
+            Some(s) => s,
+            None => bail!("Malformed token: missing subject"),
+        };
+        let aud = match aud {
+            Some(a) => a,
+            None => bail!("Malformed token: missing audience"),
+        };
         if !sub.starts_with("did:") {
             bail!("Malformed token")
         }
@@ -967,9 +1004,19 @@ pub async fn verify_jwt(
     let public_key = key.public_key();
     let claims = public_key.verify_token::<CustomClaimObj>(&jwt, verify_options)?;
 
+    let scope = if claims.custom.scope.is_empty() {
+        // Service auth tokens (from video.bsky.app etc.) don't have scope,
+        // they have lxm instead. Default to Access scope.
+        AuthScope::Access
+    } else {
+        AuthScope::from_str(&claims.custom.scope)?
+    };
+    // Service auth tokens (e.g. from video.bsky.app) use 'iss' instead of 'sub'.
+    // Fall back to issuer when subject is absent.
+    let sub = claims.subject.or_else(|| claims.issuer.clone());
     Ok(JwtPayload {
-        scope: AuthScope::from_str(&claims.custom.scope)?,
-        sub: claims.subject,
+        scope,
+        sub,
         aud: claims.audiences,
         exp: claims.expires_at,
         iat: claims.issued_at,

--- a/rsky-pds/src/lib.rs
+++ b/rsky-pds/src/lib.rs
@@ -364,6 +364,7 @@ pub async fn build_rocket(cfg: Option<RocketConfig>) -> Rocket<Build> {
                 bsky_api_get_forwarder,
                 bsky_api_post_forwarder,
                 well_known::well_known,
+                well_known::did_json,
                 all_options
             ],
         )

--- a/rsky-pds/src/well_known.rs
+++ b/rsky-pds/src/well_known.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use rocket::http::Status;
 use rocket::request::{FromRequest, Outcome};
 use rocket::response::status;
+use rocket::serde::json::Json;
 use rocket::{Request, State};
+use serde::Serialize;
 
 pub struct HostHeader(pub String);
 
@@ -57,4 +59,103 @@ pub async fn well_known(
             "Internal Server Error".to_string(),
         )),
     }
+}
+
+/// did:web DID document for service-to-service auth.
+/// Resolves did:web:{hostname} -> /.well-known/did.json
+#[derive(Serialize)]
+pub struct DidDocument {
+    #[serde(rename = "@context")]
+    context: Vec<String>,
+    id: String,
+    #[serde(rename = "verificationMethod")]
+    verification_method: Vec<VerificationMethod>,
+    service: Vec<DidService>,
+}
+
+#[derive(Serialize)]
+struct VerificationMethod {
+    id: String,
+    #[serde(rename = "type")]
+    type_: String,
+    controller: String,
+    #[serde(rename = "publicKeyMultibase")]
+    public_key_multibase: String,
+}
+
+#[derive(Serialize)]
+struct DidService {
+    id: String,
+    #[serde(rename = "type")]
+    type_: String,
+    #[serde(rename = "serviceEndpoint")]
+    service_endpoint: String,
+}
+
+#[rocket::get("/.well-known/did.json")]
+pub async fn did_json(
+    cfg: &State<ServerConfig>,
+) -> Result<Json<DidDocument>, status::Custom<String>> {
+    let hostname = &cfg.service.hostname;
+    let did = format!("did:web:{}", hostname);
+
+    // Derive public key multibase from the PDS signing key
+    let signing_key_hex = std::env::var("PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX")
+        .unwrap_or_default();
+
+    let public_key_multibase = if !signing_key_hex.is_empty() {
+        match derive_public_key_multibase(&signing_key_hex) {
+            Ok(mb) => mb,
+            Err(e) => {
+                tracing::error!("Failed to derive public key: {e}");
+                return Err(status::Custom(
+                    Status::InternalServerError,
+                    "Failed to derive signing key".to_string(),
+                ));
+            }
+        }
+    } else {
+        return Err(status::Custom(
+            Status::InternalServerError,
+            "PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX not set".to_string(),
+        ));
+    };
+
+    Ok(Json(DidDocument {
+        context: vec![
+            "https://www.w3.org/ns/did/v1".to_string(),
+            "https://w3id.org/security/multikey/v1".to_string(),
+        ],
+        id: did.clone(),
+        verification_method: vec![VerificationMethod {
+            id: format!("{}#atproto", did),
+            type_: "Multikey".to_string(),
+            controller: did.clone(),
+            public_key_multibase,
+        }],
+        service: vec![DidService {
+            id: "#atproto_pds".to_string(),
+            type_: "AtprotoPersonalDataServer".to_string(),
+            service_endpoint: format!("https://{}", hostname),
+        }],
+    }))
+}
+
+fn derive_public_key_multibase(hex_privkey: &str) -> Result<String, String> {
+    use secp256k1::{Secp256k1, SecretKey};
+
+    let privkey_bytes = hex::decode(hex_privkey)
+        .map_err(|e| format!("hex decode: {e}"))?;
+    let secp = Secp256k1::new();
+    let sk = SecretKey::from_slice(&privkey_bytes)
+        .map_err(|e| format!("secret key: {e}"))?;
+    let pk = sk.public_key(&secp);
+    let compressed = pk.serialize(); // 33 bytes compressed
+
+    // Multicodec secp256k1-pub prefix: 0xe7 0x01
+    let mut prefixed = vec![0xe7, 0x01];
+    prefixed.extend_from_slice(&compressed);
+
+    // Multibase base58btc encoding: 'z' prefix + base58btc
+    Ok(multibase::encode(multibase::Base::Base58Btc, prefixed))
 }


### PR DESCRIPTION
## Summary

- **Service auth fallback to repo signing key**: When JWT key verification fails, try the repo signing key (`PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX`). This enables accepting service auth tokens from external services like `video.bsky.app` that sign tokens with the PDS's repo signing key rather than the JWT session key.
- **Handle missing scope/sub in service tokens**: Service auth tokens from video.bsky.app use `lxm` instead of `scope` and `iss` instead of `sub`. The verifier now defaults to `Access` scope when scope is empty and falls back to `iss` when `sub` is absent.
- **Graceful error handling**: Replace `unwrap()` calls on sub/aud with proper error messages instead of panics. Accept `PDS_ADMIN_PASSWORD` as alias for `PDS_ADMIN_PASS`.
- **did:web resolution**: Serve `/.well-known/did.json` for `did:web:{hostname}` resolution, deriving the secp256k1 public key multibase from the PDS repo signing key. This enables service-to-service auth where the PDS identity is `did:web:hostname`.

## Test plan

- [ ] Verify session tokens (JWT key) still work for normal auth flows
- [ ] Verify service auth callback from video.bsky.app is accepted (token signed with repo key, missing scope, iss instead of sub)
- [ ] Verify `GET /.well-known/did.json` returns valid DID document with correct public key
- [ ] Verify admin auth works with both `PDS_ADMIN_PASSWORD` and `PDS_ADMIN_PASS`
- [ ] Run `cargo check -p rsky-pds` to verify compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)