### PR TITLE
Fix: replace panicking unwrap() in datetime parsers

### DIFF
--- a/rsky-common/src/time.rs
+++ b/rsky-common/src/time.rs
@@ -1,5 +1,5 @@
 use crate::RFC3339_VARIANT;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use chrono::offset::Utc as UtcOffset;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use std::time::SystemTime;
@@ -18,11 +18,16 @@ pub fn less_than_ago_s(time: DateTime<UtcOffset>, range: i32) -> bool {
     now < x
 }
 
-pub fn from_str_to_micros(str: &String) -> i64 {
-    NaiveDateTime::parse_from_str(str, RFC3339_VARIANT)
-        .unwrap()
-        .and_utc()
-        .timestamp_micros()
+/// Parse a datetime string to microseconds since epoch.
+/// Tries the primary RFC3339 variant format first, then falls back to
+/// full RFC 3339 parsing (handles `+00:00` offsets and other variants).
+pub fn from_str_to_micros(str: &str) -> Result<i64> {
+    if let Ok(dt) = NaiveDateTime::parse_from_str(str, RFC3339_VARIANT) {
+        return Ok(dt.and_utc().timestamp_micros());
+    }
+    DateTime::parse_from_rfc3339(str)
+        .map(|dt| dt.timestamp_micros())
+        .map_err(|e| anyhow!("failed to parse datetime {:?}: {}", str, e))
 }
 
 pub fn from_str_to_millis(str: &String) -> Result<i64> {
@@ -31,10 +36,16 @@ pub fn from_str_to_millis(str: &String) -> Result<i64> {
         .timestamp_millis())
 }
 
-pub fn from_str_to_utc(str: &String) -> DateTime<UtcOffset> {
-    NaiveDateTime::parse_from_str(str, RFC3339_VARIANT)
-        .unwrap()
-        .and_utc()
+/// Parse a datetime string to a UTC DateTime.
+/// Tries the primary RFC3339 variant format first, then falls back to
+/// full RFC 3339 parsing (handles `+00:00` offsets and other variants).
+pub fn from_str_to_utc(str: &str) -> Result<DateTime<UtcOffset>> {
+    if let Ok(dt) = NaiveDateTime::parse_from_str(str, RFC3339_VARIANT) {
+        return Ok(dt.and_utc());
+    }
+    DateTime::parse_from_rfc3339(str)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| anyhow!("failed to parse datetime {:?}: {}", str, e))
 }
 
 #[allow(deprecated)]
@@ -53,4 +64,50 @@ pub fn from_millis_to_utc(millis: i64) -> DateTime<UtcOffset> {
 
 pub fn from_millis_to_str(millis: i64) -> String {
     format!("{}", from_millis_to_utc(millis).format(RFC3339_VARIANT))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_PRIMARY: &str = "2023-11-14T22:13:20.000Z";
+    const SAMPLE_OFFSET: &str = "2023-11-14T22:13:20+00:00";
+
+    #[test]
+    fn from_str_to_micros_parses_primary_format() {
+        assert!(from_str_to_micros(SAMPLE_PRIMARY).is_ok());
+    }
+
+    #[test]
+    fn from_str_to_micros_parses_rfc3339_with_offset() {
+        // Fallback: RFC 3339 with +00:00 offset — same instant as Z suffix
+        let with_z = from_str_to_micros(SAMPLE_PRIMARY).unwrap();
+        let with_offset = from_str_to_micros(SAMPLE_OFFSET).unwrap();
+        assert_eq!(with_z, with_offset);
+    }
+
+    #[test]
+    fn from_str_to_micros_returns_err_on_invalid_input() {
+        assert!(from_str_to_micros("not-a-date").is_err());
+        assert!(from_str_to_micros("").is_err());
+    }
+
+    #[test]
+    fn from_str_to_utc_parses_primary_format() {
+        assert!(from_str_to_utc(SAMPLE_PRIMARY).is_ok());
+    }
+
+    #[test]
+    fn from_str_to_utc_parses_rfc3339_with_offset() {
+        // Both formats should resolve to the same UTC instant
+        let with_z = from_str_to_utc(SAMPLE_PRIMARY).unwrap();
+        let with_offset = from_str_to_utc(SAMPLE_OFFSET).unwrap();
+        assert_eq!(with_z, with_offset);
+    }
+
+    #[test]
+    fn from_str_to_utc_returns_err_on_invalid_input() {
+        assert!(from_str_to_utc("not-a-date").is_err());
+        assert!(from_str_to_utc("").is_err());
+    }
 }

--- a/rsky-pds/src/account_manager/helpers/email_token.rs
+++ b/rsky-pds/src/account_manager/helpers/email_token.rs
@@ -61,7 +61,7 @@ pub async fn assert_valid_token(
         })
         .await?;
     if let Some(res) = res {
-        let requested_at = from_str_to_utc(&res.requested_at);
+        let requested_at = from_str_to_utc(&res.requested_at)?;
         let expired = !less_than_ago_s(requested_at, expiration_len);
         if expired {
             bail!("Token is expired")
@@ -93,7 +93,7 @@ pub async fn assert_valid_token_and_find_did(
         })
         .await?;
     if let Some(res) = res {
-        let requested_at = from_str_to_utc(&res.requested_at);
+        let requested_at = from_str_to_utc(&res.requested_at)?;
         let expired = !less_than_ago_s(requested_at, expiration_len);
         if expired {
             bail!("Token is expired")

--- a/rsky-pds/src/account_manager/mod.rs
+++ b/rsky-pds/src/account_manager/mod.rs
@@ -277,7 +277,7 @@ impl AccountManager {
 
             // Shorten the refresh token lifespan down from its
             // original expiration time to its revocation grace period.
-            let prev_expires_at = from_str_to_micros(&token.expires_at);
+            let prev_expires_at = from_str_to_micros(&token.expires_at)?;
 
             const REFRESH_GRACE_MS: i32 = 2 * HOUR;
             let grace_expires_at = dt.timestamp_micros() + REFRESH_GRACE_MS as i64;

--- a/rsky-pds/src/apis/com/atproto/sync/subscribe_repos.rs
+++ b/rsky-pds/src/apis/com/atproto/sync/subscribe_repos.rs
@@ -151,7 +151,10 @@ pub async fn subscribe_repos<'a>(
                             let CommitEvt { rebase, too_big, repo, commit, prev, rev, since, blocks, ops, blobs, prev_data} = evt;
                             let subscribe_commit_evt = SubscribeReposCommit {
                                 seq,
-                                time: from_str_to_utc(&time),
+                                time: from_str_to_utc(&time).unwrap_or_else(|e| {
+                                tracing::warn!("failed to parse event timestamp {:?}: {}", time, e);
+                                chrono::Utc::now()
+                            }),
                                 rebase,
                                 too_big,
                                 repo,
@@ -191,7 +194,10 @@ pub async fn subscribe_repos<'a>(
                                 did,
                                 seq,
                                 handle,
-                                time: from_str_to_utc(&time),
+                                time: from_str_to_utc(&time).unwrap_or_else(|e| {
+                                tracing::warn!("failed to parse event timestamp {:?}: {}", time, e);
+                                chrono::Utc::now()
+                            }),
                             };
                             let message_frame = MessageFrame::new(subscribe_identity_evt, Some(MessageFrameOpts { r#type: Some(format!("#{0}",r#type)) }));
                             let binary = match message_frame.to_bytes() {
@@ -215,7 +221,10 @@ pub async fn subscribe_repos<'a>(
                                 seq,
                                 status,
                                 active,
-                                time: from_str_to_utc(&time),
+                                time: from_str_to_utc(&time).unwrap_or_else(|e| {
+                                tracing::warn!("failed to parse event timestamp {:?}: {}", time, e);
+                                chrono::Utc::now()
+                            }),
                             };
                             let message_frame = MessageFrame::new(subscribe_account_evt, Some(MessageFrameOpts { r#type: Some(format!("#{0}",r#type)) }));
                             let binary = match message_frame.to_bytes() {
@@ -239,7 +248,10 @@ pub async fn subscribe_repos<'a>(
                                 did,
                                 blocks,
                                 rev,
-                                time: from_str_to_utc(&time),
+                                time: from_str_to_utc(&time).unwrap_or_else(|e| {
+                                tracing::warn!("failed to parse event timestamp {:?}: {}", time, e);
+                                chrono::Utc::now()
+                            }),
                             };
                             let message_frame = MessageFrame::new(subscribe_sync_evt, Some(MessageFrameOpts { r#type: Some(format!("#{0}",r#type)) }));
                             let binary = match message_frame.to_bytes() {

--- a/rsky-pds/src/read_after_write/util.rs
+++ b/rsky-pds/src/read_after_write/util.rs
@@ -99,7 +99,7 @@ pub fn get_local_lag(local: &LocalRecords) -> Result<Option<usize>> {
         Some(oldest) => {
             let system_time = SystemTime::now();
             let now: DateTime<UtcOffset> = system_time.into();
-            let duration = now - from_str_to_utc(&oldest);
+            let duration = now - from_str_to_utc(&oldest)?;
             Ok(Some(duration.num_milliseconds() as usize))
         }
     }


### PR DESCRIPTION
Fixes #20

## What

`from_str_to_micros` and `from_str_to_utc` in `rsky-common/src/time.rs` previously called `.unwrap()` on `NaiveDateTime::parse_from_str`, converting any format mismatch into a panic that crashed the Rocket worker thread.

Both functions now:
- Return `Result` instead of panicking
- Try the primary `%Y-%m-%dT%H:%M:%S%.3fZ` format first
- Fall back to `DateTime::parse_from_rfc3339` to handle `+00:00` offsets and other stored variants

**Caller updates:**
- `account_manager/mod.rs` — propagates with `?` (token rotation returns `Result`)
- `email_token.rs` — propagates with `?`
- `read_after_write/util.rs` — propagates with `?`
- `subscribe_repos.rs` — logs a warning and falls back to `Utc::now()` to avoid aborting the event stream

## Why

`refreshSession` panicked when `token.expires_at` from the database didn't exactly match the strict `%.3fZ` format. Any row written by a different tool or an older code path would crash the worker thread with `invalid or out-of-range datetime`.

## Testing

6 unit tests added in `rsky-common::time::tests`:
- Primary format parses without error
- RFC 3339 with `+00:00` offset resolves to the same instant as `Z` suffix
- Invalid inputs return `Err` (not a panic)
- All 18 existing `rsky-common` tests continue to pass

## Checklist

- [x] Changes have been tested, including unit tests
- [x] Implementation aligns with the canonical TypeScript implementation and/or the atproto spec
- [x] Relevant documentation — n/a
- [x] Code is formatted (`cargo fmt`)
- [x] Examples: unit tests serve as usage examples