### PR TITLE
shifts JWT public key derivation from per-token-validation to on-startup

### DIFF
--- a/rsky-pds/src/account_manager/helpers/auth.rs
+++ b/rsky-pds/src/account_manager/helpers/auth.rs
@@ -6,14 +6,13 @@ use diesel::*;
 use jwt_simple::prelude::*;
 use rsky_common::time::{from_micros_to_utc, MINUTE};
 use rsky_common::{get_random_str, json_to_b64url, RFC3339_VARIANT};
-use secp256k1::{Keypair, Message, SecretKey};
+use secp256k1::{Message, SecretKey};
 use sha2::{Digest, Sha256};
 use std::time::SystemTime;
 use thiserror::Error;
 
 pub struct CreateTokensOpts {
     pub did: String,
-    pub jwt_key: Keypair,
     pub service_did: String,
     pub scope: Option<AuthScope>,
     pub jti: Option<String>,
@@ -77,7 +76,6 @@ pub enum AuthHelperError {
 pub fn create_tokens(opts: CreateTokensOpts) -> Result<(String, String)> {
     let CreateTokensOpts {
         did,
-        jwt_key,
         service_did,
         scope,
         jti,
@@ -85,7 +83,6 @@ pub fn create_tokens(opts: CreateTokensOpts) -> Result<(String, String)> {
     } = opts;
     let access_jwt = create_access_token(CreateTokensOpts {
         did: did.clone(),
-        jwt_key,
         service_did: service_did.clone(),
         scope,
         expires_in,
@@ -93,7 +90,6 @@ pub fn create_tokens(opts: CreateTokensOpts) -> Result<(String, String)> {
     })?;
     let refresh_jwt = create_refresh_token(CreateTokensOpts {
         did,
-        jwt_key,
         service_did,
         jti,
         expires_in,
@@ -105,7 +101,6 @@ pub fn create_tokens(opts: CreateTokensOpts) -> Result<(String, String)> {
 pub fn create_access_token(opts: CreateTokensOpts) -> Result<String> {
     let CreateTokensOpts {
         did,
-        jwt_key,
         service_did,
         scope,
         expires_in,
@@ -121,16 +116,13 @@ pub fn create_access_token(opts: CreateTokensOpts) -> Result<String> {
     )
     .with_audience(service_did)
     .with_subject(did);
-    // alg ES256K
-    let key = ES256kKeyPair::from_bytes(jwt_key.secret_bytes().as_slice())?;
-    let token = key.sign(claims)?;
-    Ok(token)
+
+    crate::auth_verifier::JWT_KEY.sign(claims)
 }
 
 pub fn create_refresh_token(opts: CreateTokensOpts) -> Result<String> {
     let CreateTokensOpts {
         did,
-        jwt_key,
         service_did,
         jti,
         expires_in,
@@ -147,10 +139,8 @@ pub fn create_refresh_token(opts: CreateTokensOpts) -> Result<String> {
     .with_audience(service_did)
     .with_subject(did)
     .with_jwt_id(jti);
-    // alg ES256K
-    let key = ES256kKeyPair::from_bytes(jwt_key.secret_bytes().as_slice())?;
-    let token = key.sign(claims)?;
-    Ok(token)
+
+    crate::auth_verifier::JWT_KEY.sign(claims)
 }
 
 pub async fn create_service_jwt(params: ServiceJwtParams) -> Result<String> {
@@ -197,10 +187,10 @@ pub async fn create_service_jwt(params: ServiceJwtParams) -> Result<String> {
 }
 
 // @NOTE unsafe for verification, should only be used w/ direct output from createRefreshToken() or createTokens()
-pub fn decode_refresh_token(jwt: String, jwt_key: Keypair) -> Result<RefreshToken> {
-    let key = ES256kKeyPair::from_bytes(jwt_key.secret_bytes().as_slice())?;
-    let public_key = key.public_key();
-    let claims = public_key.verify_token::<CustomClaimObj>(&jwt, None)?;
+pub fn decode_refresh_token(jwt: String) -> Result<RefreshToken> {
+    let claims = crate::auth_verifier::JWT_KEY
+        .public_key()
+        .verify_token::<CustomClaimObj>(&jwt, None)?;
     assert_eq!(
         claims.custom.scope,
         AuthScope::Refresh.as_str().to_owned(),

--- a/rsky-pds/src/account_manager/helpers/auth.rs
+++ b/rsky-pds/src/account_manager/helpers/auth.rs
@@ -1,4 +1,4 @@
-use crate::auth_verifier::AuthScope;
+use crate::auth_verifier::{AuthScope, PDS_JWT_KEYPAIR};
 use crate::db::DbConn;
 use crate::models;
 use anyhow::Result;
@@ -117,7 +117,7 @@ pub fn create_access_token(opts: CreateTokensOpts) -> Result<String> {
     .with_audience(service_did)
     .with_subject(did);
 
-    crate::auth_verifier::JWT_KEY.sign(claims)
+    PDS_JWT_KEYPAIR.sign(claims)
 }
 
 pub fn create_refresh_token(opts: CreateTokensOpts) -> Result<String> {
@@ -140,7 +140,7 @@ pub fn create_refresh_token(opts: CreateTokensOpts) -> Result<String> {
     .with_subject(did)
     .with_jwt_id(jti);
 
-    crate::auth_verifier::JWT_KEY.sign(claims)
+    PDS_JWT_KEYPAIR.sign(claims)
 }
 
 pub async fn create_service_jwt(params: ServiceJwtParams) -> Result<String> {
@@ -188,7 +188,7 @@ pub async fn create_service_jwt(params: ServiceJwtParams) -> Result<String> {
 
 // @NOTE unsafe for verification, should only be used w/ direct output from createRefreshToken() or createTokens()
 pub fn decode_refresh_token(jwt: String) -> Result<RefreshToken> {
-    let claims = crate::auth_verifier::JWT_KEY
+    let claims = PDS_JWT_KEYPAIR
         .public_key()
         .verify_token::<CustomClaimObj>(&jwt, None)?;
     assert_eq!(

--- a/rsky-pds/src/account_manager/helpers/auth.rs
+++ b/rsky-pds/src/account_manager/helpers/auth.rs
@@ -1,4 +1,5 @@
 use crate::auth_verifier::{AuthScope, PDS_JWT_KEYPAIR};
+use crate::context::PDS_REPO_SIGNING_KEYPAIR;
 use crate::db::DbConn;
 use crate::models;
 use anyhow::Result;
@@ -6,7 +7,7 @@ use diesel::*;
 use jwt_simple::prelude::*;
 use rsky_common::time::{from_micros_to_utc, MINUTE};
 use rsky_common::{get_random_str, json_to_b64url, RFC3339_VARIANT};
-use secp256k1::{Message, SecretKey};
+use secp256k1::Message;
 use sha2::{Digest, Sha256};
 use std::time::SystemTime;
 use thiserror::Error;
@@ -59,7 +60,6 @@ pub struct ServiceJwtParams {
     pub exp: Option<u64>,
     pub lxm: Option<String>,
     pub jti: Option<String>,
-    pub keypair: SecretKey,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -144,9 +144,7 @@ pub fn create_refresh_token(opts: CreateTokensOpts) -> Result<String> {
 }
 
 pub async fn create_service_jwt(params: ServiceJwtParams) -> Result<String> {
-    let ServiceJwtParams {
-        iss, aud, keypair, ..
-    } = params;
+    let ServiceJwtParams { iss, aud, .. } = params;
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("timestamp in micros since UNIX epoch")
@@ -174,7 +172,7 @@ pub async fn create_service_jwt(params: ServiceJwtParams) -> Result<String> {
     );
     let hash = Sha256::digest(to_sign_str.clone());
     let message = Message::from_digest_slice(hash.as_ref())?;
-    let mut sig = keypair.sign_ecdsa(message);
+    let mut sig = PDS_REPO_SIGNING_KEYPAIR.secret_key().sign_ecdsa(message);
     // Convert to low-s
     sig.normalize_s();
     // ASN.1 encoded per decode_dss_signature

--- a/rsky-pds/src/account_manager/mod.rs
+++ b/rsky-pds/src/account_manager/mod.rs
@@ -24,7 +24,6 @@ use rsky_common::time::{from_micros_to_str, from_str_to_micros, HOUR};
 use rsky_common::RFC3339_VARIANT;
 use rsky_lexicon::com::atproto::admin::StatusAttr;
 use rsky_lexicon::com::atproto::server::{AccountCodes, CreateAppPasswordOutput};
-use secp256k1::{Keypair, Secp256k1, SecretKey};
 use std::collections::BTreeMap;
 use std::env;
 use std::sync::Arc;
@@ -146,21 +145,15 @@ impl AccountManager {
             Some(password) => Some(password::gen_salt_and_hash(password)?),
             None => None,
         };
-        // Should be a global var so this only happens once
-        let secp = Secp256k1::new();
-        let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX")?;
-        let secret_key =
-            SecretKey::from_slice(&Result::unwrap(hex::decode(private_key.as_bytes())))?;
-        let jwt_key = Keypair::from_secret_key(&secp, &secret_key);
+
         let (access_jwt, refresh_jwt) = auth::create_tokens(CreateTokensOpts {
             did: did.clone(),
-            jwt_key,
             service_did: env::var("PDS_SERVICE_DID").unwrap(),
             scope: Some(AuthScope::Access),
             jti: None,
             expires_in: None,
         })?;
-        let refresh_payload = auth::decode_refresh_token(refresh_jwt.clone(), jwt_key)?;
+        let refresh_payload = auth::decode_refresh_token(refresh_jwt.clone())?;
         let now = rsky_common::now();
 
         if let Some(invite_code) = invite_code.clone() {
@@ -242,10 +235,7 @@ impl AccountManager {
         app_password_name: Option<String>,
     ) -> Result<(String, String)> {
         let db = self.db.clone();
-        let secp = Secp256k1::new();
-        let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX")?;
-        let secret_key = SecretKey::from_slice(&hex::decode(private_key.as_bytes())?)?;
-        let jwt_key = Keypair::from_secret_key(&secp, &secret_key);
+
         let scope = if app_password_name.is_none() {
             AuthScope::Access
         } else {
@@ -253,13 +243,12 @@ impl AccountManager {
         };
         let (access_jwt, refresh_jwt) = auth::create_tokens(CreateTokensOpts {
             did,
-            jwt_key,
             service_did: env::var("PDS_SERVICE_DID").unwrap(),
             scope: Some(scope),
             jti: None,
             expires_in: None,
         })?;
-        let refresh_payload = auth::decode_refresh_token(refresh_jwt.clone(), jwt_key)?;
+        let refresh_payload = auth::decode_refresh_token(refresh_jwt.clone())?;
         auth::store_refresh_token(refresh_payload, app_password_name, db.as_ref()).await?;
         Ok((access_jwt, refresh_jwt))
     }
@@ -296,15 +285,8 @@ impl AccountManager {
             // reuse you always receive a refresh token with the same id.
             let next_id = token.next_id.unwrap_or_else(auth::get_refresh_token_id);
 
-            let secp = Secp256k1::new();
-            let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-            let secret_key =
-                SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
-            let jwt_key = Keypair::from_secret_key(&secp, &secret_key);
-
             let (access_jwt, refresh_jwt) = auth::create_tokens(CreateTokensOpts {
                 did: token.did,
-                jwt_key,
                 service_did: env::var("PDS_SERVICE_DID").unwrap(),
                 scope: Some(if token.app_password_name.is_none() {
                     AuthScope::Access
@@ -314,7 +296,7 @@ impl AccountManager {
                 jti: Some(next_id.clone()),
                 expires_in: None,
             })?;
-            let refresh_payload = auth::decode_refresh_token(refresh_jwt.clone(), jwt_key)?;
+            let refresh_payload = auth::decode_refresh_token(refresh_jwt.clone())?;
             match try_join!(
                 auth::add_refresh_grace_period(
                     RefreshGracePeriodOpts {

--- a/rsky-pds/src/actor_store/mod.rs
+++ b/rsky-pds/src/actor_store/mod.rs
@@ -108,7 +108,7 @@ impl ActorStore {
         let commit = Repo::format_init_commit(
             self.storage.clone(),
             self.did.clone(),
-            keypair,
+            *keypair,
             Some(write_ops),
         )
         .await?;
@@ -143,7 +143,7 @@ impl ActorStore {
         let commit = Repo::format_init_commit(
             self.storage.clone(),
             self.did.clone(),
-            keypair,
+            *keypair,
             Some(write_ops),
         )
         .await?;
@@ -340,7 +340,7 @@ impl ActorStore {
                 .collect::<Result<Vec<RecordWriteOp>>>()?;
 
             let mut commit = repo
-                .format_commit(RecordWriteEnum::List(write_ops), &PDS_REPO_SIGNING_KEYPAIR)
+                .format_commit(RecordWriteEnum::List(write_ops), *PDS_REPO_SIGNING_KEYPAIR)
                 .await?;
 
             // find blocks that would be deleted but are referenced by another record

--- a/rsky-pds/src/actor_store/mod.rs
+++ b/rsky-pds/src/actor_store/mod.rs
@@ -7,6 +7,7 @@ use crate::actor_store::preference::PreferenceReader;
 use crate::actor_store::record::RecordReader;
 use crate::actor_store::repo::sql_repo::SqlRepoReader;
 use crate::actor_store::repo::types::SyncEvtData;
+use crate::context::PDS_REPO_SIGNING_KEYPAIR;
 use crate::db::DbConn;
 use anyhow::Result;
 use diesel::*;
@@ -22,8 +23,7 @@ use rsky_repo::types::{
 };
 use rsky_repo::util::format_data_key;
 use rsky_syntax::aturi::AtUri;
-use secp256k1::{Keypair, Secp256k1, SecretKey};
-use std::env;
+use secp256k1::Keypair;
 use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -89,7 +89,7 @@ impl ActorStore {
     #[deprecated]
     pub async fn create_repo_legacy(
         &self,
-        keypair: Keypair,
+        keypair: &Keypair,
         writes: Vec<PreparedCreateOrUpdate>,
     ) -> Result<CommitData> {
         let write_ops = writes
@@ -124,7 +124,7 @@ impl ActorStore {
 
     pub async fn create_repo(
         &self,
-        keypair: Keypair,
+        keypair: &Keypair,
         writes: Vec<PreparedCreateOrUpdate>,
     ) -> Result<CommitDataWithOps> {
         let write_ops = writes
@@ -338,15 +338,9 @@ impl ActorStore {
                 .into_iter()
                 .map(write_to_op)
                 .collect::<Result<Vec<RecordWriteOp>>>()?;
-            // @TODO: Use repo signing key global config
-            let secp = Secp256k1::new();
-            let repo_private_key = env::var("PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-            let repo_secret_key =
-                SecretKey::from_slice(&hex::decode(repo_private_key.as_bytes()).unwrap()).unwrap();
-            let repo_signing_key = Keypair::from_secret_key(&secp, &repo_secret_key);
 
             let mut commit = repo
-                .format_commit(RecordWriteEnum::List(write_ops), repo_signing_key)
+                .format_commit(RecordWriteEnum::List(write_ops), &PDS_REPO_SIGNING_KEYPAIR)
                 .await?;
 
             // find blocks that would be deleted but are referenced by another record

--- a/rsky-pds/src/apis/com/atproto/admin/update_account_handle.rs
+++ b/rsky-pds/src/apis/com/atproto/admin/update_account_handle.rs
@@ -1,6 +1,6 @@
 use crate::account_manager::helpers::account::AvailabilityFlags;
 use crate::account_manager::AccountManager;
-use crate::apis::com::atproto::server::get_keys_from_private_key_str;
+use crate::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::apis::ApiError;
 use crate::auth_verifier::AdminToken;
 use crate::config::ServerConfig;
@@ -11,7 +11,6 @@ use rocket::serde::json::Json;
 use rocket::State;
 use rsky_common::env::env_str;
 use rsky_lexicon::com::atproto::admin::UpdateAccountHandleInput;
-use std::env;
 
 async fn inner_update_account_handle(
     body: Json<UpdateAccountHandleInput>,
@@ -50,10 +49,8 @@ async fn inner_update_account_handle(
         None => {
             let plc_url = env_str("PDS_DID_PLC_URL").unwrap_or("https://plc.directory".to_owned());
             let plc_client = plc::Client::new(plc_url);
-            let private_key = env::var("PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-            let (signing_key, _) = get_keys_from_private_key_str(private_key)?;
             plc_client
-                .update_handle(&did, &signing_key, &handle)
+                .update_handle(&did, &PDS_PLC_ROTATION_KEYPAIR.secret_key(), &handle)
                 .await?;
             account_manager.update_handle(&did, &handle).await?;
         }

--- a/rsky-pds/src/apis/com/atproto/identity/get_recommended_did_credentials.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/get_recommended_did_credentials.rs
@@ -1,16 +1,15 @@
 use crate::account_manager::helpers::account::AvailabilityFlags;
 use crate::account_manager::AccountManager;
+use crate::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandard;
 use crate::config::ServerConfig;
+use crate::context::PDS_REPO_SIGNING_KEYPAIR;
 use rocket::serde::json::Json;
 use rocket::State;
 use rsky_crypto::utils::encode_did_key;
 use rsky_lexicon::com::atproto::identity::GetRecommendedDidCredentialsResponse;
-use secp256k1::{Keypair, Secp256k1, SecretKey};
 use serde_json::json;
-use std::env;
-use crate::context::PDS_REPO_SIGNING_KEYPAIR;
 
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/com.atproto.identity.getRecommendedDidCredentials")]
@@ -42,7 +41,7 @@ pub async fn get_recommended_did_credentials(
         "atproto": signing_key
     });
 
-    let rotation_key = get_public_rotation_key()?;
+    let rotation_key = encode_did_key(&PDS_PLC_ROTATION_KEYPAIR.public_key());
     let rotation_keys = vec![rotation_key];
 
     let services = json!({
@@ -58,31 +57,4 @@ pub async fn get_recommended_did_credentials(
         services,
     };
     Ok(Json(response))
-}
-
-fn get_public_rotation_key() -> Result<String, ApiError> {
-    let secp = Secp256k1::new();
-    let private_rotation_key = match env::var("PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX") {
-        Ok(res) => res,
-        Err(error) => {
-            tracing::error!("Error geting rotation private key\n{error}");
-            return Err(ApiError::RuntimeError);
-        }
-    };
-    match hex::decode(private_rotation_key.as_bytes()) {
-        Ok(bytes) => match SecretKey::from_slice(&bytes) {
-            Ok(secret_key) => {
-                let rotation_keypair = Keypair::from_secret_key(&secp, &secret_key);
-                Ok(encode_did_key(&rotation_keypair.public_key()))
-            }
-            Err(error) => {
-                tracing::error!("Error geting rotation secret key from bytes\n{error}");
-                Err(ApiError::RuntimeError)
-            }
-        },
-        Err(error) => {
-            tracing::error!("Unable to hex decode rotation key\n{error}");
-            Err(ApiError::RuntimeError)
-        }
-    }
 }

--- a/rsky-pds/src/apis/com/atproto/identity/get_recommended_did_credentials.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/get_recommended_did_credentials.rs
@@ -10,6 +10,7 @@ use rsky_lexicon::com::atproto::identity::GetRecommendedDidCredentialsResponse;
 use secp256k1::{Keypair, Secp256k1, SecretKey};
 use serde_json::json;
 use std::env;
+use crate::context::PDS_REPO_SIGNING_KEYPAIR;
 
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/com.atproto.identity.getRecommendedDidCredentials")]
@@ -36,7 +37,7 @@ pub async fn get_recommended_did_credentials(
         }
     }
 
-    let signing_key = get_public_signing_key()?;
+    let signing_key = encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key());
     let verification_methods = json!({
         "atproto": signing_key
     });
@@ -81,33 +82,6 @@ fn get_public_rotation_key() -> Result<String, ApiError> {
         },
         Err(error) => {
             tracing::error!("Unable to hex decode rotation key\n{error}");
-            Err(ApiError::RuntimeError)
-        }
-    }
-}
-
-fn get_public_signing_key() -> Result<String, ApiError> {
-    let secp = Secp256k1::new();
-    let private_signing_key = match env::var("PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX") {
-        Ok(res) => res,
-        Err(error) => {
-            tracing::error!("Error geting signing private key\n{error}");
-            return Err(ApiError::RuntimeError);
-        }
-    };
-    match hex::decode(private_signing_key.as_bytes()) {
-        Ok(bytes) => match SecretKey::from_slice(&bytes) {
-            Ok(secret_key) => {
-                let signing_keypair = Keypair::from_secret_key(&secp, &secret_key);
-                Ok(encode_did_key(&signing_keypair.public_key()))
-            }
-            Err(error) => {
-                tracing::error!("Error geting signing secret key from bytes\n{error}");
-                Err(ApiError::RuntimeError)
-            }
-        },
-        Err(error) => {
-            tracing::error!("Unable to hex decode signing key\n{error}");
             Err(ApiError::RuntimeError)
         }
     }

--- a/rsky-pds/src/apis/com/atproto/identity/sign_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/sign_plc_operation.rs
@@ -1,5 +1,5 @@
 use crate::account_manager::AccountManager;
-use crate::apis::com::atproto::server::get_keys_from_private_key_str;
+use crate::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessFull;
 use crate::models::models::EmailTokenPurpose;
@@ -51,9 +51,6 @@ pub async fn sign_plc_operation(
         }
     };
 
-    let private_key = env_str("PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-    let (secret_rotation_key, _) = get_keys_from_private_key_str(private_key)?;
-
     //If request doesn't contain field, check last op for field. In the case of CreateOpV1,
     // we don't set it (which is aligned with BSky Implementation
     let also_known_as = match request.also_known_as {
@@ -92,7 +89,7 @@ pub async fn sign_plc_operation(
     };
     let operation = match create_update_op(
         last_op,
-        &secret_rotation_key,
+        &PDS_PLC_ROTATION_KEYPAIR.secret_key(),
         |normalized: Operation| -> Operation {
             let mut updated = normalized.clone();
             if let Some(also_known_as) = &also_known_as {

--- a/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
@@ -11,6 +11,7 @@ use rsky_crypto::utils::encode_did_key;
 use rsky_lexicon::com::atproto::identity::SubmitPlcOperationRequest;
 use secp256k1::{Keypair, Secp256k1, SecretKey};
 use std::env;
+use crate::context::PDS_REPO_SIGNING_KEYPAIR;
 
 #[tracing::instrument(skip_all)]
 fn get_requester_did(auth: &AccessStandard) -> Result<String, ApiError> {
@@ -59,30 +60,7 @@ fn get_public_rotation_key() -> Result<String, ApiError> {
 
 #[tracing::instrument(skip_all)]
 fn get_public_signing_key() -> Result<String, ApiError> {
-    let secp = Secp256k1::new();
-    let private_signing_key = match env::var("PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX") {
-        Ok(res) => res,
-        Err(error) => {
-            tracing::error!("Error geting signing private key\n{error}");
-            return Err(ApiError::RuntimeError);
-        }
-    };
-    match hex::decode(private_signing_key.as_bytes()) {
-        Ok(bytes) => match SecretKey::from_slice(&bytes) {
-            Ok(secret_key) => {
-                let signing_keypair = Keypair::from_secret_key(&secp, &secret_key);
-                Ok(encode_did_key(&signing_keypair.public_key()))
-            }
-            Err(error) => {
-                tracing::error!("Error geting signing secret key from bytes\n{error}");
-                Err(ApiError::RuntimeError)
-            }
-        },
-        Err(error) => {
-            tracing::error!("Unable to hex decode signing key\n{error}");
-            Err(ApiError::RuntimeError)
-        }
-    }
+    Ok(encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key()))
 }
 
 #[tracing::instrument(skip_all)]

--- a/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
@@ -59,25 +59,20 @@ fn get_public_rotation_key() -> Result<String, ApiError> {
 }
 
 #[tracing::instrument(skip_all)]
-fn get_public_signing_key() -> Result<String, ApiError> {
-    Ok(encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key()))
-}
-
-#[tracing::instrument(skip_all)]
 async fn validate_plc_request(
     did: &str,
     op: &Operation,
     public_endpoint: &str,
     account_manager: &AccountManager,
 ) -> Result<(), ApiError> {
-    let public_rotation_key = get_public_signing_key()?;
+    let public_rotation_key = get_public_rotation_key()?;
     if !op.rotation_keys.contains(&public_rotation_key) {
         return Err(ApiError::InvalidRequest(
             "Rotation keys do not include server's rotation key".to_string(),
         ));
     }
 
-    let public_signing_key = get_public_signing_key()?;
+    let public_signing_key = encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key());
     match op.verification_methods.get("atproto") {
         None => {
             return Err(ApiError::InvalidRequest(

--- a/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
@@ -1,17 +1,16 @@
 use crate::account_manager::helpers::account::AvailabilityFlags;
 use crate::account_manager::AccountManager;
+use crate::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandard;
 use crate::config::ServerConfig;
+use crate::context::PDS_REPO_SIGNING_KEYPAIR;
 use crate::plc::types::{OpOrTombstone, Operation};
 use crate::{plc, SharedIdResolver, SharedSequencer};
 use rocket::serde::json::Json;
 use rocket::State;
 use rsky_crypto::utils::encode_did_key;
 use rsky_lexicon::com::atproto::identity::SubmitPlcOperationRequest;
-use secp256k1::{Keypair, Secp256k1, SecretKey};
-use std::env;
-use crate::context::PDS_REPO_SIGNING_KEYPAIR;
 
 #[tracing::instrument(skip_all)]
 fn get_requester_did(auth: &AccessStandard) -> Result<String, ApiError> {
@@ -31,41 +30,13 @@ fn get_requester_did(auth: &AccessStandard) -> Result<String, ApiError> {
 }
 
 #[tracing::instrument(skip_all)]
-fn get_public_rotation_key() -> Result<String, ApiError> {
-    let secp = Secp256k1::new();
-    let private_rotation_key = match env::var("PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX") {
-        Ok(res) => res,
-        Err(error) => {
-            tracing::error!("Error geting rotation private key\n{error}");
-            return Err(ApiError::RuntimeError);
-        }
-    };
-    match hex::decode(private_rotation_key.as_bytes()) {
-        Ok(bytes) => match SecretKey::from_slice(&bytes) {
-            Ok(secret_key) => {
-                let rotation_keypair = Keypair::from_secret_key(&secp, &secret_key);
-                Ok(encode_did_key(&rotation_keypair.public_key()))
-            }
-            Err(error) => {
-                tracing::error!("Error geting rotation secret key from bytes\n{error}");
-                Err(ApiError::RuntimeError)
-            }
-        },
-        Err(error) => {
-            tracing::error!("Unable to hex decode rotation key\n{error}");
-            Err(ApiError::RuntimeError)
-        }
-    }
-}
-
-#[tracing::instrument(skip_all)]
 async fn validate_plc_request(
     did: &str,
     op: &Operation,
     public_endpoint: &str,
     account_manager: &AccountManager,
 ) -> Result<(), ApiError> {
-    let public_rotation_key = get_public_rotation_key()?;
+    let public_rotation_key = encode_did_key(&PDS_PLC_ROTATION_KEYPAIR.public_key());
     if !op.rotation_keys.contains(&public_rotation_key) {
         return Err(ApiError::InvalidRequest(
             "Rotation keys do not include server's rotation key".to_string(),

--- a/rsky-pds/src/apis/com/atproto/identity/update_handle.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/update_handle.rs
@@ -1,6 +1,6 @@
 use crate::account_manager::helpers::account::AvailabilityFlags;
 use crate::account_manager::AccountManager;
-use crate::apis::com::atproto::server::get_keys_from_private_key_str;
+use crate::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandardCheckTakedown;
 use crate::config::ServerConfig;
@@ -11,7 +11,6 @@ use rocket::serde::json::Json;
 use rocket::State;
 use rsky_common::env::env_str;
 use rsky_lexicon::com::atproto::identity::UpdateHandleInput;
-use std::env;
 
 #[tracing::instrument(skip_all)]
 async fn inner_update_handle(
@@ -52,10 +51,8 @@ async fn inner_update_handle(
         None => {
             let plc_url = env_str("PDS_DID_PLC_URL").unwrap_or("https://plc.directory".to_owned());
             let plc_client = plc::Client::new(plc_url);
-            let private_key = env::var("PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-            let (signing_key, _) = get_keys_from_private_key_str(private_key)?;
             plc_client
-                .update_handle(&requester, &signing_key, &handle)
+                .update_handle(&requester, &PDS_PLC_ROTATION_KEYPAIR.secret_key(), &handle)
                 .await?;
             account_manager.update_handle(&requester, &handle).await?;
         }

--- a/rsky-pds/src/apis/com/atproto/server/create_account.rs
+++ b/rsky-pds/src/apis/com/atproto/server/create_account.rs
@@ -6,6 +6,7 @@ use crate::apis::com::atproto::server::safe_resolve_did_doc;
 use crate::apis::ApiError;
 use crate::auth_verifier::UserDidAuthOptional;
 use crate::config::ServerConfig;
+use crate::context::PDS_REPO_SIGNING_KEYPAIR;
 use crate::db::DbConn;
 use crate::handle::{normalize_and_validate_handle, HandleValidationContext, HandleValidationOpts};
 use crate::plc::operations::{create_op, CreateAtprotoOpInput};
@@ -30,7 +31,6 @@ pub struct TransformedCreateAccountInput {
     pub did: String,
     pub invite_code: Option<String>,
     pub password: String,
-    pub signing_key: Keypair,
     pub plc_op: Option<Operation>,
     pub deactivated: bool,
 }
@@ -66,7 +66,6 @@ pub async fn server_create_account(
         password,
         deactivated,
         plc_op,
-        signing_key,
     } = validate_inputs_for_local_pds(
         cfg,
         id_resolver,
@@ -79,7 +78,10 @@ pub async fn server_create_account(
     // Create new actor repo TODO: Proper rollback
     let mut actor_store =
         ActorStore::new(did.clone(), S3BlobStore::new(did.clone(), s3_config), db);
-    let commit = match actor_store.create_repo(signing_key, Vec::new()).await {
+    let commit = match actor_store
+        .create_repo(&PDS_REPO_SIGNING_KEYPAIR, Vec::new())
+        .await
+    {
         Ok(commit) => commit,
         Err(error) => {
             tracing::error!("Failed to create repo\n{:?}", error);
@@ -302,12 +304,6 @@ pub async fn validate_inputs_for_local_pds(
         Some(ref pass) => pass.clone(),
     };
 
-    // Get Signing Key
-    let secp = Secp256k1::new();
-    let private_key = env::var("PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-    let secret_key = SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
-    let signing_key = Keypair::from_secret_key(&secp, &secret_key);
-
     match input.did {
         Some(input_did) => {
             if input_did == requester.unwrap_or("n/a".to_string()) {
@@ -320,7 +316,7 @@ pub async fn validate_inputs_for_local_pds(
             deactivated = true;
         }
         None => {
-            let res = format_did_and_plc_op(input, signing_key).await?;
+            let res = format_did_and_plc_op(input).await?;
             did = res.0;
             plc_op = Some(res.1);
             deactivated = false;
@@ -333,7 +329,6 @@ pub async fn validate_inputs_for_local_pds(
         did,
         invite_code,
         password,
-        signing_key,
         plc_op,
         deactivated,
     })
@@ -342,7 +337,6 @@ pub async fn validate_inputs_for_local_pds(
 #[tracing::instrument(skip_all)]
 async fn format_did_and_plc_op(
     input: CreateAccountInput,
-    signing_key: Keypair,
 ) -> Result<(String, Operation), ApiError> {
     let mut rotation_keys: Vec<String> = Vec::new();
 
@@ -362,7 +356,7 @@ async fn format_did_and_plc_op(
     //Build PLC Create Operation
 
     let create_op_input = CreateAtprotoOpInput {
-        signing_key: encode_did_key(&signing_key.public_key()),
+        signing_key: encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key()),
         handle: input.handle,
         pds: format!(
             "https://{}",

--- a/rsky-pds/src/apis/com/atproto/server/create_account.rs
+++ b/rsky-pds/src/apis/com/atproto/server/create_account.rs
@@ -5,6 +5,7 @@ use crate::actor_store::ActorStore;
 use crate::apis::com::atproto::server::safe_resolve_did_doc;
 use crate::apis::ApiError;
 use crate::auth_verifier::UserDidAuthOptional;
+use crate::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::config::ServerConfig;
 use crate::context::PDS_REPO_SIGNING_KEYPAIR;
 use crate::db::DbConn;
@@ -21,7 +22,6 @@ use rocket::State;
 use rsky_common::env::env_str;
 use rsky_crypto::utils::encode_did_key;
 use rsky_lexicon::com::atproto::server::{CreateAccountInput, CreateAccountOutput};
-use secp256k1::{Keypair, Secp256k1, SecretKey};
 use std::env;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -335,9 +335,7 @@ pub async fn validate_inputs_for_local_pds(
 }
 
 #[tracing::instrument(skip_all)]
-async fn format_did_and_plc_op(
-    input: CreateAccountInput,
-) -> Result<(String, Operation), ApiError> {
+async fn format_did_and_plc_op(input: CreateAccountInput) -> Result<(String, Operation), ApiError> {
     let mut rotation_keys: Vec<String> = Vec::new();
 
     //Add user provided rotation key
@@ -346,12 +344,7 @@ async fn format_did_and_plc_op(
     }
 
     //Add PDS rotation key
-    let secp = Secp256k1::new();
-    let private_rotation_key = env::var("PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-    let private_secret_key =
-        SecretKey::from_slice(&hex::decode(private_rotation_key.as_bytes()).unwrap()).unwrap();
-    let rotation_keypair = Keypair::from_secret_key(&secp, &private_secret_key);
-    rotation_keys.push(encode_did_key(&rotation_keypair.public_key()));
+    rotation_keys.push(encode_did_key(&PDS_PLC_ROTATION_KEYPAIR.public_key()));
 
     //Build PLC Create Operation
 
@@ -364,7 +357,7 @@ async fn format_did_and_plc_op(
         ),
         rotation_keys,
     };
-    let response = match create_op(create_op_input, rotation_keypair.secret_key()).await {
+    let response = match create_op(create_op_input, PDS_PLC_ROTATION_KEYPAIR.secret_key()).await {
         Ok(res) => res,
         Err(error) => {
             tracing::error!("{error}");

--- a/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
+++ b/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
@@ -8,8 +8,6 @@ use chrono::DateTime;
 use rocket::serde::json::Json;
 use rsky_common::time::{from_micros_to_utc, HOUR, MINUTE};
 use rsky_lexicon::com::atproto::server::GetServiceAuthOutput;
-use secp256k1::SecretKey;
-use std::env;
 use std::time::SystemTime;
 
 pub async fn inner_get_service_auth(
@@ -20,9 +18,6 @@ pub async fn inner_get_service_auth(
 ) -> Result<String> {
     let credentials = auth.access.credentials.unwrap();
     let did = credentials.clone().did.unwrap();
-    // We just use the repo signing key
-    let private_key = env::var("PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-    let keypair = SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
     let exp = match exp {
         None => None,
         Some(exp) => Some(exp * 1000),
@@ -53,7 +48,6 @@ pub async fn inner_get_service_auth(
         exp: None,
         lxm,
         jti: None,
-        keypair,
     })
     .await
 }

--- a/rsky-pds/src/apis/com/atproto/server/mod.rs
+++ b/rsky-pds/src/apis/com/atproto/server/mod.rs
@@ -8,6 +8,7 @@ use rsky_crypto::utils::encode_did_key;
 use rsky_identity::types::DidDocument;
 use secp256k1::{PublicKey, Secp256k1, SecretKey};
 use std::env;
+use crate::context::PDS_REPO_SIGNING_KEYPAIR;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct AssertionContents {
@@ -147,13 +148,8 @@ pub async fn assert_valid_doc_contents(contents: AssertionContents) -> Result<()
     if pds_endpoint.is_none() || pds_endpoint.unwrap() != public_url {
         bail!("DID document atproto_pds service endpoint does not match PDS public url")
     }
-
-    let repo_signing_key = env::var("PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-    let repo_signing_keypair =
-        SecretKey::from_slice(&hex::decode(repo_signing_key.as_bytes()).unwrap()).unwrap();
-    let secp = Secp256k1::new();
-    let repo_public_key = repo_signing_keypair.public_key(&secp);
-    if signing_key.is_none() || signing_key.unwrap() != encode_did_key(&repo_public_key) {
+    
+    if signing_key.is_none() || signing_key.unwrap() != encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key()) {
         bail!("DID document verification method does not match expected signing key")
     }
     Ok(())

--- a/rsky-pds/src/apis/com/atproto/server/mod.rs
+++ b/rsky-pds/src/apis/com/atproto/server/mod.rs
@@ -1,3 +1,4 @@
+use crate::context::PDS_REPO_SIGNING_KEYPAIR;
 use crate::{plc, SharedIdResolver};
 use anyhow::{bail, Result};
 use rand::{distributions::Alphanumeric, Rng};
@@ -6,9 +7,16 @@ use rocket::State;
 use rsky_common::env::{env_int, env_str};
 use rsky_crypto::utils::encode_did_key;
 use rsky_identity::types::DidDocument;
-use secp256k1::{PublicKey, Secp256k1, SecretKey};
+use secp256k1::{Keypair, Secp256k1, SecretKey};
 use std::env;
-use crate::context::PDS_REPO_SIGNING_KEYPAIR;
+use std::sync::LazyLock;
+
+pub static PDS_PLC_ROTATION_KEYPAIR: LazyLock<Keypair> = LazyLock::new(|| {
+    let secp = Secp256k1::new();
+    let private_key = env::var("PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX").unwrap();
+    let secret_key = SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
+    Keypair::from_secret_key(&secp, &secret_key)
+});
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct AssertionContents {
@@ -75,20 +83,6 @@ pub fn validate_handle(handle: &str) -> bool {
     // Need to check suffix here and need to make sure handle doesn't include "." after trumming it
 }
 
-pub fn get_keys_from_private_key_str(private_key: String) -> Result<(SecretKey, PublicKey)> {
-    let secp = Secp256k1::new();
-    let decoded_key = hex::decode(private_key.as_bytes()).map_err(|error| {
-        let context = format!("Issue decoding hex '{}'", private_key);
-        anyhow::Error::new(error).context(context)
-    })?;
-    let secret_key = SecretKey::from_slice(&decoded_key).map_err(|error| {
-        let context = format!("Issue creating secret key from input '{}'", private_key);
-        anyhow::Error::new(error).context(context)
-    })?;
-    let public_key = secret_key.public_key(&secp);
-    Ok((secret_key, public_key))
-}
-
 pub async fn is_valid_did_doc_for_service(did: String) -> Result<bool> {
     match assert_valid_did_documents_for_service(did).await {
         Ok(()) => Ok(true),
@@ -127,9 +121,7 @@ pub async fn assert_valid_doc_contents(contents: AssertionContents) -> Result<()
         pds_endpoint,
         rotation_keys,
     } = contents;
-    let private_key = env::var("PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-    let (_, plc_rotation_key) = get_keys_from_private_key_str(private_key)?;
-    let plc_rotation_key = encode_did_key(&plc_rotation_key);
+    let plc_rotation_key = encode_did_key(&PDS_PLC_ROTATION_KEYPAIR.public_key());
 
     if let Some(rotation_keys) = rotation_keys {
         if !rotation_keys.contains(plc_rotation_key) {
@@ -148,8 +140,10 @@ pub async fn assert_valid_doc_contents(contents: AssertionContents) -> Result<()
     if pds_endpoint.is_none() || pds_endpoint.unwrap() != public_url {
         bail!("DID document atproto_pds service endpoint does not match PDS public url")
     }
-    
-    if signing_key.is_none() || signing_key.unwrap() != encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key()) {
+
+    if signing_key.is_none()
+        || signing_key.unwrap() != encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key())
+    {
         bail!("DID document verification method does not match expected signing key")
     }
     Ok(())

--- a/rsky-pds/src/auth_verifier.rs
+++ b/rsky-pds/src/auth_verifier.rs
@@ -22,7 +22,7 @@ use thiserror::Error;
 
 const INFINITY: u64 = u64::MAX;
 
-pub static JWT_KEY: std::sync::LazyLock<ES256kKeyPair> = std::sync::LazyLock::new(|| {
+pub static PDS_JWT_KEYPAIR: std::sync::LazyLock<ES256kKeyPair> = std::sync::LazyLock::new(|| {
     let secp = Secp256k1::new();
     let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX").unwrap();
     let secret_key = SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
@@ -962,7 +962,7 @@ pub fn bearer_token_from_req(request: &Request) -> Result<Option<String>> {
 }
 
 pub fn verify_jwt(jwt: &str, verify_options: Option<VerificationOptions>) -> Result<JwtPayload> {
-    let claims = JWT_KEY
+    let claims = PDS_JWT_KEYPAIR
         .public_key()
         .verify_token::<CustomClaimObj>(jwt, verify_options)?;
 

--- a/rsky-pds/src/auth_verifier.rs
+++ b/rsky-pds/src/auth_verifier.rs
@@ -22,6 +22,17 @@ use thiserror::Error;
 
 const INFINITY: u64 = u64::MAX;
 
+pub static JWT_PUBLIC_KEY: std::sync::LazyLock<ES256kPublicKey> = std::sync::LazyLock::new(|| {
+    let secp = Secp256k1::new();
+    let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX").unwrap();
+    let secret_key =
+        SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
+    let jwt_key = Keypair::from_secret_key(&secp, &secret_key);
+    let key = ES256kKeyPair::from_bytes(jwt_key.secret_bytes().as_slice()).unwrap();
+
+    key.public_key()
+});
+
 #[derive(PartialEq, Clone, Debug)]
 pub enum AuthScope {
     Access,
@@ -163,7 +174,7 @@ impl<'r> FromRequest<'r> for Refresh {
             token,
             payload,
             audience,
-        } = match validate_bearer_token(req, vec![AuthScope::Refresh], Some(options)).await {
+        } = match validate_bearer_token(req, vec![AuthScope::Refresh], Some(options)) {
             Ok(result) => {
                 let payload = result.payload.clone();
                 match payload.jti {
@@ -432,7 +443,7 @@ impl<'r> FromRequest<'r> for RevokeRefreshToken {
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
         let mut options = VerificationOptions::default();
         options.max_validity = Some(Duration::from_secs(INFINITY));
-        match validate_bearer_token(req, vec![AuthScope::Refresh], Some(options)).await {
+        match validate_bearer_token(req, vec![AuthScope::Refresh], Some(options)) {
             Ok(result) => match result.payload.jti {
                 Some(jti) => Outcome::Success(RevokeRefreshToken { id: jti }),
                 None => {
@@ -717,7 +728,7 @@ pub async fn validate_bearer_access_token<'r>(
         token,
         audience,
         ..
-    } = validate_bearer_token(request, scopes, Some(options)).await?;
+    } = validate_bearer_token(request, scopes, Some(options))?;
     let is_privileged = vec![AuthScope::Access, AuthScope::AppPassPrivileged].contains(&scope);
     Ok(AccessOutput {
         credentials: Some(Credentials {
@@ -734,19 +745,14 @@ pub async fn validate_bearer_access_token<'r>(
     })
 }
 
-pub async fn validate_bearer_token<'r>(
+pub fn validate_bearer_token<'r>(
     request: &'r Request<'_>,
     scopes: Vec<AuthScope>,
     verify_options: Option<VerificationOptions>,
 ) -> Result<ValidatedBearer> {
     let token = bearer_token_from_req(request)?;
     if let Some(token) = token {
-        let secp = Secp256k1::new();
-        let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-        let secret_key =
-            SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
-        let jwt_key = Keypair::from_secret_key(&secp, &secret_key);
-        let payload = verify_jwt(token.clone(), jwt_key, verify_options).await?;
+        let payload = verify_jwt(&token, verify_options)?;
         let JwtPayload {
             sub, aud, scope, ..
         } = payload.clone();
@@ -797,7 +803,7 @@ pub async fn validate_access_token<'r>(
         token,
         audience,
         ..
-    } = validate_bearer_token(request, scopes, Some(options)).await?;
+    } = validate_bearer_token(request, scopes, Some(options))?;
     let ValidateAccessTokenOpts {
         check_takedown,
         check_deactivated,
@@ -958,14 +964,11 @@ pub fn bearer_token_from_req(request: &Request) -> Result<Option<String>> {
     }
 }
 
-pub async fn verify_jwt(
-    jwt: String,
-    jwt_key: Keypair,
+pub fn verify_jwt(
+    jwt: &str,
     verify_options: Option<VerificationOptions>,
 ) -> Result<JwtPayload> {
-    let key = ES256kKeyPair::from_bytes(jwt_key.secret_bytes().as_slice())?;
-    let public_key = key.public_key();
-    let claims = public_key.verify_token::<CustomClaimObj>(&jwt, verify_options)?;
+    let claims = JWT_PUBLIC_KEY.verify_token::<CustomClaimObj>(jwt, verify_options)?;
 
     Ok(JwtPayload {
         scope: AuthScope::from_str(&claims.custom.scope)?,

--- a/rsky-pds/src/auth_verifier.rs
+++ b/rsky-pds/src/auth_verifier.rs
@@ -25,8 +25,7 @@ const INFINITY: u64 = u64::MAX;
 pub static JWT_PUBLIC_KEY: std::sync::LazyLock<ES256kPublicKey> = std::sync::LazyLock::new(|| {
     let secp = Secp256k1::new();
     let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-    let secret_key =
-        SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
+    let secret_key = SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
     let jwt_key = Keypair::from_secret_key(&secp, &secret_key);
     let key = ES256kKeyPair::from_bytes(jwt_key.secret_bytes().as_slice()).unwrap();
 
@@ -964,10 +963,7 @@ pub fn bearer_token_from_req(request: &Request) -> Result<Option<String>> {
     }
 }
 
-pub fn verify_jwt(
-    jwt: &str,
-    verify_options: Option<VerificationOptions>,
-) -> Result<JwtPayload> {
+pub fn verify_jwt(jwt: &str, verify_options: Option<VerificationOptions>) -> Result<JwtPayload> {
     let claims = JWT_PUBLIC_KEY.verify_token::<CustomClaimObj>(jwt, verify_options)?;
 
     Ok(JwtPayload {

--- a/rsky-pds/src/auth_verifier.rs
+++ b/rsky-pds/src/auth_verifier.rs
@@ -22,14 +22,12 @@ use thiserror::Error;
 
 const INFINITY: u64 = u64::MAX;
 
-pub static JWT_PUBLIC_KEY: std::sync::LazyLock<ES256kPublicKey> = std::sync::LazyLock::new(|| {
+pub static JWT_KEY: std::sync::LazyLock<ES256kKeyPair> = std::sync::LazyLock::new(|| {
     let secp = Secp256k1::new();
     let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX").unwrap();
     let secret_key = SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
     let jwt_key = Keypair::from_secret_key(&secp, &secret_key);
-    let key = ES256kKeyPair::from_bytes(jwt_key.secret_bytes().as_slice()).unwrap();
-
-    key.public_key()
+    ES256kKeyPair::from_bytes(jwt_key.secret_bytes().as_slice()).unwrap()
 });
 
 #[derive(PartialEq, Clone, Debug)]
@@ -964,7 +962,9 @@ pub fn bearer_token_from_req(request: &Request) -> Result<Option<String>> {
 }
 
 pub fn verify_jwt(jwt: &str, verify_options: Option<VerificationOptions>) -> Result<JwtPayload> {
-    let claims = JWT_PUBLIC_KEY.verify_token::<CustomClaimObj>(jwt, verify_options)?;
+    let claims = JWT_KEY
+        .public_key()
+        .verify_token::<CustomClaimObj>(jwt, verify_options)?;
 
     Ok(JwtPayload {
         scope: AuthScope::from_str(&claims.custom.scope)?,

--- a/rsky-pds/src/auth_verifier.rs
+++ b/rsky-pds/src/auth_verifier.rs
@@ -18,11 +18,12 @@ use rsky_identity::types::DidDocument;
 use secp256k1::{Keypair, Secp256k1, SecretKey};
 use std::env;
 use std::str;
+use std::sync::LazyLock;
 use thiserror::Error;
 
 const INFINITY: u64 = u64::MAX;
 
-pub static PDS_JWT_KEYPAIR: std::sync::LazyLock<ES256kKeyPair> = std::sync::LazyLock::new(|| {
+pub static PDS_JWT_KEYPAIR: LazyLock<ES256kKeyPair> = LazyLock::new(|| {
     let secp = Secp256k1::new();
     let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX").unwrap();
     let secret_key = SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();

--- a/rsky-pds/src/context.rs
+++ b/rsky-pds/src/context.rs
@@ -2,19 +2,24 @@ use crate::account_manager::helpers::auth::ServiceJwtParams;
 use crate::xrpc_server::auth::create_service_auth_headers;
 use anyhow::Result;
 use reqwest::header::HeaderMap;
-use secp256k1::SecretKey;
+use secp256k1::{Keypair, Secp256k1, SecretKey};
 use std::env;
+use std::sync::LazyLock;
+
+pub static PDS_REPO_SIGNING_KEYPAIR: LazyLock<Keypair> = LazyLock::new(|| {
+    let secp = Secp256k1::new();
+    let private_key = env::var("PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX").unwrap();
+    let secret_key = SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
+    Keypair::from_secret_key(&secp, &secret_key)
+});
 
 pub async fn service_auth_headers(did: &str, aud: &str, lxm: &str) -> Result<HeaderMap> {
-    let private_key = env::var("PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX")?;
-    let keypair = SecretKey::from_slice(&hex::decode(private_key.as_bytes())?)?;
     create_service_auth_headers(ServiceJwtParams {
         iss: did.to_owned(),
         aud: aud.to_owned(),
         exp: None,
         lxm: Some(lxm.to_owned()),
         jti: None,
-        keypair,
     })
     .await
 }

--- a/rsky-pds/src/main.rs
+++ b/rsky-pds/src/main.rs
@@ -4,6 +4,7 @@ use rsky_pds::build_rocket;
 async fn main() {
     let _ = &rsky_pds::context::PDS_REPO_SIGNING_KEYPAIR;
     let _ = &rsky_pds::auth_verifier::PDS_JWT_KEYPAIR;
+    let _ = &rsky_pds::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 
     let subscriber = tracing_subscriber::FmtSubscriber::new();
     tracing::subscriber::set_global_default(subscriber).unwrap();

--- a/rsky-pds/src/main.rs
+++ b/rsky-pds/src/main.rs
@@ -2,9 +2,9 @@ use rsky_pds::build_rocket;
 
 #[rocket::main]
 async fn main() {
-    let _ = &rsky_pds::context::PDS_REPO_SIGNING_KEYPAIR;
-    let _ = &rsky_pds::auth_verifier::PDS_JWT_KEYPAIR;
-    let _ = &rsky_pds::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
+    let _ = &*rsky_pds::context::PDS_REPO_SIGNING_KEYPAIR;
+    let _ = &*rsky_pds::auth_verifier::PDS_JWT_KEYPAIR;
+    let _ = &*rsky_pds::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 
     let subscriber = tracing_subscriber::FmtSubscriber::new();
     tracing::subscriber::set_global_default(subscriber).unwrap();

--- a/rsky-pds/src/main.rs
+++ b/rsky-pds/src/main.rs
@@ -2,6 +2,7 @@ use rsky_pds::build_rocket;
 
 #[rocket::main]
 async fn main() {
+    let _ = &rsky_pds::auth_verifier::JWT_KEY;
     let subscriber = tracing_subscriber::FmtSubscriber::new();
     tracing::subscriber::set_global_default(subscriber).unwrap();
     let _ = build_rocket(None).await.launch().await;

--- a/rsky-pds/src/main.rs
+++ b/rsky-pds/src/main.rs
@@ -2,7 +2,7 @@ use rsky_pds::build_rocket;
 
 #[rocket::main]
 async fn main() {
-    let _ = &rsky_pds::auth_verifier::JWT_KEY;
+    let _ = &rsky_pds::auth_verifier::PDS_JWT_KEYPAIR;
     let subscriber = tracing_subscriber::FmtSubscriber::new();
     tracing::subscriber::set_global_default(subscriber).unwrap();
     let _ = build_rocket(None).await.launch().await;

--- a/rsky-pds/src/main.rs
+++ b/rsky-pds/src/main.rs
@@ -2,7 +2,9 @@ use rsky_pds::build_rocket;
 
 #[rocket::main]
 async fn main() {
+    let _ = &rsky_pds::context::PDS_REPO_SIGNING_KEYPAIR;
     let _ = &rsky_pds::auth_verifier::PDS_JWT_KEYPAIR;
+
     let subscriber = tracing_subscriber::FmtSubscriber::new();
     tracing::subscriber::set_global_default(subscriber).unwrap();
     let _ = build_rocket(None).await.launch().await;

--- a/rsky-pds/src/read_after_write/viewer.rs
+++ b/rsky-pds/src/read_after_write/viewer.rs
@@ -44,8 +44,6 @@ use rsky_lexicon::app::bsky::graph::ListView;
 use rsky_repo::types::Ids;
 use rsky_syntax::aturi::AtUri;
 use rsky_syntax::handle::INVALID_HANDLE;
-use secp256k1::SecretKey;
-use std::env;
 use std::str::FromStr;
 
 pub type Agent = AtpServiceClient<ReqwestClient>;
@@ -144,16 +142,12 @@ impl LocalViewer {
         match &self.appview_did {
             None => bail!("Could not find bsky appview did"),
             Some(appview_did) => {
-                let private_key = env::var("PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX").unwrap();
-                let keypair =
-                    SecretKey::from_slice(&hex::decode(private_key.as_bytes()).unwrap()).unwrap();
                 create_service_auth_headers(ServiceJwtParams {
                     iss: did.to_owned(),
                     aud: appview_did.clone(),
                     exp: None,
                     lxm: Some(lxm.to_owned()),
                     jti: None,
-                    keypair,
                 })
                 .await
             }

--- a/rsky-relay/src/server/server.rs
+++ b/rsky-relay/src/server/server.rs
@@ -321,8 +321,7 @@ impl Server {
                     "{\"error\":\"InvalidRequest\",\"message\":\"invalid or missing hostname\"}",
                 )
             }
-            ("POST", PATH_ADMIN_BAN | PATH_ADMIN_UNBAN)
-            | ("GET", PATH_ADMIN_LIST_BANS) => {
+            ("POST", PATH_ADMIN_BAN | PATH_ADMIN_UNBAN) | ("GET", PATH_ADMIN_LIST_BANS) => {
                 self.handle_admin(&mut stream, url.path(), &url, is_admin_authed)
             }
             _ => write_response(

--- a/rsky-repo/src/repo.rs
+++ b/rsky-repo/src/repo.rs
@@ -152,7 +152,7 @@ impl Repo {
     pub async fn format_init_commit(
         storage: Arc<RwLock<dyn RepoStorage>>,
         did: String,
-        keypair: Keypair,
+        keypair: &Keypair,
         initial_writes: Option<Vec<RecordCreateOrUpdateOp>>,
     ) -> Result<CommitData> {
         let mut new_blocks = BlockMap::new();
@@ -204,7 +204,7 @@ impl Repo {
     pub async fn create(
         storage: Arc<RwLock<dyn RepoStorage>>,
         did: String,
-        keypair: Keypair,
+        keypair: &Keypair,
         initial_writes: Option<Vec<RecordCreateOrUpdateOp>>,
     ) -> Result<Self> {
         let commit =
@@ -215,7 +215,7 @@ impl Repo {
     pub async fn format_commit(
         &mut self,
         to_write: RecordWriteEnum,
-        keypair: Keypair,
+        keypair: &Keypair,
     ) -> Result<CommitData> {
         let writes = match to_write {
             RecordWriteEnum::List(to_write) => to_write,
@@ -309,13 +309,13 @@ impl Repo {
     pub async fn apply_writes(
         &mut self,
         to_write: RecordWriteEnum,
-        keypair: Keypair,
+        keypair: &Keypair,
     ) -> Result<Self> {
         let commit = self.format_commit(to_write, keypair).await?;
         self.apply_commit(commit).await
     }
 
-    pub fn format_resign_commit(&self, rev: String, keypair: Keypair) -> Result<CommitData> {
+    pub fn format_resign_commit(&self, rev: String, keypair: &Keypair) -> Result<CommitData> {
         let commit = util::sign_commit(
             UnsignedCommit {
                 did: self.did(),
@@ -339,7 +339,7 @@ impl Repo {
         })
     }
 
-    pub async fn resign_commit(&mut self, rev: String, keypair: Keypair) -> Result<Self> {
+    pub async fn resign_commit(&mut self, rev: String, keypair: &Keypair) -> Result<Self> {
         let formatted = self.format_resign_commit(rev, keypair)?;
         self.apply_commit(formatted).await
     }
@@ -401,7 +401,7 @@ mod tests {
             repo_data.insert(coll_name.to_string(), coll_data);
         }
         let writes = RecordWriteEnum::List(writes);
-        let updated = repo.apply_writes(writes, keypair).await?;
+        let updated = repo.apply_writes(writes, &keypair).await?;
         Ok(FillRepoOutput {
             repo: updated,
             data: repo_data,
@@ -547,7 +547,7 @@ mod tests {
             repo_data.insert(coll_name.to_string(), coll_data);
         }
         let commit = repo
-            .format_commit(RecordWriteEnum::List(writes), keypair)
+            .format_commit(RecordWriteEnum::List(writes), &keypair)
             .await?;
         Ok(FormatEditOutput {
             commit,
@@ -561,7 +561,7 @@ mod tests {
         let secp = Secp256k1::new();
         let keypair = Keypair::new(&secp, &mut thread_rng());
         let did_key = encode_did_key(&keypair.public_key());
-        let _ = Repo::create(Arc::new(RwLock::new(storage)), did_key, keypair, None).await?;
+        let _ = Repo::create(Arc::new(RwLock::new(storage)), did_key, &keypair, None).await?;
         Ok(())
     }
 
@@ -574,7 +574,7 @@ mod tests {
         let repo = Repo::create(
             Arc::new(RwLock::new(storage)),
             did_key.clone(),
-            keypair,
+            &keypair,
             None,
         )
         .await?;
@@ -592,7 +592,7 @@ mod tests {
         let mut repo = Repo::create(
             Arc::new(RwLock::new(storage)),
             did_key.clone(),
-            keypair,
+            &keypair,
             None,
         )
         .await?;
@@ -606,7 +606,7 @@ mod tests {
                     rkey: rkey.clone(),
                     record: record.clone(),
                 })),
-                keypair,
+                &keypair,
             )
             .await?;
 
@@ -624,7 +624,7 @@ mod tests {
                     rkey: rkey.clone(),
                     record: updated_record.clone(),
                 })),
-                keypair,
+                &keypair,
             )
             .await?;
         let got = repo.get_record(COLL_NAME.to_string(), rkey.clone()).await?;
@@ -639,7 +639,7 @@ mod tests {
                     collection: COLL_NAME.to_string(),
                     rkey: rkey.clone(),
                 })),
-                keypair,
+                &keypair,
             )
             .await?;
         let got = repo.get_record(COLL_NAME.to_string(), rkey.clone()).await?;
@@ -656,7 +656,7 @@ mod tests {
         let mut repo = Repo::create(
             Arc::new(RwLock::new(storage)),
             did_key.clone(),
-            keypair,
+            &keypair,
             None,
         )
         .await?;
@@ -677,7 +677,7 @@ mod tests {
         let mut repo = Repo::create(
             Arc::new(RwLock::new(storage)),
             did_key.clone(),
-            keypair,
+            &keypair,
             None,
         )
         .await?;
@@ -711,7 +711,7 @@ mod tests {
         let mut repo = Repo::create(
             Arc::new(RwLock::new(storage)),
             did_key.clone(),
-            keypair,
+            &keypair,
             None,
         )
         .await?;
@@ -745,7 +745,7 @@ mod tests {
         let mut repo = Repo::create(
             Arc::new(RwLock::new(storage)),
             did_key.clone(),
-            keypair,
+            &keypair,
             None,
         )
         .await?;
@@ -779,7 +779,7 @@ mod tests {
         let mut repo = Repo::create(
             Arc::new(RwLock::new(storage)),
             did_key.clone(),
-            keypair,
+            &keypair,
             None,
         )
         .await?;
@@ -822,7 +822,7 @@ mod tests {
         let mut repo = Repo::create(
             Arc::new(RwLock::new(blockstore)),
             did.to_string(),
-            keypair,
+            &keypair,
             None,
         )
         .await?;
@@ -839,7 +839,7 @@ mod tests {
                         rkey,
                         record: serde_json::from_value(record.clone())?,
                     })),
-                    keypair,
+                    &keypair,
                 )
                 .await?;
         }
@@ -855,7 +855,7 @@ mod tests {
                         collection: collection.to_string(),
                         rkey: keys[0].clone(),
                     })),
-                    keypair,
+                    &keypair,
                 )
                 .await?;
             let car = blocks_to_car_file(Some(&commit.cid), commit.new_blocks).await?;
@@ -888,7 +888,7 @@ mod tests {
                         collection: collection.to_string(),
                         rkey: rkey.clone(),
                     })),
-                    keypair,
+                    &keypair,
                 )
                 .await?;
             let car = blocks_to_car_file(Some(&commit.cid), commit.relevant_blocks.clone()).await?;
@@ -919,7 +919,7 @@ mod tests {
         let mut repo = Repo::create(
             Arc::new(RwLock::new(storage)),
             repo_did.to_string(),
-            keypair,
+            &keypair,
             None,
         )
         .await?;
@@ -954,7 +954,7 @@ mod tests {
         let mut repo = Repo::create(
             Arc::new(RwLock::new(storage)),
             repo_did.to_string(),
-            keypair,
+            &keypair,
             None,
         )
         .await?;
@@ -993,7 +993,7 @@ mod tests {
         let mut repo = Repo::create(
             Arc::new(RwLock::new(storage)),
             repo_did.to_string(),
-            keypair,
+            &keypair,
             None,
         )
         .await?;
@@ -1033,7 +1033,7 @@ mod tests {
         let mut repo = Repo::create(
             Arc::new(RwLock::new(storage)),
             repo_did.to_string(),
-            keypair,
+            &keypair,
             None,
         )
         .await?;
@@ -1074,7 +1074,7 @@ mod tests {
         let mut repo = Repo::create(
             Arc::new(RwLock::new(storage)),
             repo_did.to_string(),
-            keypair,
+            &keypair,
             None,
         )
         .await?;
@@ -1114,7 +1114,7 @@ mod tests {
         let mut repo = Repo::create(
             Arc::new(RwLock::new(storage)),
             repo_did.to_string(),
-            keypair,
+            &keypair,
             None,
         )
         .await?;
@@ -1170,7 +1170,7 @@ mod tests {
         let mut repo = Repo::create(
             Arc::new(RwLock::new(storage)),
             repo_did.to_string(),
-            keypair,
+            &keypair,
             None,
         )
         .await?;
@@ -1211,7 +1211,7 @@ mod tests {
         let mut repo = Repo::create(
             Arc::new(RwLock::new(storage)),
             repo_did.to_string(),
-            keypair,
+            &keypair,
             None,
         )
         .await?;

--- a/rsky-repo/src/util.rs
+++ b/rsky-repo/src/util.rs
@@ -17,7 +17,7 @@ use std::fmt::Display;
 use std::str::FromStr;
 use tokio::try_join;
 
-pub fn sign_commit(unsigned: UnsignedCommit, keypair: Keypair) -> Result<Commit> {
+pub fn sign_commit(unsigned: UnsignedCommit, keypair: &Keypair) -> Result<Commit> {
     let commit_sig = sign_without_indexmap(&unsigned, &keypair.secret_key())?;
     Ok(Commit {
         did: unsigned.did,


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes in this PR -->
This PR takes the JWT public key derivation from the `PDS_JWT_KEY_K256_PRIVATE_KEY_HEX` env var that was spread across a couple of functions and being run per-request/validation, and shifts it up into a `static` initialization that is only run on startup. It also drops the `async` from two functions (`verify_jwt` + `validate_bearer_token`) which do not perform any async operations or contain any `.await`s.

The overall goal of this change is to reduce the amount of work on the server for each authenticated request.

## Related Issues
<!-- Link any relevant issues -->

## Changes
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [x] Other (please specify): perf optimization

## Checklist
- [x] I have tested the changes (including writing unit tests).
- [x] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp) TS ATproto is storing this caching the [`_jwt_key`](https://github.com/bluesky-social/atproto/blob/700074694157718e33c974b666f4563f9647a50c/packages/pds/src/auth-verifier.ts#L469) on the class instance, but because these functions in Rust are bare and not associated to a struct, using `LazyLock` as a `static` seemed like a reasonable compromize
- [ ] I have updated relevant documentation. - n/a
- [x] I have formatted my code correctly
- [ ] I have provided examples for how this code works or will be used - n/a

Super excited about the project and if this kind of submission isn't the kind of thing you're looking for I'd love to find another better way to help out!