### PR TITLE
fix(rsky-relay): rustfmt match arm in server.rs

### DIFF
--- a/rsky-relay/src/server/server.rs
+++ b/rsky-relay/src/server/server.rs
@@ -321,8 +321,7 @@ impl Server {
                     "{\"error\":\"InvalidRequest\",\"message\":\"invalid or missing hostname\"}",
                 )
             }
-            ("POST", PATH_ADMIN_BAN | PATH_ADMIN_UNBAN)
-            | ("GET", PATH_ADMIN_LIST_BANS) => {
+            ("POST", PATH_ADMIN_BAN | PATH_ADMIN_UNBAN) | ("GET", PATH_ADMIN_LIST_BANS) => {
                 self.handle_admin(&mut stream, url.path(), &url, is_admin_authed)
             }
             _ => write_response(


### PR DESCRIPTION
## Summary

- Collapses a two-line match arm introduced in 96e4858 (`Add PDS host banning to rsky-relay with admin API`) into one line, satisfying `cargo fmt -- --check`
- `rust.yml` CI has been failing on the `formatting` job since that commit was merged

## Change

```rust
// before
("POST", PATH_ADMIN_BAN | PATH_ADMIN_UNBAN)
| ("GET", PATH_ADMIN_LIST_BANS) => {

// after
("POST", PATH_ADMIN_BAN | PATH_ADMIN_UNBAN) | ("GET", PATH_ADMIN_LIST_BANS) => {
```

No logic change — purely what `rustfmt` requires.