### PR TITLE
Fix: omit None fields in actor lexicon view structs

### DIFF
--- a/rsky-lexicon/src/app/bsky/actor.rs
+++ b/rsky-lexicon/src/app/bsky/actor.rs
@@ -18,14 +18,21 @@ pub struct PutPreferencesInput {
 #[serde(rename = "app.bsky.actor.profile")]
 #[serde(rename_all = "camelCase")]
 pub struct Profile {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// Small image to be displayed next to posts from account. AKA, 'profile picture'
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub avatar: Option<Blob>,
     /// Larger horizontal image to display behind profile view.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub banner: Option<Blob>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<ProfileLabels>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub joined_via_starter_pack: Option<StrongRef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_at: Option<DateTime<Utc>>,
 }
 
@@ -41,11 +48,17 @@ pub enum ProfileLabels {
 pub struct ProfileViewBasic {
     pub did: String,
     pub handle: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub avatar: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub associated: Option<RefProfileAssociated>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub viewer: Option<ViewerState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<Label>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_at: Option<String>,
 }
 
@@ -54,10 +67,14 @@ pub struct ProfileViewBasic {
 pub struct ProfileView {
     pub did: String,
     pub handle: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub avatar: Option<String>,
     pub labels: Vec<Label>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub indexed_at: Option<String>,
 }
 
@@ -66,18 +83,30 @@ pub struct ProfileView {
 pub struct ProfileViewDetailed {
     pub did: String,
     pub handle: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub avatar: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub banner: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub followers_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub follows_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub posts_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub associated: Option<RefProfileAssociated>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub joined_via_starter_pack: Option<StarterPackViewBasic>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub viewer: Option<ViewerState>,
     pub labels: Vec<Label>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub indexed_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_at: Option<String>,
 }
 
@@ -90,16 +119,22 @@ pub struct GetProfilesOutput {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RefProfileAssociated {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub lists: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub feedgens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub starter_packs: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub labeler: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat: Option<RefProfileAssociatedChat>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RefProfileAssociatedChat {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_incoming: Option<AssociatedChatAllowIncoming>,
 }
 
@@ -116,12 +151,19 @@ pub enum AssociatedChatAllowIncoming {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ViewerState {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub muted: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub muted_by_list: Option<ListViewBasic>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub blocked_by: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub blocking_by_list: Option<ListViewBasic>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub following: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub followed_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub known_followers: Option<KnownFollowers>,
 }
 
@@ -185,6 +227,7 @@ impl RefPreferences {
 #[serde(rename_all = "camelCase")]
 pub struct ContentLabelPref {
     // Which labeler does this preference apply to? If undefined, applies globally.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub labeler_did: Option<String>,
     pub label: String,
     pub visibility: ContentLabelVisibility,
@@ -226,6 +269,7 @@ pub struct SavedFeedsPrefV2 {
 pub struct SavedFeedsPref {
     pub pinned: Vec<String>,
     pub saved: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timeline_index: Option<i64>,
 }
 
@@ -241,14 +285,19 @@ pub struct FeedViewPref {
     // The URI of the feed, or an identifier which describes the feed.
     pub feed: String,
     // Hide replies in the feed.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hide_replies: Option<bool>,
     // Hide replies in the feed if they are not by followed users.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hide_replies_by_unfollowed: Option<bool>,
     // Hide replies in the feed if they do not have this number of likes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hide_replies_by_like_count: Option<i64>,
     // Hide reposts in the feed.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hide_reposts: Option<bool>,
     // Hide quote posts in the feed.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hide_quote_posts: Option<bool>,
 }
 
@@ -256,8 +305,10 @@ pub struct FeedViewPref {
 #[serde(rename_all = "camelCase")]
 pub struct ThreadViewPref {
     // Sorting mode for threads.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<ThreadViewSort>,
     // Show followed users at the top of all replies.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub prioritize_followed_users: Option<bool>,
 }
 
@@ -315,9 +366,11 @@ pub struct AdultContentPref {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BskyAppStatePref {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub active_progress_guide: Option<BskyAppProgressGuide>,
     // An array of tokens which identify nudges (modals, popups, tours, highlight dots)
     // that should be shown to the user.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub queued_nudges: Option<Vec<String>>,
 }
 
@@ -336,4 +389,121 @@ pub struct LabelersPref {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct LabelersPrefItem {
     pub did: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_view_basic_omits_none_fields() {
+        let view = ProfileViewBasic {
+            did: "did:plc:abc".to_string(),
+            handle: "alice.bsky.social".to_string(),
+            display_name: None,
+            avatar: None,
+            associated: None,
+            viewer: None,
+            labels: None,
+            created_at: None,
+        };
+        let json = serde_json::to_value(&view).unwrap();
+        assert!(!json.as_object().unwrap().contains_key("displayName"));
+        assert!(!json.as_object().unwrap().contains_key("avatar"));
+        assert!(!json.as_object().unwrap().contains_key("associated"));
+        assert!(!json.as_object().unwrap().contains_key("viewer"));
+        assert!(!json.as_object().unwrap().contains_key("labels"));
+        assert!(!json.as_object().unwrap().contains_key("createdAt"));
+        assert_eq!(json["did"], "did:plc:abc");
+        assert_eq!(json["handle"], "alice.bsky.social");
+    }
+
+    #[test]
+    fn profile_view_detailed_omits_none_fields() {
+        let view = ProfileViewDetailed {
+            did: "did:plc:abc".to_string(),
+            handle: "alice.bsky.social".to_string(),
+            display_name: None,
+            description: None,
+            avatar: None,
+            banner: None,
+            followers_count: None,
+            follows_count: None,
+            posts_count: None,
+            associated: None,
+            joined_via_starter_pack: None,
+            viewer: None,
+            labels: vec![],
+            indexed_at: None,
+            created_at: None,
+        };
+        let json = serde_json::to_value(&view).unwrap();
+        let obj = json.as_object().unwrap();
+        for key in &[
+            "displayName",
+            "description",
+            "avatar",
+            "banner",
+            "followersCount",
+            "followsCount",
+            "postsCount",
+            "associated",
+            "joinedViaStarterPack",
+            "viewer",
+            "indexedAt",
+            "createdAt",
+        ] {
+            assert!(!obj.contains_key(*key), "expected key `{key}` to be absent");
+        }
+    }
+
+    #[test]
+    fn viewer_state_omits_none_fields() {
+        let viewer = ViewerState {
+            muted: None,
+            muted_by_list: None,
+            blocked_by: None,
+            blocking_by_list: None,
+            following: None,
+            followed_by: None,
+            known_followers: None,
+        };
+        let json = serde_json::to_value(&viewer).unwrap();
+        let obj = json.as_object().unwrap();
+        assert!(obj.is_empty(), "expected empty object, got: {obj:?}");
+    }
+
+    #[test]
+    fn ref_profile_associated_omits_none_fields() {
+        let associated = RefProfileAssociated {
+            lists: None,
+            feedgens: None,
+            starter_packs: None,
+            labeler: None,
+            chat: None,
+        };
+        let json = serde_json::to_value(&associated).unwrap();
+        let obj = json.as_object().unwrap();
+        assert!(obj.is_empty(), "expected empty object, got: {obj:?}");
+    }
+
+    #[test]
+    fn profile_view_basic_includes_present_fields() {
+        let view = ProfileViewBasic {
+            did: "did:plc:abc".to_string(),
+            handle: "alice.bsky.social".to_string(),
+            display_name: Some("Alice".to_string()),
+            avatar: Some("https://cdn.example.com/avatar.jpg".to_string()),
+            associated: None,
+            viewer: None,
+            labels: None,
+            created_at: Some("2024-01-01T00:00:00Z".to_string()),
+        };
+        let json = serde_json::to_value(&view).unwrap();
+        assert_eq!(json["displayName"], "Alice");
+        assert_eq!(json["avatar"], "https://cdn.example.com/avatar.jpg");
+        assert_eq!(json["createdAt"], "2024-01-01T00:00:00Z");
+        assert!(!json.as_object().unwrap().contains_key("associated"));
+        assert!(!json.as_object().unwrap().contains_key("viewer"));
+    }
 }


### PR DESCRIPTION
Fixes #163

## What

Added `#[serde(skip_serializing_if = "Option::is_none")]` to all `Option<T>` fields in the actor lexicon view and preference structs:

- `Profile`, `ProfileViewBasic`, `ProfileView`, `ProfileViewDetailed`
- `RefProfileAssociated`, `RefProfileAssociatedChat`, `ViewerState`
- `ContentLabelPref`, `SavedFeedsPref`, `FeedViewPref`, `ThreadViewPref`, `BskyAppStatePref`

## Why

Per the AT Protocol spec, optional is not automatically nullable. Unset `Option<T>` fields were serialized as explicit `null` (e.g. `displayName: null`, `avatar: null`, `viewer.knownFollowers: null`), violating the lexicon contract and causing client-visible failures in the read-after-write path.

## Testing

5 unit tests added in `rsky-lexicon::app::bsky::actor::tests` covering `None` fields being absent and `Some` fields being present in serialized output. All compile checks pass for `rsky-pds`, `rsky-feedgen`, `rsky-firehose`, `rsky-labeler`.

## Checklist

- [x] Changes have been tested, including unit tests
- [x] Implementation aligns with the canonical TypeScript implementation and/or the atproto spec
- [x] Relevant documentation — n/a
- [x] Code is formatted (`cargo fmt`)
- [x] Examples: unit tests serve as usage examples