### PR TITLE
fixes pass by ref error introduced on d1b5bb8fe0cfe58d800799510f0c1cd532374cdc

### DIFF
--- a/rsky-pds/Dockerfile
+++ b/rsky-pds/Dockerfile
@@ -2,14 +2,44 @@
 # https://hub.docker.com/_/rust
 FROM rust AS builder
 
-# Copy local code to the container image.
 WORKDIR /usr/src/rsky
-RUN git clone --depth 1 https://github.com/blacksky-algorithms/rsky.git .
-# We can swap the line above for the lines below once we have stronger versioning
-# per workspace member
-# RUN git clone --depth 1 https://github.com/blacksky-algorithms/rsky.git . && \
-#     git checkout <TBD when we have stronger versioning>
 
+# Copy workspace and all crate manifests for dependency resolution
+COPY Cargo.toml Cargo.lock ./
+COPY palomar-sync/Cargo.toml palomar-sync/Cargo.toml
+COPY rsky-common/Cargo.toml rsky-common/Cargo.toml
+COPY rsky-crypto/Cargo.toml rsky-crypto/Cargo.toml
+COPY rsky-feedgen/Cargo.toml rsky-feedgen/Cargo.toml
+COPY rsky-firehose/Cargo.toml rsky-firehose/Cargo.toml
+COPY rsky-identity/Cargo.toml rsky-identity/Cargo.toml
+COPY rsky-jetstream-subscriber/Cargo.toml rsky-jetstream-subscriber/Cargo.toml
+COPY rsky-labeler/Cargo.toml rsky-labeler/Cargo.toml
+COPY rsky-lexicon/Cargo.toml rsky-lexicon/Cargo.toml
+COPY rsky-pds/Cargo.toml rsky-pds/Cargo.toml
+COPY rsky-relay/Cargo.toml rsky-relay/Cargo.toml
+COPY rsky-repo/Cargo.toml rsky-repo/Cargo.toml
+COPY rsky-satnav/Cargo.toml rsky-satnav/Cargo.toml
+COPY rsky-syntax/Cargo.toml rsky-syntax/Cargo.toml
+COPY rsky-video/Cargo.toml rsky-video/Cargo.toml
+COPY rsky-wintermute/Cargo.toml rsky-wintermute/Cargo.toml
+
+# Copy real source for library crates that rsky-pds depends on
+COPY rsky-common/src rsky-common/src
+COPY rsky-crypto/src rsky-crypto/src
+COPY rsky-identity/src rsky-identity/src
+COPY rsky-lexicon/src rsky-lexicon/src
+COPY rsky-repo/src rsky-repo/src
+COPY rsky-syntax/src rsky-syntax/src
+
+# Stub out binary workspace members so cargo can resolve the workspace
+RUN mkdir -p \
+    palomar-sync/src rsky-feedgen/src rsky-firehose/src \
+    rsky-jetstream-subscriber/src rsky-labeler/src rsky-relay/src \
+    rsky-satnav/src rsky-video/src rsky-wintermute/src && \
+    for crate in palomar-sync rsky-feedgen rsky-firehose rsky-jetstream-subscriber \
+        rsky-labeler rsky-relay rsky-satnav rsky-video rsky-wintermute; do \
+        echo 'fn main() {}' > $crate/src/main.rs; \
+    done
 
 # Create an empty src directory to trick Cargo into thinking it's a valid Rust project
 RUN mkdir -p rsky-pds/src && echo "fn main() {}" > rsky-pds/src/main.rs

--- a/rsky-pds/src/actor_store/mod.rs
+++ b/rsky-pds/src/actor_store/mod.rs
@@ -108,7 +108,7 @@ impl ActorStore {
         let commit = Repo::format_init_commit(
             self.storage.clone(),
             self.did.clone(),
-            *keypair,
+            keypair,
             Some(write_ops),
         )
         .await?;
@@ -143,7 +143,7 @@ impl ActorStore {
         let commit = Repo::format_init_commit(
             self.storage.clone(),
             self.did.clone(),
-            *keypair,
+            keypair,
             Some(write_ops),
         )
         .await?;
@@ -340,7 +340,7 @@ impl ActorStore {
                 .collect::<Result<Vec<RecordWriteOp>>>()?;
 
             let mut commit = repo
-                .format_commit(RecordWriteEnum::List(write_ops), *PDS_REPO_SIGNING_KEYPAIR)
+                .format_commit(RecordWriteEnum::List(write_ops), &PDS_REPO_SIGNING_KEYPAIR)
                 .await?;
 
             // find blocks that would be deleted but are referenced by another record


### PR DESCRIPTION
## Summary

cc: @afbase 

reverts change [here](https://github.com/blacksky-algorithms/rsky/pull/171#issuecomment-4248682034) which was to cope with CI issue described in comment.

above change breaks build locally post-merge.

EDIT: should be fine in CI now that `rsky-repo` changes on main

## Related Issues
<!-- Link any relevant issues -->

## Changes
- [ ] Feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [x] I have tested the changes (including writing unit tests).
- [x] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [ ] I have updated relevant documentation. - n/a
- [x] I have formatted my code correctly - n/a
- [ ] I have provided examples for how this code works or will be used - n/a