### PR TITLE
Fix: serialize response body not wrapper struct in read-after-write

### DIFF
--- a/rsky-pds/src/read_after_write/util.rs
+++ b/rsky-pds/src/read_after_write/util.rs
@@ -60,7 +60,7 @@ impl<'r, T: Serialize> Responder<'r, 'static> for ReadAfterWriteResponse<T> {
                 let mut builder = Response::build();
                 let encoding = handler_response.encoding.clone();
                 let headers = handler_response.headers.clone();
-                let bytes = serde_json::to_vec(&handler_response).unwrap();
+                let bytes = serde_json::to_vec(&handler_response.body).unwrap();
                 builder.sized_body(bytes.len(), Cursor::new(bytes));
                 builder
                     .status(Status::Ok)
@@ -191,6 +191,61 @@ pub fn format_munged_response<T: DeserializeOwned + serde::Serialize>(
             }
         },
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct TestBody {
+        did: String,
+        handle: String,
+    }
+
+    #[test]
+    fn handler_response_serializes_body_not_wrapper() {
+        let response: HandlerResponse<TestBody> = HandlerResponse {
+            encoding: "application/json".to_string(),
+            body: TestBody {
+                did: "did:plc:abc".to_string(),
+                handle: "alice.bsky.social".to_string(),
+            },
+            headers: None,
+        };
+
+        let bytes = serde_json::to_vec(&response.body).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        // Body fields are present at the top level
+        assert_eq!(value["did"], "did:plc:abc");
+        assert_eq!(value["handle"], "alice.bsky.social");
+
+        // Wrapper fields must not appear — that was the bug
+        assert!(!value.as_object().unwrap().contains_key("encoding"));
+        assert!(!value.as_object().unwrap().contains_key("body"));
+        assert!(!value.as_object().unwrap().contains_key("headers"));
+    }
+
+    #[test]
+    fn handler_response_wrapper_shape_is_wrong_for_xrpc() {
+        // Demonstrates what the bug looked like: serializing the wrapper
+        // instead of .body produces an envelope that clients cannot parse.
+        let response: HandlerResponse<TestBody> = HandlerResponse {
+            encoding: "application/json".to_string(),
+            body: TestBody {
+                did: "did:plc:abc".to_string(),
+                handle: "alice.bsky.social".to_string(),
+            },
+            headers: None,
+        };
+
+        let wrapped = serde_json::to_value(&response).unwrap();
+        // The wrapper contains envelope fields — this is what clients used to receive
+        assert_eq!(wrapped["encoding"], json!("application/json"));
+        assert!(wrapped.as_object().unwrap().contains_key("body"));
+    }
 }
 
 pub fn nodejs_format(format: &str, args: &[&dyn std::fmt::Display]) -> String {


### PR DESCRIPTION
Fixes #162

## What

In `rsky-pds/src/read_after_write/util.rs`, the `HandlerResponse` arm of the `Responder` impl was serializing `&handler_response` (the wrapper struct) instead of `&handler_response.body`.

```rust
// before
let bytes = serde_json::to_vec(&handler_response).unwrap();

// after
let bytes = serde_json::to_vec(&handler_response.body).unwrap();
```

## Why

Clients were receiving `{"encoding":"application/json","body":{...},"headers":null}` instead of plain XRPC JSON, breaking `app.bsky.actor.getProfile`, `app.bsky.actor.getProfiles`, and `app.bsky.feed.getAuthorFeed` on the read-after-write path.

## Testing

2 unit tests added in `rsky-pds::read_after_write::util::tests`:
- `handler_response_serializes_body_not_wrapper` — verifies `.body` produces flat XRPC JSON
- `handler_response_wrapper_shape_is_wrong_for_xrpc` — documents the incorrect shape the bug produced

## Checklist

- [x] Changes have been tested, including unit tests
- [x] Implementation aligns with the canonical TypeScript implementation and/or the atproto spec
- [x] Relevant documentation — n/a
- [x] Code is formatted (`cargo fmt`)
- [x] Examples: unit tests serve as usage examples