### PR TITLE
Fix: increment postsCount by local writes in read-after-write profile munge

### DIFF
--- a/rsky-pds/src/apis/app/bsky/actor/get_profile.rs
+++ b/rsky-pds/src/apis/app/bsky/actor/get_profile.rs
@@ -96,7 +96,7 @@ pub fn get_profile_munge(
             if original.did != requester {
                 return Ok(original);
             }
-            Ok(local_viewer.update_profile_detailed(original, profile.record))
+            Ok(local_viewer.update_profile_detailed(original, profile.record, local.posts.len()))
         }
     }
 }

--- a/rsky-pds/src/apis/app/bsky/actor/get_profiles.rs
+++ b/rsky-pds/src/apis/app/bsky/actor/get_profiles.rs
@@ -92,7 +92,11 @@ pub fn get_profiles_munge(
                     if prof.did != requester {
                         prof
                     } else {
-                        local_viewer.update_profile_detailed(prof, profile.record.clone())
+                        local_viewer.update_profile_detailed(
+                            prof,
+                            profile.record.clone(),
+                            local.posts.len(),
+                        )
                     }
                 })
                 .collect::<Vec<ProfileViewDetailed>>();

--- a/rsky-pds/src/read_after_write/viewer.rs
+++ b/rsky-pds/src/read_after_write/viewer.rs
@@ -565,6 +565,7 @@ impl LocalViewer {
         &self,
         view: ProfileViewDetailed,
         record: Profile,
+        local_posts_count: usize,
     ) -> ProfileViewDetailed {
         let ProfileViewDetailed {
             did,
@@ -620,7 +621,7 @@ impl LocalViewer {
             },
             followers_count,
             follows_count,
-            posts_count,
+            posts_count: apply_local_posts_count(posts_count, local_posts_count),
             associated,
             joined_via_starter_pack,
             viewer,
@@ -650,6 +651,32 @@ impl LocalViewer {
             )
             .build();
         Ok(AtpServiceClient::new(client))
+    }
+}
+
+/// Adds locally written posts to an upstream posts_count.
+/// Returns None if the upstream count is unknown.
+pub fn apply_local_posts_count(upstream: Option<usize>, local_posts: usize) -> Option<usize> {
+    upstream.map(|c| c + local_posts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_posts_added_to_upstream_count() {
+        assert_eq!(apply_local_posts_count(Some(5), 3), Some(8));
+    }
+
+    #[test]
+    fn zero_local_posts_leaves_count_unchanged() {
+        assert_eq!(apply_local_posts_count(Some(10), 0), Some(10));
+    }
+
+    #[test]
+    fn unknown_upstream_count_stays_none() {
+        assert_eq!(apply_local_posts_count(None, 5), None);
     }
 }
 


### PR DESCRIPTION
Fixes #164

## What

`update_profile_detailed` in `read_after_write/viewer.rs` now accepts a `local_posts_count: usize` parameter and adds it to the upstream `posts_count` via a new `apply_local_posts_count` helper. Both call sites (`get_profile_munge` and `get_profiles_munge`) pass `local.posts.len()`.

## Why

After `createRecord`, the read-after-write munge was overlaying profile-record fields (`displayName`, `description`, `avatar`, `banner`) but passing upstream `followers_count`, `follows_count`, and `posts_count` through unchanged. The stale `postsCount` caused `bsky.app` to render a blank profile shell immediately after a post, because the appview response was inconsistent with the local feed state.

## Testing

3 unit tests for `apply_local_posts_count` in `read_after_write::viewer::tests`:
- local posts are added to the upstream count
- zero local posts leave the count unchanged
- `None` upstream count stays `None` (unknown, not guessed)

Full `LocalViewer`-level integration testing is not feasible without a live database, which is noted as a known limitation.

## Checklist

- [x] Changes have been tested, including unit tests
- [x] Implementation aligns with the canonical TypeScript implementation and/or the atproto spec
- [x] Relevant documentation — n/a
- [x] Code is formatted (`cargo fmt`)
- [x] Examples: unit tests serve as usage examples