### PR TITLE
rsky-repo `cargo clippy`

### DIFF
--- a/rsky-common/src/time.rs
+++ b/rsky-common/src/time.rs
@@ -30,7 +30,7 @@ pub fn from_str_to_micros(str: &str) -> Result<i64> {
         .map_err(|e| anyhow!("failed to parse datetime {:?}: {}", str, e))
 }
 
-pub fn from_str_to_millis(str: &String) -> Result<i64> {
+pub fn from_str_to_millis(str: &str) -> Result<i64> {
     Ok(NaiveDateTime::parse_from_str(str, RFC3339_VARIANT)?
         .and_utc()
         .timestamp_millis())
@@ -58,7 +58,9 @@ pub fn from_micros_to_str(micros: i64) -> String {
     format!("{}", from_micros_to_utc(micros).format(RFC3339_VARIANT))
 }
 
+#[allow(deprecated)]
 pub fn from_millis_to_utc(millis: i64) -> DateTime<UtcOffset> {
+    // todo: use non-deprecated APIs
     DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp_millis(millis).unwrap(), Utc)
 }
 

--- a/rsky-pds/src/account_manager/helpers/account.rs
+++ b/rsky-pds/src/account_manager/helpers/account.rs
@@ -81,7 +81,7 @@ pub fn select_account_qb(flags: Option<AvailabilityFlags>) -> BoxedQuery<'static
     let AvailabilityFlags {
         include_taken_down,
         include_deactivated,
-    } = flags.unwrap_or_else(|| AvailabilityFlags {
+    } = flags.unwrap_or(AvailabilityFlags {
         include_taken_down: Some(false),
         include_deactivated: Some(false),
     });

--- a/rsky-pds/src/account_manager/mod.rs
+++ b/rsky-pds/src/account_manager/mod.rs
@@ -452,7 +452,7 @@ impl AccountManager {
 
     // Email Tokens
     // ----------
-    pub async fn confirm_email<'em>(&self, opts: ConfirmEmailOpts<'em>) -> Result<()> {
+    pub async fn confirm_email(&self, opts: ConfirmEmailOpts<'_>) -> Result<()> {
         let db = self.db.clone();
         let ConfirmEmailOpts { did, token } = opts;
         email_token::assert_valid_token(

--- a/rsky-pds/src/actor_store/blob/mod.rs
+++ b/rsky-pds/src/actor_store/blob/mod.rs
@@ -160,11 +160,7 @@ impl BlobReader {
             size: size as i64,
             cid,
             mime_type,
-            width: if let Some(ref info) = img_info {
-                Some(info.width as i32)
-            } else {
-                None
-            },
+            width: img_info.as_ref().map(|info| info.width as i32),
             height: if let Some(info) = img_info {
                 Some(info.height as i32)
             } else {
@@ -227,7 +223,7 @@ impl BlobReader {
         self.delete_dereferenced_blobs(writes.clone()).await?;
         let _ = stream::iter(writes)
             .then(|write| async move {
-                Ok::<(), anyhow::Error>(match write {
+                match write {
                     PreparedWrite::Create(w) => {
                         for blob in w.blobs {
                             self.verify_blob_and_make_permanent(blob.clone()).await?;
@@ -241,7 +237,8 @@ impl BlobReader {
                         }
                     }
                     _ => (),
-                })
+                };
+                Ok::<(), anyhow::Error>(())
             })
             .collect::<Vec<_>>()
             .await

--- a/rsky-pds/src/actor_store/mod.rs
+++ b/rsky-pds/src/actor_store/mod.rs
@@ -156,7 +156,7 @@ impl ActorStore {
                 acc.push(CommitOp {
                     action: CommitAction::Create,
                     path: format_data_key(aturi.get_collection(), aturi.get_rkey()),
-                    cid: Some(w.cid.clone()),
+                    cid: Some(w.cid),
                     prev: None,
                 });
                 Ok(acc)
@@ -294,7 +294,7 @@ impl ActorStore {
                     cid,
                     prev: None,
                 };
-                if let Some(_) = current_record {
+                if current_record.is_some() {
                     op.prev = current_record;
                 };
                 commit_ops.push(op);
@@ -377,7 +377,7 @@ impl ActorStore {
 
         let _ = stream::iter(writes)
             .then(|write| async move {
-                Ok::<(), anyhow::Error>(match write {
+                match write {
                     PreparedWrite::Create(write) => {
                         let write_at_uri: AtUri = write.uri.try_into()?;
                         self.record
@@ -408,7 +408,8 @@ impl ActorStore {
                         let write_at_uri: AtUri = write.uri.try_into()?;
                         self.record.delete_record(&write_at_uri).await?
                     }
-                })
+                };
+                Ok::<(), anyhow::Error>(())
             })
             .collect::<Vec<_>>()
             .await
@@ -470,7 +471,7 @@ impl ActorStore {
             })
             .await?;
         res.into_iter()
-            .map(|row| Cid::from_str(&row).map_err(|error| anyhow::Error::new(error)))
+            .map(|row| Cid::from_str(&row).map_err(anyhow::Error::new))
             .collect::<Result<Vec<Cid>>>()
     }
 }

--- a/rsky-pds/src/actor_store/record/mod.rs
+++ b/rsky-pds/src/actor_store/record/mod.rs
@@ -120,6 +120,7 @@ impl RecordReader {
             .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn list_records_for_collection(
         &mut self,
         collection: String,
@@ -133,11 +134,7 @@ impl RecordReader {
         use crate::schema::pds::record::dsl as RecordSchema;
         use crate::schema::pds::repo_block::dsl as RepoBlockSchema;
 
-        let include_soft_deleted: bool = if let Some(include_soft_deleted) = include_soft_deleted {
-            include_soft_deleted
-        } else {
-            false
-        };
+        let include_soft_deleted: bool = include_soft_deleted.unwrap_or_default();
         let mut builder = RecordSchema::record
             .inner_join(RepoBlockSchema::repo_block.on(RepoBlockSchema::cid.eq(RecordSchema::cid)))
             .limit(limit)
@@ -190,11 +187,7 @@ impl RecordReader {
         use crate::schema::pds::record::dsl as RecordSchema;
         use crate::schema::pds::repo_block::dsl as RepoBlockSchema;
 
-        let include_soft_deleted: bool = if let Some(include_soft_deleted) = include_soft_deleted {
-            include_soft_deleted
-        } else {
-            false
-        };
+        let include_soft_deleted: bool = include_soft_deleted.unwrap_or_default();
         let mut builder = RecordSchema::record
             .inner_join(RepoBlockSchema::repo_block.on(RepoBlockSchema::cid.eq(RecordSchema::cid)))
             .select((models::Record::as_select(), models::RepoBlock::as_select()))
@@ -231,11 +224,7 @@ impl RecordReader {
     ) -> Result<bool> {
         use crate::schema::pds::record::dsl as RecordSchema;
 
-        let include_soft_deleted: bool = if let Some(include_soft_deleted) = include_soft_deleted {
-            include_soft_deleted
-        } else {
-            false
-        };
+        let include_soft_deleted: bool = include_soft_deleted.unwrap_or_default();
         let mut builder = RecordSchema::record
             .select(RecordSchema::uri)
             .filter(RecordSchema::uri.eq(uri))
@@ -250,7 +239,7 @@ impl RecordReader {
             .db
             .run(move |conn| builder.first::<String>(conn).optional())
             .await?;
-        Ok(!!record_uri.is_some())
+        Ok(record_uri.is_some())
     }
 
     pub async fn get_record_takedown_status(&self, uri: String) -> Result<Option<StatusAttr>> {
@@ -337,14 +326,8 @@ impl RecordReader {
         let record_backlinks = get_backlinks(uri, record)?;
         let conflicts: Vec<Vec<Record>> = stream::iter(record_backlinks)
             .then(|backlink| async move {
-                Ok::<Vec<Record>, anyhow::Error>(
-                    self.get_record_backlinks(
-                        uri.get_collection(),
-                        backlink.path,
-                        backlink.link_to,
-                    )
-                    .await?,
-                )
+                self.get_record_backlinks(uri.get_collection(), backlink.path, backlink.link_to)
+                    .await
             })
             .collect::<Vec<_>>()
             .await
@@ -356,7 +339,7 @@ impl RecordReader {
             .filter_map(|record| {
                 AtUri::make(
                     env::var("PDS_HOSTNAME").unwrap_or("localhost".to_owned()),
-                    Some(String::from(uri.get_collection())),
+                    Some(uri.get_collection()),
                     Some(record.rkey),
                 )
                 .ok()
@@ -382,7 +365,7 @@ impl RecordReader {
         let rkey = uri.get_rkey();
         let hostname = uri.get_hostname().to_string();
         let action = action.unwrap_or(WriteOpAction::Create);
-        let indexed_at = timestamp.unwrap_or_else(|| rsky_common::now());
+        let indexed_at = timestamp.unwrap_or_else(rsky_common::now);
         let row = Record {
             did: self.did.clone(),
             uri: uri.to_string(),
@@ -472,7 +455,7 @@ impl RecordReader {
     }
 
     pub async fn add_backlinks(&self, backlinks: Vec<Backlink>) -> Result<()> {
-        if backlinks.len() == 0 {
+        if backlinks.is_empty() {
             Ok(())
         } else {
             use crate::schema::pds::backlink::dsl as BacklinkSchema;

--- a/rsky-pds/src/actor_store/repo/sql_repo.rs
+++ b/rsky-pds/src/actor_store/repo/sql_repo.rs
@@ -40,13 +40,13 @@ impl ReadableBlockstore for SqlRepoReader {
     ) -> Pin<Box<dyn Future<Output = Result<Option<Vec<u8>>>> + Send + Sync + 'a>> {
         let did: String = self.did.clone();
         let db: Arc<DbConn> = self.db.clone();
-        let cid = cid.clone();
+        let cid = *cid;
 
         Box::pin(async move {
             use crate::schema::pds::repo_block::dsl as RepoBlockSchema;
             let cached = {
                 let cache_guard = self.cache.read().await;
-                cache_guard.get(cid).map(|v| v.clone())
+                cache_guard.get(cid).cloned()
             };
             if let Some(cached_result) = cached {
                 return Ok(Some(cached_result.clone()));

--- a/rsky-pds/src/apis/app/bsky/actor/get_profile.rs
+++ b/rsky-pds/src/apis/app/bsky/actor/get_profile.rs
@@ -50,6 +50,7 @@ pub async fn inner_get_profile(
 
 /// Get detailed profile view of an actor. Does not require auth,
 /// but contains relevant metadata with auth.
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/app.bsky.actor.getProfile?<actor>")]
 pub async fn get_profile(

--- a/rsky-pds/src/apis/app/bsky/actor/get_profiles.rs
+++ b/rsky-pds/src/apis/app/bsky/actor/get_profiles.rs
@@ -43,6 +43,7 @@ pub async fn inner_get_profiles(
 }
 
 /// Get detailed profile views of multiple actors.
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/app.bsky.actor.getProfiles?<actors>")]
 pub async fn get_profiles(

--- a/rsky-pds/src/apis/app/bsky/feed/get_actor_likes.rs
+++ b/rsky-pds/src/apis/app/bsky/feed/get_actor_likes.rs
@@ -15,6 +15,7 @@ use rsky_lexicon::app::bsky::feed::{AuthorFeed, FeedViewPost, PostView};
 
 const METHOD_NSID: &str = "app.bsky.feed.getActorLikes";
 
+#[allow(clippy::too_many_arguments)]
 pub async fn inner_get_actor_likes(
     _actor: String,
     _limit: Option<u8>,
@@ -50,6 +51,7 @@ pub async fn inner_get_actor_likes(
 }
 
 /// Get a list of posts liked by an actor. Does not require auth.
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/app.bsky.feed.getActorLikes?<actor>&<limit>&<cursor>")]
 pub async fn get_actor_likes(

--- a/rsky-pds/src/apis/app/bsky/feed/get_author_feed.rs
+++ b/rsky-pds/src/apis/app/bsky/feed/get_author_feed.rs
@@ -16,6 +16,7 @@ use rsky_lexicon::app::bsky::feed::{AuthorFeed, FeedViewPost, PostView};
 
 const METHOD_NSID: &str = "app.bsky.feed.getAuthorFeed";
 
+#[allow(clippy::too_many_arguments)]
 pub async fn inner_get_author_feed(
     _actor: String,
     _limit: Option<u8>,
@@ -52,6 +53,7 @@ pub async fn inner_get_author_feed(
 }
 
 /// Get a view of an actor's 'author feed' (post and reposts by the author). Does not require auth.
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/app.bsky.feed.getAuthorFeed?<actor>&<limit>&<cursor>&<filter>")]
 pub async fn get_author_feed(
@@ -201,9 +203,6 @@ pub fn is_users_feed(feed: &AuthorFeed, requester: &String) -> bool {
     match first {
         None => false,
         Some(first) if first.reason.is_none() && &first.post.author.did == requester => true,
-        Some(first) => match first.reason {
-            Some(ref reason) if &reason.by.did == requester => true,
-            _ => false,
-        },
+        Some(first) => matches!(first.reason, Some(ref reason) if &reason.by.did == requester),
     }
 }

--- a/rsky-pds/src/apis/app/bsky/feed/get_feed.rs
+++ b/rsky-pds/src/apis/app/bsky/feed/get_feed.rs
@@ -104,10 +104,7 @@ impl<'r> FromRequest<'r> for GetFeedPipeThrough {
                                 );
                                 let proxy_req = ProxyRequest {
                                     headers,
-                                    query: match req.uri().query() {
-                                        None => None,
-                                        Some(query) => Some(query.to_string()),
-                                    },
+                                    query: req.uri().query().map(|query| query.to_string()),
                                     path: req.uri().path().to_string(),
                                     method: req.method(),
                                     id_resolver: req

--- a/rsky-pds/src/apis/app/bsky/feed/get_post_thread.rs
+++ b/rsky-pds/src/apis/app/bsky/feed/get_post_thread.rs
@@ -42,8 +42,7 @@ pub struct ReadAfterWriteNotFoundOutput {
     pub lag: Option<usize>,
 }
 
-#[allow(non_snake_case)]
-#[allow(unused_variables)]
+#[allow(unused_variables, non_snake_case, clippy::too_many_arguments)]
 pub async fn inner_get_post_thread(
     uri: String,
     depth: u16,
@@ -122,8 +121,7 @@ pub async fn inner_get_post_thread(
 
 /// Get posts in a thread. Does not require auth, but additional metadata and filtering
 /// will be applied for authed requests.
-#[allow(non_snake_case)]
-#[allow(unused_variables)]
+#[allow(unused_variables, non_snake_case, clippy::too_many_arguments)]
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/app.bsky.feed.getPostThread?<uri>&<depth>&<parentHeight>")]
 pub async fn get_post_thread(
@@ -173,17 +171,11 @@ pub async fn get_post_thread(
                         } = xrpc
                         {
                             let xrpc_error = ErrorMessageResponse {
-                                code: match error {
-                                    None => None,
-                                    Some(error) => Some(
-                                        ErrorCode::from_str(error)
-                                            .unwrap_or(ErrorCode::InternalServerError),
-                                    ),
-                                },
-                                message: match message {
-                                    None => None,
-                                    Some(message) => Some(message.to_string()),
-                                },
+                                code: error.as_ref().map(|error| {
+                                    ErrorCode::from_str(error)
+                                        .unwrap_or(ErrorCode::InternalServerError)
+                                }),
+                                message: message.as_ref().map(|message| message.to_string()),
                             };
                             Err(ApiError::BadRequest(
                                 "XRPCError".to_string(),
@@ -228,7 +220,7 @@ pub async fn add_posts_to_thread(
     posts: Vec<RecordDescript<Post>>,
 ) -> Result<ThreadViewPost> {
     let in_thread = find_posts_in_thread(&original, posts);
-    if in_thread.len() == 0 {
+    if in_thread.is_empty() {
         return Ok(original);
     }
     let mut thread = original;

--- a/rsky-pds/src/apis/app/bsky/feed/get_timeline.rs
+++ b/rsky-pds/src/apis/app/bsky/feed/get_timeline.rs
@@ -15,6 +15,7 @@ use rsky_lexicon::app::bsky::feed::AuthorFeed;
 
 const METHOD_NSID: &str = "app.bsky.feed.getTimeline";
 
+#[allow(clippy::too_many_arguments)]
 pub async fn inner_get_timeline(
     _algorithm: Option<String>,
     _limit: Option<u8>,
@@ -51,6 +52,7 @@ pub async fn inner_get_timeline(
 
 /// Get a view of the requesting account's home timeline.
 /// This is expected to be some form of reverse-chronological feed.
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/app.bsky.feed.getTimeline?<algorithm>&<limit>&<cursor>")]
 pub async fn get_timeline(
@@ -66,7 +68,7 @@ pub async fn get_timeline(
     account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<AuthorFeed>, ApiError> {
     if let Some(limit) = limit {
-        if limit > 100 || limit < 1 {
+        if !(1..=100).contains(&limit) {
             return Err(ApiError::InvalidRequest("invalid limit".to_string()));
         }
     }

--- a/rsky-pds/src/apis/com/atproto/admin/get_invite_codes.rs
+++ b/rsky-pds/src/apis/com/atproto/admin/get_invite_codes.rs
@@ -45,6 +45,12 @@ pub struct KeySetPaginateOpts {
 /// These types relate as such. Implementers define the relations marked with a *:
 ///   Result -*-> LabeledResult <-*-> Cursor <--> packed/string cursor
 ///                     ↳ SQL Condition
+impl Default for TimeCodeKeySet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TimeCodeKeySet {
     pub fn new() -> Self {
         TimeCodeKeySet {}
@@ -113,7 +119,7 @@ impl TimeCodeKeySet {
             None => Ok(None),
             Some(cursor_str) => {
                 let result = cursor_str.split("::").collect::<Vec<&str>>();
-                match (result.get(0), result.get(1), result.get(2)) {
+                match (result.first(), result.get(1), result.get(2)) {
                     (Some(primary), Some(secondary), None) => Ok(Some(Cursor {
                         primary: primary.to_string(),
                         secondary: secondary.to_string(),
@@ -210,6 +216,12 @@ pub struct UseCodeResult {
 
 pub struct UseCodeKeyset {}
 
+impl Default for UseCodeKeyset {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl UseCodeKeyset {
     pub fn new() -> Self {
         UseCodeKeyset {}
@@ -278,7 +290,7 @@ impl UseCodeKeyset {
             None => Ok(None),
             Some(cursor_str) => {
                 let result = cursor_str.split("::").collect::<Vec<&str>>();
-                match (result.get(0), result.get(1), result.get(2)) {
+                match (result.first(), result.get(1), result.get(2)) {
                     (Some(primary), Some(secondary), None) => Ok(Some(Cursor {
                         primary: primary.to_string(),
                         secondary: secondary.to_string(),

--- a/rsky-pds/src/apis/com/atproto/identity/request_plc_operation_signature.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/request_plc_operation_signature.rs
@@ -32,7 +32,7 @@ async fn get_account(
         include_deactivated: Some(true),
     };
     match account_manager
-        .get_account(&requester_did.to_string(), Some(availability_flags))
+        .get_account(requester_did, Some(availability_flags))
         .await
     {
         Ok(account) => match account {
@@ -55,7 +55,7 @@ async fn create_email_token(
     account_manager: &AccountManager,
 ) -> Result<String, ApiError> {
     match account_manager
-        .create_email_token(&requester.to_string(), EmailTokenPurpose::PlcOperation)
+        .create_email_token(requester, EmailTokenPurpose::PlcOperation)
         .await
     {
         Ok(res) => Ok(res),

--- a/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
@@ -78,7 +78,7 @@ async fn validate_plc_request(
 
     let account = match account_manager
         .get_account(
-            &did.to_string(),
+            did,
             Some(AvailabilityFlags {
                 include_deactivated: Some(true),
                 include_taken_down: None,

--- a/rsky-pds/src/apis/com/atproto/repo/get_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/get_record.rs
@@ -11,6 +11,7 @@ use rocket::State;
 use rsky_lexicon::com::atproto::repo::GetRecordOutput;
 use rsky_syntax::aturi::AtUri;
 
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all)]
 async fn inner_get_record(
     repo: String,
@@ -65,6 +66,7 @@ async fn inner_get_record(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/com.atproto.repo.getRecord?<repo>&<collection>&<rkey>&<cid>")]
 pub async fn get_record(

--- a/rsky-pds/src/apis/com/atproto/repo/import_repo.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/import_repo.rs
@@ -23,7 +23,7 @@ use rsky_repo::sync::consumer::{verify_diff, VerifyRepoInput};
 use rsky_repo::types::{PreparedWrite, RecordWriteDescript, VerifiedDiff};
 use std::num::NonZeroU64;
 
-struct ImportRepoInput {
+pub struct ImportRepoInput {
     car_with_root: CarWithRoot,
 }
 

--- a/rsky-pds/src/apis/com/atproto/repo/list_missing_blobs.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/list_missing_blobs.rs
@@ -30,10 +30,7 @@ pub async fn list_missing_blobs(
         .await
     {
         Ok(blobs) => {
-            let cursor = match blobs.last() {
-                Some(last_blob) => Some(last_blob.cid.clone()),
-                None => None,
-            };
+            let cursor = blobs.last().map(|last_blob| last_blob.cid.clone());
             Ok(Json(ListMissingBlobsOutput { cursor, blobs }))
         }
         Err(error) => {

--- a/rsky-pds/src/apis/com/atproto/repo/list_records.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/list_records.rs
@@ -10,7 +10,7 @@ use rocket::State;
 use rsky_lexicon::com::atproto::repo::{ListRecordsOutput, Record};
 use rsky_syntax::aturi::AtUri;
 
-#[allow(non_snake_case)]
+#[allow(non_snake_case, clippy::too_many_arguments)]
 async fn inner_list_records(
     // The handle or DID of the repo.
     repo: String,
@@ -74,7 +74,7 @@ async fn inner_list_records(
 }
 
 #[tracing::instrument(skip_all)]
-#[allow(non_snake_case)]
+#[allow(non_snake_case, clippy::too_many_arguments)]
 #[rocket::get("/xrpc/com.atproto.repo.listRecords?<repo>&<collection>&<limit>&<cursor>&<rkeyStart>&<rkeyEnd>&<reverse>")]
 pub async fn list_records(
     // The handle or DID of the repo.

--- a/rsky-pds/src/apis/com/atproto/server/create_account.rs
+++ b/rsky-pds/src/apis/com/atproto/server/create_account.rs
@@ -36,6 +36,7 @@ pub struct TransformedCreateAccountInput {
 }
 
 //TODO: Potential for taking advantage of async better
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all)]
 #[rocket::post(
     "/xrpc/com.atproto.server.createAccount",

--- a/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
+++ b/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
@@ -18,10 +18,7 @@ pub async fn inner_get_service_auth(
 ) -> Result<String> {
     let credentials = auth.access.credentials.unwrap();
     let did = credentials.clone().did.unwrap();
-    let exp = match exp {
-        None => None,
-        Some(exp) => Some(exp * 1000),
-    };
+    let exp = exp.map(|exp| exp * 1000);
     if let Some(exp) = exp {
         let system_time = SystemTime::now();
         let now: DateTime<UtcOffset> = system_time.into();

--- a/rsky-pds/src/apis/com/atproto/server/mod.rs
+++ b/rsky-pds/src/apis/com/atproto/server/mod.rs
@@ -95,14 +95,8 @@ pub async fn assert_valid_did_documents_for_service(did: String) -> Result<()> {
         let plc_url = env_str("PDS_DID_PLC_URL").unwrap_or("https://plc.directory".to_owned());
         let plc_client = plc::Client::new(plc_url);
         let resolved = plc_client.get_document_data(&did).await?;
-        let pds_endpoint = match resolved.services.get("atproto_pds") {
-            Some(service) => Some(service.endpoint.clone()),
-            None => None,
-        };
-        let signing_key = match resolved.verification_methods.get("atproto") {
-            Some(key) => Some(key.clone()),
-            None => None,
-        };
+        let pds_endpoint = resolved.services.get("atproto_pds").map(|service| service.endpoint.clone());
+        let signing_key = resolved.verification_methods.get("atproto").cloned();
         assert_valid_doc_contents(AssertionContents {
             pds_endpoint,
             signing_key,

--- a/rsky-pds/src/apis/com/atproto/server/mod.rs
+++ b/rsky-pds/src/apis/com/atproto/server/mod.rs
@@ -95,7 +95,10 @@ pub async fn assert_valid_did_documents_for_service(did: String) -> Result<()> {
         let plc_url = env_str("PDS_DID_PLC_URL").unwrap_or("https://plc.directory".to_owned());
         let plc_client = plc::Client::new(plc_url);
         let resolved = plc_client.get_document_data(&did).await?;
-        let pds_endpoint = resolved.services.get("atproto_pds").map(|service| service.endpoint.clone());
+        let pds_endpoint = resolved
+            .services
+            .get("atproto_pds")
+            .map(|service| service.endpoint.clone());
         let signing_key = resolved.verification_methods.get("atproto").cloned();
         assert_valid_doc_contents(AssertionContents {
             pds_endpoint,

--- a/rsky-pds/src/apis/com/atproto/sync/get_record.rs
+++ b/rsky-pds/src/apis/com/atproto/sync/get_record.rs
@@ -18,6 +18,7 @@ use std::str::FromStr;
 #[response(status = 200, content_type = "application/vnd.ipld.car")]
 pub struct BlockResponder(Vec<u8>);
 
+#[allow(clippy::too_many_arguments)]
 async fn inner_get_record(
     did: String,
     collection: String,
@@ -56,6 +57,7 @@ async fn inner_get_record(
 
 /// Get data blocks needed to prove the existence or non-existence of record in the current version
 /// of repo. Does not require auth.
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/com.atproto.sync.getRecord?<did>&<collection>&<rkey>&<commit>")]
 pub async fn get_record(

--- a/rsky-pds/src/apis/com/atproto/sync/list_blobs.rs
+++ b/rsky-pds/src/apis/com/atproto/sync/list_blobs.rs
@@ -13,6 +13,7 @@ use rocket::serde::json::Json;
 use rocket::State;
 use rsky_lexicon::com::atproto::sync::ListBlobsOutput;
 
+#[allow(clippy::too_many_arguments)]
 async fn inner_list_blobs(
     did: String,
     since: Option<String>, // Optional revision of the repo to list blobs since.
@@ -40,10 +41,7 @@ async fn inner_list_blobs(
         })
         .await?;
 
-    let last_blob: Option<String> = match blob_cids.last() {
-        None => None,
-        Some(last) => Some(last.clone()),
-    };
+    let last_blob: Option<String> = blob_cids.last().cloned();
     Ok(ListBlobsOutput {
         cursor: last_blob,
         cids: blob_cids,
@@ -52,6 +50,7 @@ async fn inner_list_blobs(
 
 /// List blob CIDs for an account, since some repo revision. Does not require auth;
 /// implemented by PDS
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/com.atproto.sync.listBlobs?<did>&<since>&<limit>&<cursor>")]
 pub async fn list_blobs(

--- a/rsky-pds/src/apis/com/atproto/sync/list_repos.rs
+++ b/rsky-pds/src/apis/com/atproto/sync/list_repos.rs
@@ -44,6 +44,12 @@ pub struct KeySetPaginateOpts {
 /// These types relate as such. Implementers define the relations marked with a *:
 ///   Result -*-> LabeledResult <-*-> Cursor <--> packed/string cursor
 ///                     ↳ SQL Condition
+impl Default for TimeDidKeySet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TimeDidKeySet {
     pub fn new() -> Self {
         TimeDidKeySet {}

--- a/rsky-pds/src/apis/com/atproto/sync/subscribe_repos.rs
+++ b/rsky-pds/src/apis/com/atproto/sync/subscribe_repos.rs
@@ -27,7 +27,7 @@ use ws::Message;
 fn get_backfill_limit(ms: u64) -> String {
     let system_time = SystemTime::now();
     let mut dt: DateTime<UtcOffset> = system_time.into();
-    dt = dt - Duration::milliseconds(ms as i64);
+    dt -= Duration::milliseconds(ms as i64);
     format!("{}", dt.format(RFC3339_VARIANT))
 }
 
@@ -35,6 +35,7 @@ fn get_backfill_limit(ms: u64) -> String {
 /// and identity update events, for all repositories on the current server. See the atproto
 /// specifications for details around stream sequencing, repo versioning, CAR diff format, and more.
 /// Public and does not require auth; implemented by PDS and Relay.
+#[allow(clippy::needless_lifetimes)]
 #[rocket::get("/xrpc/com.atproto.sync.subscribeRepos?<cursor>")]
 #[allow(unused_variables)]
 pub async fn subscribe_repos<'a>(
@@ -147,7 +148,7 @@ pub async fn subscribe_repos<'a>(
 
                     match evt {
                         SeqEvt::TypedCommitEvt(commit) => {
-                            let TypedCommitEvt { r#type, seq, time, evt } = commit;
+                            let TypedCommitEvt { r#type, seq, time, evt } = *commit;
                             let CommitEvt { rebase, too_big, repo, commit, prev, rev, since, blocks, ops, blobs, prev_data} = evt;
                             let subscribe_commit_evt = SubscribeReposCommit {
                                 seq,
@@ -165,10 +166,7 @@ pub async fn subscribe_repos<'a>(
                                 blocks,
                                 ops: ops.into_iter().map(|op| SubscribeReposCommitOperation {
                                     path: op.path,
-                                    cid: match op.cid {
-                                        None => None,
-                                        Some(cid) => Some(cid)
-                                    },
+                                    cid: op.cid,
                                     action: op.action.to_string()
                                 }).collect::<Vec<SubscribeReposCommitOperation>>(),
                                 blobs: blobs.into_iter().map(|blob| blob.to_string()).collect::<Vec<String>>(),

--- a/rsky-pds/src/auth_verifier.rs
+++ b/rsky-pds/src/auth_verifier.rs
@@ -51,6 +51,7 @@ impl AuthScope {
         }
     }
 
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(scope: &str) -> Result<Self> {
         match scope {
             "com.atproto.access" => Ok(AuthScope::Access),
@@ -162,10 +163,13 @@ impl<'r> FromRequest<'r> for Refresh {
     type Error = AuthError;
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        let mut options = VerificationOptions::default();
-        options.allowed_audiences = Some(HashSet::from_strings(&[
-            env::var("PDS_SERVICE_DID").unwrap()
-        ]));
+        let options = VerificationOptions {
+            allowed_audiences: Some(HashSet::from_strings(&[
+                env::var("PDS_SERVICE_DID").unwrap()
+            ])),
+            ..Default::default()
+        };
+
         let ValidatedBearer {
             did,
             scope,
@@ -209,8 +213,8 @@ impl<'r> FromRequest<'r> for Refresh {
     }
 }
 
-pub async fn access_check<'r>(
-    req: &'r Request<'_>,
+pub async fn access_check(
+    req: &Request<'_>,
     scopes: Vec<AuthScope>,
     opts: Option<ValidateAccessTokenOpts>,
 ) -> Outcome<AccessOutput, AuthError> {
@@ -439,8 +443,11 @@ impl<'r> FromRequest<'r> for RevokeRefreshToken {
     type Error = AuthError;
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        let mut options = VerificationOptions::default();
-        options.max_validity = Some(Duration::from_secs(INFINITY));
+        let options = VerificationOptions {
+            max_validity: Some(Duration::from_secs(INFINITY)),
+            ..Default::default()
+        };
+
         match validate_bearer_token(req, vec![AuthScope::Refresh], Some(options)) {
             Ok(result) => match result.payload.jti {
                 Some(jti) => Outcome::Success(RevokeRefreshToken { id: jti }),
@@ -712,14 +719,15 @@ impl<'r> FromRequest<'r> for OptionalAccessOrAdminToken {
     }
 }
 
-pub async fn validate_bearer_access_token<'r>(
-    request: &'r Request<'_>,
+pub async fn validate_bearer_access_token(
+    request: &Request<'_>,
     scopes: Vec<AuthScope>,
 ) -> Result<AccessOutput> {
-    let mut options = VerificationOptions::default();
-    options.allowed_audiences = Some(HashSet::from_strings(&[
-        env::var("PDS_SERVICE_DID").unwrap()
-    ]));
+    let options = VerificationOptions {
+        allowed_audiences: Some(HashSet::from_strings(&[env::var("PDS_SERVICE_DID")?])),
+        ..Default::default()
+    };
+
     let ValidatedBearer {
         did,
         scope,
@@ -727,7 +735,7 @@ pub async fn validate_bearer_access_token<'r>(
         audience,
         ..
     } = validate_bearer_token(request, scopes, Some(options))?;
-    let is_privileged = vec![AuthScope::Access, AuthScope::AppPassPrivileged].contains(&scope);
+    let is_privileged = [AuthScope::Access, AuthScope::AppPassPrivileged].contains(&scope);
     Ok(AccessOutput {
         credentials: Some(Credentials {
             r#type: "access".to_string(),
@@ -743,8 +751,8 @@ pub async fn validate_bearer_access_token<'r>(
     })
 }
 
-pub fn validate_bearer_token<'r>(
-    request: &'r Request<'_>,
+pub fn validate_bearer_token(
+    request: &Request,
     scopes: Vec<AuthScope>,
     verify_options: Option<VerificationOptions>,
 ) -> Result<ValidatedBearer> {
@@ -763,7 +771,7 @@ pub fn validate_bearer_token<'r>(
             if !aud.starts_with("did:") {
                 bail!("Malformed token")
             }
-            if scopes.len() > 0 && !scopes.contains(&scope) {
+            if !scopes.is_empty() && !scopes.contains(&scope) {
                 bail!("Bad token scope")
                 /*{
                     "error": "InvalidToken",
@@ -786,15 +794,16 @@ pub fn validate_bearer_token<'r>(
 }
 
 // @TODO: Implement DPop/OAuth
-pub async fn validate_access_token<'r>(
-    request: &'r Request<'_>,
+pub async fn validate_access_token(
+    request: &Request<'_>,
     scopes: Vec<AuthScope>,
     opts: Option<ValidateAccessTokenOpts>,
 ) -> Result<AccessOutput> {
-    let mut options = VerificationOptions::default();
-    options.allowed_audiences = Some(HashSet::from_strings(&[
-        env::var("PDS_SERVICE_DID").unwrap()
-    ]));
+    let options = VerificationOptions {
+        allowed_audiences: Some(HashSet::from_strings(&[env::var("PDS_SERVICE_DID")?])),
+        ..Default::default()
+    };
+
     let ValidatedBearer {
         did,
         scope,
@@ -805,7 +814,7 @@ pub async fn validate_access_token<'r>(
     let ValidateAccessTokenOpts {
         check_takedown,
         check_deactivated,
-    } = opts.unwrap_or_else(|| ValidateAccessTokenOpts {
+    } = opts.unwrap_or(ValidateAccessTokenOpts {
         check_takedown: Some(false),
         check_deactivated: Some(false),
     });
@@ -873,8 +882,8 @@ pub async fn validate_access_token<'r>(
     })
 }
 
-pub async fn verify_service_jwt<'r>(
-    request: &'r Request<'_>,
+pub async fn verify_service_jwt(
+    request: &Request<'_>,
     id_resolver: &State<SharedIdResolver>,
     opts: ServiceJwtOpts,
 ) -> Result<VerifiedServiceJwt> {
@@ -884,7 +893,7 @@ pub async fn verify_service_jwt<'r>(
             _ => (),
         }
         let parts = iss.split("#").collect::<Vec<&str>>();
-        if let (Some(did), Some(service_id)) = (parts.get(0), parts.get(1)) {
+        if let (Some(did), Some(service_id)) = (parts.first(), parts.get(1)) {
             let (did, service_id) = (did.to_string(), *service_id);
             let key_id = if service_id == "atproto_labeler" {
                 "atproto_label"
@@ -898,7 +907,7 @@ pub async fn verify_service_jwt<'r>(
                 Err(err) => bail!("could not resolve iss did: `{err}`"),
                 Ok(res) => res,
             };
-            match get_verification_material(&did_doc, &key_id.to_string()) {
+            match get_verification_material(&did_doc, key_id) {
                 None => bail!("missing or bad key in did doc"),
                 Some(parsed_key) => match get_did_key_from_multibase(parsed_key)? {
                     None => bail!("missing or bad key in did doc"),
@@ -993,7 +1002,7 @@ pub fn parse_basic_auth(token: &str) -> Option<BasicAuth> {
     };
     let parsed_parts = parsed_str.split(":").collect::<Vec<&str>>();
 
-    match (parsed_parts.get(0), parsed_parts.get(1)) {
+    match (parsed_parts.first(), parsed_parts.get(1)) {
         (Some(username), Some(password)) => Some(BasicAuth {
             username: username.to_string(),
             password: password.to_string(),

--- a/rsky-pds/src/config/mod.rs
+++ b/rsky-pds/src/config/mod.rs
@@ -82,12 +82,12 @@ pub fn env_to_cfg() -> ServerConfig {
         privacy_policy_url: env_str("PDS_PRIVACY_POLICY_URL"),
         terms_of_service_url: env_str("PDS_TERMS_OF_SERVICE_URL"),
         accepting_imports: env_bool("PDS_ACCEPTING_REPO_IMPORTS").unwrap_or(true),
-        blob_upload_limit: env_int("PDS_BLOB_UPLOAD_LIMIT").unwrap_or_else(|| 5 * 1024 * 1024), // 5mb
+        blob_upload_limit: env_int("PDS_BLOB_UPLOAD_LIMIT").unwrap_or(5 * 1024 * 1024), // 5mb
         contact_email_address: env_str("PDS_CONTACT_EMAIL_ADDRESS"),
         dev_mode: env_bool("PDS_DEV_MODE").unwrap_or(false),
     };
     let service_handle_domains: Vec<String>;
-    if env_list("PDS_SERVICE_HANDLE_DOMAINS").len() > 0 {
+    if !env_list("PDS_SERVICE_HANDLE_DOMAINS").is_empty() {
         service_handle_domains = env_list("PDS_SERVICE_HANDLE_DOMAINS");
     } else if hostname == "localhost" {
         service_handle_domains = vec![".test".to_string()];
@@ -98,41 +98,35 @@ pub fn env_to_cfg() -> ServerConfig {
         plc_url: env_str("PDS_DID_PLC_URL").unwrap_or("https://plc.directory".to_string()),
         resolver_timeout: env_int("PDS_ID_RESOLVER_TIMEOUT").unwrap_or_else(|| 3 * SECOND as usize)
             as u64,
-        cache_state_ttl: env_int("PDS_DID_CACHE_STALE_TTL").unwrap_or_else(|| HOUR as usize) as u64,
-        cache_max_ttl: env_int("PDS_DID_CACHE_MAX_TTL").unwrap_or_else(|| DAY as usize) as u64,
+        cache_state_ttl: env_int("PDS_DID_CACHE_STALE_TTL").unwrap_or(HOUR as usize) as u64,
+        cache_max_ttl: env_int("PDS_DID_CACHE_MAX_TTL").unwrap_or(DAY as usize) as u64,
         recovery_did_key: env_str("PDS_RECOVERY_DID_KEY"),
         service_handle_domains,
         handle_backup_name_servers: Some(env_list("PDS_HANDLE_BACKUP_NAMESERVERS")),
         enable_did_doc_with_session: env_bool("PDS_ENABLE_DID_DOC_WITH_SESSION").unwrap_or(false),
     };
-    let bsky_app_view_cfg: Option<ServiceConfig> = match env_str("PDS_BSKY_APP_VIEW_URL") {
-        None => None,
-        Some(mod_service_url) => Some(ServiceConfig {
+    let bsky_app_view_cfg: Option<ServiceConfig> =
+        env_str("PDS_BSKY_APP_VIEW_URL").map(|mod_service_url| ServiceConfig {
             url: mod_service_url,
             did: env_str("PDS_BSKY_APP_VIEW_DID").expect(
                 "if bsky appview service url is configured, must configure its did as well.",
             ),
             cdn_url_pattern: env_str("PDS_BSKY_APP_VIEW_CDN_URL_PATTERN"),
-        }),
-    };
-    let mod_service_cfg: Option<ServiceConfig> = match env_str("PDS_MOD_SERVICE_URL") {
-        None => None,
-        Some(mod_service_url) => Some(ServiceConfig {
+        });
+    let mod_service_cfg: Option<ServiceConfig> =
+        env_str("PDS_MOD_SERVICE_URL").map(|mod_service_url| ServiceConfig {
             url: mod_service_url,
             did: env_str("PDS_MOD_SERVICE_DID")
                 .expect("if mod service url is configured, must configure its did as well."),
             cdn_url_pattern: None,
-        }),
-    };
-    let mut report_service_cfg: Option<ServiceConfig> = match env_str("PDS_REPORT_SERVICE_URL") {
-        None => None,
-        Some(mod_service_url) => Some(ServiceConfig {
+        });
+    let mut report_service_cfg: Option<ServiceConfig> =
+        env_str("PDS_REPORT_SERVICE_URL").map(|mod_service_url| ServiceConfig {
             url: mod_service_url,
             did: env_str("PDS_REPORT_SERVICE_DID")
                 .expect("if mod service url is configured, must configure its did as well."),
             cdn_url_pattern: None,
-        }),
-    };
+        });
 
     // if there's a mod service, default report service into it
     if mod_service_cfg.is_some() && report_service_cfg.is_none() {
@@ -171,7 +165,7 @@ pub fn env_to_cfg() -> ServerConfig {
 }
 
 impl ServerConfig {
-    pub async fn appview_auth_headers(&self, did: &String, lxm: &String) -> Result<HeaderMap> {
+    pub async fn appview_auth_headers(&self, did: &str, lxm: &str) -> Result<HeaderMap> {
         match &self.bsky_app_view {
             None => bail!("No appview configured."),
             Some(bsky_app_view) => {

--- a/rsky-pds/src/lib.rs
+++ b/rsky-pds/src/lib.rs
@@ -262,8 +262,14 @@ pub async fn build_rocket(cfg: Option<RocketConfig>) -> Rocket<Build> {
     let local_viewer = SharedLocalViewer {
         local_viewer: RwLock::new(LocalViewer::creator(LocalViewerCreatorParams {
             pds_hostname: cfg.service.hostname.clone(),
-            appview_agent: cfg.bsky_app_view.as_ref().map(|bsky_app_view| bsky_app_view.url.clone()),
-            appview_did: cfg.bsky_app_view.as_ref().map(|bsky_app_view| bsky_app_view.did.clone()),
+            appview_agent: cfg
+                .bsky_app_view
+                .as_ref()
+                .map(|bsky_app_view| bsky_app_view.url.clone()),
+            appview_did: cfg
+                .bsky_app_view
+                .as_ref()
+                .map(|bsky_app_view| bsky_app_view.did.clone()),
             appview_cdn_url_pattern: match cfg.bsky_app_view {
                 None => None,
                 Some(ref bsky_app_view) => bsky_app_view.cdn_url_pattern.clone(),

--- a/rsky-pds/src/lib.rs
+++ b/rsky-pds/src/lib.rs
@@ -262,14 +262,8 @@ pub async fn build_rocket(cfg: Option<RocketConfig>) -> Rocket<Build> {
     let local_viewer = SharedLocalViewer {
         local_viewer: RwLock::new(LocalViewer::creator(LocalViewerCreatorParams {
             pds_hostname: cfg.service.hostname.clone(),
-            appview_agent: match cfg.bsky_app_view {
-                None => None,
-                Some(ref bsky_app_view) => Some(bsky_app_view.url.clone()),
-            },
-            appview_did: match cfg.bsky_app_view {
-                None => None,
-                Some(ref bsky_app_view) => Some(bsky_app_view.did.clone()),
-            },
+            appview_agent: cfg.bsky_app_view.as_ref().map(|bsky_app_view| bsky_app_view.url.clone()),
+            appview_did: cfg.bsky_app_view.as_ref().map(|bsky_app_view| bsky_app_view.did.clone()),
             appview_cdn_url_pattern: match cfg.bsky_app_view {
                 None => None,
                 Some(ref bsky_app_view) => bsky_app_view.cdn_url_pattern.clone(),

--- a/rsky-pds/src/models/error_code.rs
+++ b/rsky-pds/src/models/error_code.rs
@@ -53,6 +53,7 @@ pub enum ErrorCode {
 }
 
 impl ErrorCode {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(code: &str) -> Result<Self> {
         match code {
             "MultipleChoices" => Ok(Self::MultipleChoices),

--- a/rsky-pds/src/pipethrough.rs
+++ b/rsky-pds/src/pipethrough.rs
@@ -67,10 +67,7 @@ impl<'r> FromRequest<'r> for HandlerPipeThrough {
                 );
                 let proxy_req = ProxyRequest {
                     headers,
-                    query: match req.uri().query() {
-                        None => None,
-                        Some(query) => Some(query.to_string()),
-                    },
+                    query: req.uri().query().map(|query| query.to_string()),
                     path: req.uri().path().to_string(),
                     method: req.method(),
                     id_resolver: req.guard::<&State<SharedIdResolver>>().await.unwrap(),
@@ -134,10 +131,7 @@ impl<'r> FromRequest<'r> for ProxyRequest<'r> {
         );
         Outcome::Success(Self {
             headers,
-            query: match req.uri().query() {
-                None => None,
-                Some(query) => Some(query.to_string()),
-            },
+            query: req.uri().query().map(|query| query.to_string()),
             path: req.uri().path().to_string(),
             method: req.method(),
             id_resolver: req.guard::<&State<SharedIdResolver>>().await.unwrap(),
@@ -146,8 +140,8 @@ impl<'r> FromRequest<'r> for ProxyRequest<'r> {
     }
 }
 
-pub async fn pipethrough<'r>(
-    req: &'r ProxyRequest<'_>,
+pub async fn pipethrough(
+    req: &ProxyRequest<'_>,
     requester: Option<String>,
     override_opts: OverrideOpts,
 ) -> Result<HandlerPipeThrough> {
@@ -163,8 +157,8 @@ pub async fn pipethrough<'r>(
     parse_proxy_res(res).await
 }
 
-pub async fn pipethrough_procedure<'r, T: serde::Serialize>(
-    req: &'r ProxyRequest<'_>,
+pub async fn pipethrough_procedure<T: serde::Serialize>(
+    req: &ProxyRequest<'_>,
     requester: Option<String>,
     body: Option<T>,
 ) -> Result<HandlerPipeThrough> {
@@ -184,8 +178,8 @@ pub async fn pipethrough_procedure<'r, T: serde::Serialize>(
 }
 
 #[tracing::instrument(skip_all)]
-pub async fn pipethrough_procedure_post<'r>(
-    req: &'r ProxyRequest<'_>,
+pub async fn pipethrough_procedure_post(
+    req: &ProxyRequest<'_>,
     requester: Option<String>,
     body: Option<Data<'_>>,
 ) -> Result<HandlerPipeThrough, ApiError> {
@@ -236,8 +230,8 @@ const REQ_HEADERS_TO_FORWARD: [&str; 4] = [
 ];
 
 #[tracing::instrument(skip_all)]
-pub async fn format_url_and_aud<'r>(
-    req: &'r ProxyRequest<'_>,
+pub async fn format_url_and_aud(
+    req: &ProxyRequest<'_>,
     aud_override: Option<String>,
 ) -> Result<UrlAndAud> {
     let proxy_to = parse_proxy_header(req).await?;
@@ -251,10 +245,9 @@ pub async fn format_url_and_aud<'r>(
             );
             Some(proxy_to.service_url.clone())
         }
-        None => match default_proxy {
-            Some(ref default_proxy) => Some(default_proxy.url.clone()),
-            None => None,
-        },
+        None => default_proxy
+            .as_ref()
+            .map(|default_proxy| default_proxy.url.clone()),
     };
     let aud = match aud_override {
         Some(_) => aud_override,
@@ -285,8 +278,8 @@ pub async fn format_url_and_aud<'r>(
     }
 }
 
-pub async fn format_headers<'r>(
-    req: &'r ProxyRequest<'_>,
+pub async fn format_headers(
+    req: &ProxyRequest<'_>,
     aud: String,
     lxm: String,
     requester: Option<String>,
@@ -381,14 +374,14 @@ pub fn format_req_init_with_value(
     }
 }
 
-pub async fn parse_proxy_header<'r>(req: &'r ProxyRequest<'_>) -> Result<Option<ProxyHeader>> {
+pub async fn parse_proxy_header(req: &ProxyRequest<'_>) -> Result<Option<ProxyHeader>> {
     let headers = &req.headers;
     let proxy_to: Option<&String> = headers.get("atproto-proxy");
     match proxy_to {
         None => Ok(None),
         Some(proxy_to) => {
             let parts: Vec<&str> = proxy_to.split("#").collect::<Vec<&str>>();
-            match (parts.get(0), parts.get(1), parts.get(2)) {
+            match (parts.first(), parts.get(1), parts.get(2)) {
                 (Some(did), Some(service_id), None) => {
                     let did = did.to_string();
                     let id_resolver = req.id_resolver;
@@ -445,14 +438,12 @@ pub async fn make_request(req_init: RequestBuilder) -> Result<Response> {
                 bail!(InvalidRequestError::XRPCError(XRPCError::FailedResponse {
                     status,
                     headers,
-                    error: match error_body["error"].as_str() {
-                        None => None,
-                        Some(error_body_error) => Some(error_body_error.to_string()),
-                    },
-                    message: match error_body["message"].as_str() {
-                        None => None,
-                        Some(error_body_message) => Some(error_body_message.to_string()),
-                    }
+                    error: error_body["error"]
+                        .as_str()
+                        .map(|error_body_error| error_body_error.to_string()),
+                    message: error_body["message"]
+                        .as_str()
+                        .map(|error_body_message| error_body_message.to_string())
                 }))
             }
         },
@@ -546,7 +537,7 @@ lazy_static! {
 
 }
 
-pub async fn default_service<'r>(req: &'r ProxyRequest<'_>, nsid: &str) -> Option<ServiceConfig> {
+pub async fn default_service(req: &ProxyRequest<'_>, nsid: &str) -> Option<ServiceConfig> {
     let cfg = req.cfg;
     match Ids::from_str(nsid) {
         Ok(Ids::ToolsOzoneTeamAddMember) => cfg.mod_service.clone(),
@@ -591,8 +582,7 @@ pub fn is_safe_url(url: Url) -> bool {
         return false;
     }
     match url.host_str() {
-        None => false,
-        Some(hostname) if hostname == "localhost" => false,
+        None | Some("localhost") => false,
         Some(hostname) => {
             if std::net::IpAddr::from_str(hostname).is_ok() {
                 return false;

--- a/rsky-pds/src/read_after_write/util.rs
+++ b/rsky-pds/src/read_after_write/util.rs
@@ -77,14 +77,11 @@ impl<'r, T: Serialize> Responder<'r, 'static> for ReadAfterWriteResponse<T> {
 }
 
 pub fn get_repo_rev(headers: &BTreeMap<String, String>) -> Option<String> {
-    headers.get(REPO_REV_HEADER).map(|value| value.clone())
+    headers.get(REPO_REV_HEADER).cloned()
 }
 
 pub fn get_local_lag(local: &LocalRecords) -> Result<Option<usize>> {
-    let mut oldest: Option<String> = match local.profile {
-        None => None,
-        Some(ref profile) => Some(profile.indexed_at.clone()),
-    };
+    let mut oldest: Option<String> = local.profile.as_ref().map(|profile| profile.indexed_at.clone());
     for post in local.posts.clone() {
         match oldest {
             None => oldest = Some(post.indexed_at),
@@ -105,6 +102,7 @@ pub fn get_local_lag(local: &LocalRecords) -> Result<Option<usize>> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all)]
 pub async fn handle_read_after_write<T: DeserializeOwned + serde::Serialize>(
     nsid: String,
@@ -140,6 +138,7 @@ pub async fn handle_read_after_write<T: DeserializeOwned + serde::Serialize>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn read_after_write_internal<T: DeserializeOwned + serde::Serialize>(
     nsid: String,
     requester: String,
@@ -150,7 +149,7 @@ pub async fn read_after_write_internal<T: DeserializeOwned + serde::Serialize>(
     db: DbConn,
     account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<T>> {
-    let headers = &res.headers.clone().unwrap_or_else(BTreeMap::new);
+    let headers = &res.headers.clone().unwrap_or_default();
     let rev = get_repo_rev(headers);
     match rev {
         None => Ok(ReadAfterWriteResponse::HandlerPipeThrough(res)),
@@ -191,6 +190,18 @@ pub fn format_munged_response<T: DeserializeOwned + serde::Serialize>(
             }
         },
     })
+}
+
+pub fn nodejs_format(format: &str, args: &[&dyn std::fmt::Display]) -> String {
+    let mut result = String::new();
+    let parts = format.split("{}");
+    for (i, part) in parts.enumerate() {
+        result.push_str(part);
+        if i < args.len() {
+            result.push_str(&args[i].to_string());
+        }
+    }
+    result
 }
 
 #[cfg(test)]
@@ -246,16 +257,4 @@ mod tests {
         assert_eq!(wrapped["encoding"], json!("application/json"));
         assert!(wrapped.as_object().unwrap().contains_key("body"));
     }
-}
-
-pub fn nodejs_format(format: &str, args: &[&dyn std::fmt::Display]) -> String {
-    let mut result = String::new();
-    let parts = format.split("{}");
-    for (i, part) in parts.enumerate() {
-        result.push_str(part);
-        if i < args.len() {
-            result.push_str(&args[i].to_string());
-        }
-    }
-    result
 }

--- a/rsky-pds/src/read_after_write/util.rs
+++ b/rsky-pds/src/read_after_write/util.rs
@@ -81,7 +81,10 @@ pub fn get_repo_rev(headers: &BTreeMap<String, String>) -> Option<String> {
 }
 
 pub fn get_local_lag(local: &LocalRecords) -> Result<Option<usize>> {
-    let mut oldest: Option<String> = local.profile.as_ref().map(|profile| profile.indexed_at.clone());
+    let mut oldest: Option<String> = local
+        .profile
+        .as_ref()
+        .map(|profile| profile.indexed_at.clone());
     for post in local.posts.clone() {
         match oldest {
             None => oldest = Some(post.indexed_at),

--- a/rsky-pds/src/read_after_write/viewer.rs
+++ b/rsky-pds/src/read_after_write/viewer.rs
@@ -112,10 +112,7 @@ impl LocalViewer {
                             Some(AtpServiceClient::new(client))
                         }
                     },
-                    match params.appview_agent {
-                        None => None,
-                        Some(ref bsky_app_view_url) => Some(bsky_app_view_url.clone()),
-                    },
+                    params.appview_agent.clone(),
                     params.appview_did.clone(),
                     params.appview_cdn_url_pattern.clone(),
                 )
@@ -133,7 +130,7 @@ impl LocalViewer {
                 cid
             ),
             Some(appview_cdn_url_pattern) => {
-                util::nodejs_format(&*appview_cdn_url_pattern, &[&pattern, &self.did, &cid])
+                util::nodejs_format(appview_cdn_url_pattern, &[&pattern, &self.did, &cid])
             }
         }
     }
@@ -205,12 +202,9 @@ impl LocalViewer {
                     },
                     avatar: match record {
                         Some(record) => match record.avatar {
-                            Some(avatar) => match avatar.r#ref {
-                                Some(r#ref) => Some(
-                                    self.get_image_url("avatar".to_string(), r#ref.to_string()),
-                                ),
-                                None => None,
-                            },
+                            Some(avatar) => avatar.r#ref.map(|r#ref| {
+                                self.get_image_url("avatar".to_string(), r#ref.to_string())
+                            }),
                             None => None,
                         },
                         None => None,
@@ -330,7 +324,7 @@ impl LocalViewer {
                     .map(|img| ViewImage {
                         thumb: self.get_image_url(
                             "feed_thumbnail".to_string(),
-                            img.image.r#ref.clone().unwrap().to_string(),
+                            img.image.r#ref.unwrap().to_string(),
                         ),
                         fullsize: self.get_image_url(
                             "feed_fullsize".to_string(),
@@ -406,7 +400,7 @@ impl LocalViewer {
                         None => Ok(None),
                         Some(post) => {
                             let post: PostView =
-                                serde_json::from_value(serde_json::to_value(&post)?)?;
+                                serde_json::from_value(serde_json::to_value(post)?)?;
                             Ok(Some(record::ViewUnion::ViewRecord(ViewRecord {
                                 uri: post.uri,
                                 cid: post.cid,
@@ -416,10 +410,7 @@ impl LocalViewer {
                                 reply_count: None,
                                 repost_count: None,
                                 like_count: None,
-                                embeds: match post.embed {
-                                    Some(post_embed) => Some(vec![post_embed]),
-                                    None => None,
-                                },
+                                embeds: post.embed.map(|post_embed| vec![post_embed]),
                                 indexed_at: post.indexed_at,
                             })))
                         }
@@ -501,12 +492,9 @@ impl LocalViewer {
             display_name: record.display_name,
             avatar: match record.avatar {
                 None => None,
-                Some(avatar) => match avatar.r#ref {
-                    Some(r#ref) => {
-                        Some(self.get_image_url("avatar".to_string(), r#ref.to_string()))
-                    }
-                    None => None,
-                },
+                Some(avatar) => avatar
+                    .r#ref
+                    .map(|r#ref| self.get_image_url("avatar".to_string(), r#ref.to_string())),
             },
             associated,
             viewer,
@@ -605,12 +593,9 @@ impl LocalViewer {
             avatar,
             banner: match record.banner {
                 None => None,
-                Some(record_banner) => match record_banner.r#ref {
-                    Some(r#ref) => {
-                        Some(self.get_image_url("banner".to_string(), r#ref.to_string()))
-                    }
-                    None => None,
-                },
+                Some(record_banner) => record_banner
+                    .r#ref
+                    .map(|r#ref| self.get_image_url("banner".to_string(), r#ref.to_string())),
             },
             followers_count,
             follows_count,
@@ -626,7 +611,7 @@ impl LocalViewer {
 
     async fn get_authenticated_agent_for_nsid(
         &self,
-        nsid: &String,
+        nsid: &str,
     ) -> Result<AtpServiceClient<ReqwestClient>> {
         let auth_headers = self.service_auth_headers(&self.did, nsid).await?;
         let base = match self.appview_agent_str {
@@ -639,8 +624,7 @@ impl LocalViewer {
                     .user_agent(APP_USER_AGENT)
                     .timeout(std::time::Duration::from_millis(1000))
                     .default_headers(auth_headers)
-                    .build()
-                    .unwrap(),
+                    .build()?,
             )
             .build();
         Ok(AtpServiceClient::new(client))
@@ -706,7 +690,7 @@ pub async fn get_records_since_rev(actor_store: &ActorStore, rev: String) -> Res
         |mut acc: LocalRecords, cur| {
             let uri: AtUri = AtUri::new(cur.0.uri, None)?;
             if uri.get_collection() == Ids::AppBskyActorProfile.as_str()
-                && uri.get_rkey() == "self".to_string()
+                && uri.get_rkey() == *"self"
             {
                 let profile: Profile = serde_ipld_dagcbor::from_slice(cur.1.content.as_slice())?;
                 let descript = RecordDescript {

--- a/rsky-pds/src/repo/prepare.rs
+++ b/rsky-pds/src/repo/prepare.rs
@@ -86,7 +86,7 @@ pub fn blobs_for_write(record: RepoRecord, validate: bool) -> anyhow::Result<Vec
 
 pub fn find_blob_refs(val: Lex, path: Option<Vec<String>>, layer: Option<u8>) -> Vec<FoundBlobRef> {
     let layer = layer.unwrap_or(0);
-    let path = path.unwrap_or_else(std::vec::Vec::new);
+    let path = path.unwrap_or_default();
     if layer > 32 {
         return vec![];
     }
@@ -156,7 +156,7 @@ pub fn set_collection_name(
         );
     }
     if let Some(Lex::Ipld(Ipld::Json(JsonValue::String(record_type)))) = record.get("$type") {
-        if validate && record_type.to_string() != *collection {
+        if validate && record_type != collection {
             bail!("Invalid $type: expected {collection}, got {record_type}")
         }
     }

--- a/rsky-pds/src/sequencer/events.rs
+++ b/rsky-pds/src/sequencer/events.rs
@@ -165,7 +165,7 @@ pub struct TypedAccountEvt {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum SeqEvt {
-    TypedCommitEvt(TypedCommitEvt),
+    TypedCommitEvt(Box<TypedCommitEvt>),
     // TypedHandleEvt(TypedHandleEvt),
     TypedIdentityEvt(TypedIdentityEvt),
     TypedAccountEvt(TypedAccountEvt),
@@ -339,16 +339,16 @@ pub async fn format_seq_sync_evt(did: String, data: SyncEvtData) -> Result<model
 }
 
 pub async fn sync_evt_data_from_commit(mut commit_data: CommitDataWithOps) -> Result<SyncEvtData> {
-    let cid = vec![commit_data.commit_data.cid.clone()];
+    let cid = vec![commit_data.commit_data.cid];
     match commit_data.commit_data.relevant_blocks.get_many(cid) {
-        Ok(blocks_and_missing) if blocks_and_missing.missing.len() > 0 => Err(anyhow::anyhow!(
+        Ok(blocks_and_missing) if !blocks_and_missing.missing.is_empty() => Err(anyhow::anyhow!(
             "commit block was not found, could not build sync event"
         )),
         Ok(blocks_and_missing) => Ok(SyncEvtData {
             rev: commit_data.commit_data.rev,
-            cid: commit_data.commit_data.cid.clone(),
+            cid: commit_data.commit_data.cid,
             blocks: blocks_and_missing.blocks,
         }),
-        Err(e) => Err(e.into()),
+        Err(e) => Err(e),
     }
 }

--- a/rsky-pds/src/sequencer/mod.rs
+++ b/rsky-pds/src/sequencer/mod.rs
@@ -51,7 +51,7 @@ impl Sequencer {
         self.last_seen = Some(curr.unwrap_or(0));
         if self.waker.is_none() {
             loop {
-                while let Some(_) = self.next().await {}
+                while self.next().await.is_some() {}
             }
         }
         Ok(())
@@ -136,7 +136,7 @@ impl Sequencer {
         }
 
         let rows = seq_qb.get_results(conn)?;
-        if rows.len() < 1 {
+        if rows.is_empty() {
             return Ok(vec![]);
         }
 
@@ -147,12 +147,12 @@ impl Sequencer {
                 None => continue, // should never hit this because of WHERE clause
                 Some(seq) => match row.event_type.as_str() {
                     "append" | "rebase" => {
-                        seq_evts.push(SeqEvt::TypedCommitEvt(TypedCommitEvt {
+                        seq_evts.push(SeqEvt::TypedCommitEvt(Box::new(TypedCommitEvt {
                             r#type: "commit".to_string(),
                             seq,
                             time,
                             evt: cbor_to_struct(row.event)?,
-                        }));
+                        })));
                     }
                     "sync" => {
                         seq_evts.push(SeqEvt::TypedSyncEvt(TypedSyncEvt {
@@ -263,7 +263,7 @@ impl Stream for Sequencer {
             return Poll::Ready(None);
         }
         // if already polling, do not start another poll
-        return match futures::executor::block_on(self.request_seq_range(RequestSeqRangeOpts {
+        match futures::executor::block_on(self.request_seq_range(RequestSeqRangeOpts {
             earliest_seq: self.last_seen,
             latest_seq: None,
             earliest_time: None,
@@ -280,7 +280,7 @@ impl Stream for Sequencer {
                 Poll::Ready(Some(Err(err)))
             }
             Ok(evts) => {
-                if evts.len() > 0 {
+                if !evts.is_empty() {
                     self.tries_with_no_results = 0;
                     futures::executor::block_on(EVENT_EMITTER.write()).emit(
                         "events",
@@ -300,19 +300,19 @@ impl Stream for Sequencer {
                     Poll::Pending
                 }
             }
-        };
+        }
     }
 }
 
 pub async fn delete_all_for_user(did: &String, excluding_seqs: Option<Vec<i64>>) -> Result<()> {
     use crate::schema::pds::repo_seq::dsl as RepoSeqSchema;
     let conn = &mut establish_connection_for_sequencer()?;
-    let excluding_seqs = excluding_seqs.unwrap_or_else(|| vec![]);
+    let excluding_seqs = excluding_seqs.unwrap_or_default();
 
     let mut builder = delete(RepoSeqSchema::repo_seq)
         .filter(RepoSeqSchema::did.eq(did))
         .into_boxed();
-    if excluding_seqs.len() > 0 {
+    if !excluding_seqs.is_empty() {
         builder = builder.filter(RepoSeqSchema::seq.ne_all(excluding_seqs));
     }
     builder.execute(conn)?;

--- a/rsky-pds/src/sequencer/outbox.rs
+++ b/rsky-pds/src/sequencer/outbox.rs
@@ -42,10 +42,10 @@ impl Outbox {
         }
     }
 
-    pub async fn events<'a>(
-        &'a mut self,
+    pub async fn events(
+        &mut self,
         backfill_cursor: Option<i64>,
-    ) -> impl Stream<Item = Result<SeqEvt>> + 'a {
+    ) -> impl Stream<Item = Result<SeqEvt>> + use<'_> {
         try_stream! {
             if let Some(cursor) = backfill_cursor {
                 let backfill_stream = self.get_backfill(cursor).await;
@@ -131,10 +131,10 @@ impl Outbox {
         }
     }
 
-    pub async fn get_backfill<'a>(
-        &'a mut self,
+    pub async fn get_backfill(
+        &mut self,
         backfill_cursor: i64,
-    ) -> impl Stream<Item = Result<SeqEvt>> + 'a {
+    ) -> impl Stream<Item = Result<SeqEvt>> + use<'_> {
         try_stream! {
             loop {
                 let earliest_seq = if self.last_seen > -1 {

--- a/rsky-pds/tests/common/mod.rs
+++ b/rsky-pds/tests/common/mod.rs
@@ -62,7 +62,7 @@ pub async fn get_client(postgres: &ContainerAsync<Postgres>) -> Client {
     let connection_string = format!("postgres://postgres:postgres@localhost:{port}/postgres",);
     Client::untracked(
         build_rocket(Some(RocketConfig {
-            db_url: String::from(connection_string),
+            db_url: connection_string,
         }))
         .await,
     )

--- a/rsky-repo/src/block_map.rs
+++ b/rsky-repo/src/block_map.rs
@@ -19,6 +19,12 @@ pub struct BlockMap {
     pub map: BTreeMap<String, Bytes>,
 }
 
+impl Default for BlockMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BlockMap {
     pub fn new() -> Self {
         BlockMap {
@@ -35,9 +41,9 @@ impl BlockMap {
         Ok(cid)
     }
 
-    pub fn set(&mut self, cid: Cid, bytes: Vec<u8>) -> () {
+    pub fn set(&mut self, cid: Cid, bytes: Vec<u8>) {
         self.map.insert(cid.to_string(), Bytes(bytes));
-        ()
+        
     }
 
     pub fn get(&self, cid: Cid) -> Option<&Vec<u8>> {
@@ -66,14 +72,14 @@ impl BlockMap {
         self.map.contains_key(&cid.to_string())
     }
 
-    pub fn clear(&mut self) -> () {
+    pub fn clear(&mut self) {
         self.map.clear()
     }
 
     // Not really using. Issues with closures
-    pub fn for_each(&self, cb: impl Fn(&Vec<u8>, Cid) -> ()) -> Result<()> {
+    pub fn for_each(&self, cb: impl Fn(&Vec<u8>, Cid)) -> Result<()> {
         for (key, val) in self.map.iter() {
-            cb(&val.0, Cid::from_str(&key)?);
+            cb(&val.0, Cid::from_str(key)?);
         }
         Ok(())
     }
@@ -94,10 +100,10 @@ impl BlockMap {
     }
 
     pub fn add_map(&mut self, to_add: BlockMap) -> Result<()> {
-        let results = for (cid, bytes) in to_add.map.iter() {
+        for (cid, bytes) in to_add.map.iter() {
             self.set(Cid::from_str(cid)?, bytes.0.clone());
         };
-        Ok(results)
+        Ok(())
     }
 
     pub fn size(&self) -> usize {

--- a/rsky-repo/src/block_map.rs
+++ b/rsky-repo/src/block_map.rs
@@ -43,7 +43,6 @@ impl BlockMap {
 
     pub fn set(&mut self, cid: Cid, bytes: Vec<u8>) {
         self.map.insert(cid.to_string(), Bytes(bytes));
-        
     }
 
     pub fn get(&self, cid: Cid) -> Option<&Vec<u8>> {
@@ -102,7 +101,7 @@ impl BlockMap {
     pub fn add_map(&mut self, to_add: BlockMap) -> Result<()> {
         for (cid, bytes) in to_add.map.iter() {
             self.set(Cid::from_str(cid)?, bytes.0.clone());
-        };
+        }
         Ok(())
     }
 

--- a/rsky-repo/src/car.rs
+++ b/rsky-repo/src/car.rs
@@ -34,7 +34,7 @@ where
     let (writer, mut reader) = tokio::io::duplex(8 * 1024); // 8KB buffer
 
     // Create CAR header with roots
-    let roots = root.map_or_else(Vec::new, |r| vec![r.clone()]);
+    let roots = root.map_or_else(Vec::new, |r| vec![*r]);
     let header = CarHeader::new_v1(roots);
     let car_writer = CarWriter::new(header, writer);
 

--- a/rsky-repo/src/cid_set.rs
+++ b/rsky-repo/src/cid_set.rs
@@ -9,7 +9,7 @@ pub struct CidSet {
 impl CidSet {
     pub fn new(arr: Option<Vec<Cid>>) -> Self {
         let str_arr: Vec<String> = arr
-            .unwrap_or(Vec::new())
+            .unwrap_or_default()
             .into_iter()
             .map(|cid| cid.to_string())
             .collect::<Vec<String>>();
@@ -18,28 +18,28 @@ impl CidSet {
         }
     }
 
-    pub fn add(&mut self, cid: Cid) -> () {
+    pub fn add(&mut self, cid: Cid) {
         let _ = &self.set.insert(cid.to_string());
-        ()
+        
     }
 
-    pub fn add_set(&mut self, to_merge: CidSet) -> () {
+    pub fn add_set(&mut self, to_merge: CidSet) {
         for cid in to_merge.to_list() {
             let _ = &self.add(cid);
         }
-        ()
+        
     }
 
-    pub fn subtract_set(&mut self, to_subtract: CidSet) -> () {
+    pub fn subtract_set(&mut self, to_subtract: CidSet) {
         for cid in to_subtract.to_list() {
             self.delete(cid);
         }
-        ()
+        
     }
 
-    pub fn delete(&mut self, cid: Cid) -> () {
+    pub fn delete(&mut self, cid: Cid) {
         self.set.remove(&cid.to_string());
-        ()
+        
     }
 
     pub fn has(&self, cid: Cid) -> bool {
@@ -50,19 +50,16 @@ impl CidSet {
         self.set.len()
     }
 
-    pub fn clear(mut self) -> () {
+    pub fn clear(mut self) {
         self.set.clear();
-        ()
+        
     }
 
     pub fn to_list(&self) -> Vec<Cid> {
         self.set
             .clone()
             .into_iter()
-            .filter_map(|cid| match Cid::from_str(&cid) {
-                Ok(r) => Some(r),
-                Err(_) => None,
-            })
+            .filter_map(|cid| Cid::from_str(&cid).ok())
             .collect::<Vec<Cid>>()
     }
 }

--- a/rsky-repo/src/cid_set.rs
+++ b/rsky-repo/src/cid_set.rs
@@ -20,26 +20,22 @@ impl CidSet {
 
     pub fn add(&mut self, cid: Cid) {
         let _ = &self.set.insert(cid.to_string());
-        
     }
 
     pub fn add_set(&mut self, to_merge: CidSet) {
         for cid in to_merge.to_list() {
             let _ = &self.add(cid);
         }
-        
     }
 
     pub fn subtract_set(&mut self, to_subtract: CidSet) {
         for cid in to_subtract.to_list() {
             self.delete(cid);
         }
-        
     }
 
     pub fn delete(&mut self, cid: Cid) {
         self.set.remove(&cid.to_string());
-        
     }
 
     pub fn has(&self, cid: Cid) -> bool {
@@ -52,7 +48,6 @@ impl CidSet {
 
     pub fn clear(mut self) {
         self.set.clear();
-        
     }
 
     pub fn to_list(&self) -> Vec<Cid> {

--- a/rsky-repo/src/data_diff.rs
+++ b/rsky-repo/src/data_diff.rs
@@ -38,6 +38,12 @@ pub struct DataDiff {
     pub removed_mst_blocks: CidSet,
 }
 
+impl Default for DataDiff {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DataDiff {
     pub fn new() -> Self {
         DataDiff {
@@ -88,11 +94,11 @@ impl DataDiff {
         Ok(())
     }
 
-    pub fn leaf_add(&mut self, key: &String, cid: Cid) -> () {
+    pub fn leaf_add(&mut self, key: &str, cid: Cid) {
         self.adds.insert(
-            key.clone(),
+            key.to_owned(),
             DataAdd {
-                key: key.clone(),
+                key: key.to_owned(),
                 cid,
             },
         );
@@ -101,17 +107,16 @@ impl DataDiff {
         } else {
             self.new_leaf_cids.add(cid);
         }
-        ()
     }
 
-    pub fn leaf_update(&mut self, key: &String, prev: Cid, cid: Cid) -> () {
+    pub fn leaf_update(&mut self, key: &str, prev: Cid, cid: Cid) {
         if prev.eq(&cid) {
-            return ();
+            return;
         }
         self.updates.insert(
-            key.clone(),
+            key.to_owned(),
             DataUpdate {
-                key: key.clone(),
+                key: key.to_owned(),
                 prev,
                 cid,
             },
@@ -120,11 +125,11 @@ impl DataDiff {
         self.new_leaf_cids.add(cid);
     }
 
-    pub fn leaf_delete(&mut self, key: &String, cid: Cid) -> () {
+    pub fn leaf_delete(&mut self, key: &str, cid: Cid) {
         self.deletes.insert(
-            key.clone(),
+            key.to_owned(),
             DataDelete {
-                key: key.clone(),
+                key: key.to_owned(),
                 cid,
             },
         );
@@ -135,14 +140,13 @@ impl DataDiff {
         }
     }
 
-    pub fn tree_add(&mut self, cid: Cid, bytes: Vec<u8>) -> () {
+    pub fn tree_add(&mut self, cid: Cid, bytes: Vec<u8>) {
         if self.removed_cids.has(cid) {
             self.removed_cids.delete(cid);
             self.removed_mst_blocks.delete(cid);
         } else {
             self.new_mst_blocks.set(cid, bytes);
         }
-        ()
     }
 
     pub fn tree_delete(&mut self, cid: Cid) -> Result<()> {

--- a/rsky-repo/src/mst/diff.rs
+++ b/rsky-repo/src/mst/diff.rs
@@ -13,9 +13,10 @@ pub async fn null_diff(tree: MST) -> Result<DataDiff> {
     Ok(diff)
 }
 
+#[allow(clippy::comparison_chain)]
 pub async fn mst_diff(curr: &mut MST, prev: Option<&mut MST>) -> Result<DataDiff> {
     curr.get_pointer().await?;
-    return if let Some(prev) = prev {
+    if let Some(prev) = prev {
         prev.get_pointer().await?;
         let mut diff = DataDiff::new();
 
@@ -50,6 +51,7 @@ pub async fn mst_diff(curr: &mut MST, prev: Option<&mut MST>) -> Result<DataDiff
 
                     // if both pointers are leaves, record an update & advance both or record
                     // the lowest key and advance that pointer
+                    // todo: switch to match statement
                     if let (NodeEntry::Leaf(left_leaf), NodeEntry::Leaf(right_leaf)) =
                         (&left, &right)
                     {
@@ -75,6 +77,7 @@ pub async fn mst_diff(curr: &mut MST, prev: Option<&mut MST>) -> Result<DataDiff
                     // try to catch up with the lower
                     // if the higher walker is pointed at a leaf, then advance the lower walker
                     // to try to catch up the higher
+                    // todo: switch to match statement
                     if left_walker.layer()? > right_walker.layer()? {
                         if left.is_leaf() {
                             diff.node_add(right).await?;
@@ -101,6 +104,7 @@ pub async fn mst_diff(curr: &mut MST, prev: Option<&mut MST>) -> Result<DataDiff
                     if let (NodeEntry::MST(left_tree), NodeEntry::MST(right_tree)) =
                         (&mut left, &mut right)
                     {
+                        // todo: switch to match statement
                         if left_tree
                             .get_pointer()
                             .await?
@@ -136,5 +140,5 @@ pub async fn mst_diff(curr: &mut MST, prev: Option<&mut MST>) -> Result<DataDiff
         Ok(diff)
     } else {
         Ok(null_diff(curr.clone()).await?)
-    };
+    }
 }

--- a/rsky-repo/src/mst/mod.rs
+++ b/rsky-repo/src/mst/mod.rs
@@ -36,7 +36,7 @@ use std::{fmt, mem};
 use tokio::io::DuplexStream;
 use tokio::sync::RwLock;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct NodeIter {
     entries: Vec<NodeEntry>, // Contains the remaining children of a node,
     // The iterator of the parent node, if present
@@ -44,16 +44,6 @@ pub struct NodeIter {
     // without indirection
     parent: Option<Box<NodeIter>>,
     this: Option<NodeEntry>,
-}
-
-impl Default for NodeIter {
-    fn default() -> Self {
-        NodeIter {
-            entries: vec![],
-            parent: None,
-            this: None,
-        }
-    }
 }
 
 /// We want to traverse (i.e. iterate over) this kind of tree depth-first. This means that
@@ -131,21 +121,11 @@ impl NodeIter {
 }
 
 /// Alternative implementation of iterator
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct NodeIterReachable {
     entries: Vec<NodeEntry>,
     parent: Option<Box<NodeIterReachable>>,
     this: Option<NodeEntry>,
-}
-
-impl Default for NodeIterReachable {
-    fn default() -> Self {
-        NodeIterReachable {
-            entries: vec![],
-            parent: None,
-            this: None,
-        }
-    }
 }
 
 impl NodeIterReachable {
@@ -248,10 +228,7 @@ pub struct TreeEntry {
 
 impl Debug for TreeEntry {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let t_string = match &self.t {
-            None => None,
-            Some(cid) => Some(cid.to_string()),
-        };
+        let t_string = self.t.as_ref().map(|cid| cid.to_string());
         f.debug_struct("TreeEntry")
             .field("p", &self.p)
             .field("k", &self.k)
@@ -271,10 +248,7 @@ pub struct NodeData {
 
 impl Debug for NodeData {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let cid = match &self.l {
-            None => None,
-            Some(cid) => Some(cid.to_string()),
-        };
+        let cid = self.l.as_ref().map(|cid| cid.to_string());
         f.debug_struct("NodeData")
             .field("l", &cid)
             .field("e", &self.e)
@@ -331,17 +305,11 @@ pub enum NodeEntry {
 
 impl NodeEntry {
     pub fn is_tree(&self) -> bool {
-        match self {
-            NodeEntry::MST(_) => true,
-            _ => false,
-        }
+        matches!(self, NodeEntry::MST(_))
     }
 
     pub fn is_leaf(&self) -> bool {
-        match self {
-            NodeEntry::Leaf(_) => true,
-            _ => false,
-        }
+        matches!(self, NodeEntry::Leaf(_))
     }
 
     fn iter(self) -> NodeIter {
@@ -492,7 +460,7 @@ impl Display for MST {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         fn pointer_str(mst: &MST) -> String {
             let cid_guard = mst.pointer.try_read().unwrap();
-            format!("*({})", util::short_cid(&*cid_guard))
+            format!("*({})", util::short_cid(&cid_guard))
         }
 
         fn fmt_mst(mst: &MST, f: &mut Formatter<'_>, prefix: &str, is_last: bool) -> fmt::Result {
@@ -566,7 +534,7 @@ impl MST {
         entries: Option<Vec<NodeEntry>>,
         layer: Option<u32>,
     ) -> Result<Self> {
-        let entries = entries.unwrap_or(Vec::new());
+        let entries = entries.unwrap_or_default();
         let pointer = util::cid_for_entries(entries.as_slice()).await?;
         Ok(MST::new(storage, pointer, Some(entries), layer))
     }
@@ -598,7 +566,7 @@ impl MST {
     pub async fn new_tree(&mut self, entries: Vec<NodeEntry>) -> Result<Self> {
         let mut mst = MST::new(
             self.storage.clone(),
-            self.pointer.read().await.clone(),
+            *self.pointer.read().await,
             Some(entries),
             self.layer,
         );
@@ -619,19 +587,16 @@ impl MST {
                 let pointer = self.pointer.read().await;
                 let data: CborValue = storage_guard
                     .read_obj(
-                        &*pointer,
+                        &pointer,
                         Box::new(|obj: CborValue| {
-                            match serde_cbor::value::from_value::<NodeData>(obj.clone()) {
-                                Ok(_) => true,
-                                Err(_) => false,
-                            }
+                            serde_cbor::value::from_value::<NodeData>(obj.clone()).is_ok()
                         }),
                     )
                     .await?;
                 let data: NodeData = serde_cbor::value::from_value(data)?;
 
                 // Compute the layer
-                let first_leaf = data.e.get(0);
+                let first_leaf = data.e.first();
                 let layer = match first_leaf {
                     Some(first_leaf) => Some(util::leading_zeros_on_hash(&first_leaf.k)?),
                     None => None,
@@ -651,7 +616,7 @@ impl MST {
         guard
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("No entries present"))
-            .map(|v| v.clone())
+            .cloned()
     }
 
     // We don't hash the node on every mutation for performance reasons
@@ -682,7 +647,7 @@ impl MST {
             }
         }
 
-        if outdated.len() > 0 {
+        if !outdated.is_empty() {
             for outdated_entry in &outdated {
                 let _ = outdated_entry.get_pointer().await?;
             }
@@ -765,9 +730,10 @@ impl MST {
 
     /// Adds a new leaf for the given key/value pair
     /// Throws if a leaf with that key already exists
+    #[allow(clippy::comparison_chain)]
     #[async_recursion(Sync)]
     pub async fn add(&mut self, key: &str, value: Cid, known_zeros: Option<u32>) -> Result<Self> {
-        util::ensure_valid_mst_key(&key)?;
+        util::ensure_valid_mst_key(key)?;
         let key_zeros: u32;
         if let Some(z) = known_zeros {
             key_zeros = z;
@@ -781,9 +747,10 @@ impl MST {
             value,
         };
 
+        // todo: rewrite as match
         return if key_zeros == layer {
             // it belongs in this layer
-            let index = self.find_gt_or_equal_leaf_index(&key).await?;
+            let index = self.find_gt_or_equal_leaf_index(key).await?;
 
             let found = self.at_index(index).await?;
             if let Some(NodeEntry::Leaf(l)) = found {
@@ -875,7 +842,7 @@ impl MST {
         }
         let prev = self.at_index(index - 1).await?;
         if let Some(NodeEntry::MST(mut p)) = prev {
-            return Ok(p.get(key).await?);
+            return p.get(key).await;
         }
         return Ok(None);
     }
@@ -913,7 +880,7 @@ impl MST {
     /// Deletes the value at the given key
     pub async fn delete(&mut self, key: &String) -> Result<Self> {
         let altered = self.delete_recurse(key).await?;
-        Ok(altered.trim_top().await?)
+        altered.trim_top().await
     }
 
     #[async_recursion(Sync)]
@@ -945,7 +912,7 @@ impl MST {
         return if let Some(NodeEntry::MST(mut p)) = prev {
             let subtree = &mut p.delete_recurse(key).await?;
             let subtree_entries = subtree.get_entries().await?;
-            if subtree_entries.len() == 0 {
+            if subtree_entries.is_empty() {
                 self.remove_entry(index - 1).await
             } else {
                 self.update_entry(index - 1, NodeEntry::MST(subtree.clone()))
@@ -962,11 +929,11 @@ impl MST {
     /// update entry in place
     pub async fn update_entry(&mut self, index: isize, entry: NodeEntry) -> Result<Self> {
         let mut update = Vec::new();
-        for e in self.slice(Some(0), Some(index)).await?.to_vec() {
+        for e in self.slice(Some(0), Some(index)).await?.iter().cloned() {
             update.push(e);
         }
         update.push(entry);
-        for e in self.slice(Some(index + 1), None).await?.to_vec() {
+        for e in self.slice(Some(index + 1), None).await?.iter().cloned() {
             update.push(e);
         }
         self.new_tree(update).await
@@ -999,10 +966,7 @@ impl MST {
     pub async fn at_index(&mut self, index: isize) -> Result<Option<NodeEntry>> {
         let entries = self.get_entries().await?;
         if index >= 0 {
-            Ok(entries
-                .into_iter()
-                .nth(index as usize)
-                .map(|entry| entry.clone()))
+            Ok(entries.into_iter().nth(index as usize))
         } else {
             Ok(None)
         }
@@ -1016,9 +980,9 @@ impl MST {
             (Some(start), Some(end)) => {
                 // Adapted from Javascript Array.prototype.slice()
                 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice
-                let start: usize = if start < 0 && start >= (-1 * entry_len) {
+                let start: usize = if start < 0 && start >= -entry_len {
                     (start + entry_len) as usize
-                } else if start < (-1 * entry_len) {
+                } else if start < -entry_len {
                     0
                 } else if start >= entry_len {
                     return Ok(vec![]);
@@ -1026,9 +990,9 @@ impl MST {
                     start as usize
                 };
 
-                let end: usize = if end < 0 && end >= (-1 * entry_len) {
+                let end: usize = if end < 0 && end >= -entry_len {
                     (end + entry_len) as usize
-                } else if end < (-1 * entry_len) {
+                } else if end < -entry_len {
                     0
                 } else if end >= entry_len {
                     entries.len()
@@ -1041,9 +1005,9 @@ impl MST {
                 Ok(entries[start..end].to_vec())
             }
             (Some(start), None) => {
-                let start: usize = if start < 0 && start >= (-1 * entry_len) {
+                let start: usize = if start < 0 && start >= -entry_len {
                     (start + entry_len) as usize
-                } else if start < (-1 * entry_len) {
+                } else if start < -entry_len {
                     0
                 } else if start >= entry_len {
                     return Ok(vec![]);
@@ -1053,9 +1017,9 @@ impl MST {
                 Ok(entries[start..].to_vec())
             }
             (None, Some(end)) => {
-                let end: usize = if end < 0 && end >= (-1 * entry_len) {
+                let end: usize = if end < 0 && end >= -entry_len {
                     (end + entry_len) as usize
-                } else if end < (-1 * entry_len) {
+                } else if end < -entry_len {
                     0
                 } else if end >= entry_len {
                     entries.len()
@@ -1073,11 +1037,11 @@ impl MST {
     /// inserts entry at index
     pub async fn splice_in(&mut self, entry: NodeEntry, index: isize) -> Result<Self> {
         let mut update = Vec::new();
-        for e in self.slice(Some(0), Some(index)).await?.to_vec() {
+        for e in self.slice(Some(0), Some(index)).await?.iter().cloned() {
             update.push(e);
         }
         update.push(entry);
-        for e in self.slice(Some(index), None).await?.to_vec() {
+        for e in self.slice(Some(index), None).await?.iter().cloned() {
             update.push(e);
         }
         self.new_tree(update).await
@@ -1158,16 +1122,15 @@ impl MST {
             }
         }
 
-        let left_output: Option<Self>;
-        match left.get_entries().await?.len() {
-            0 => left_output = None,
-            _ => left_output = Some(left),
+        let left_output = match left.get_entries().await?.len() {
+            0 => None,
+            _ => Some(left),
         };
-        let right_output: Option<Self>;
-        match right.get_entries().await?.len() {
-            0 => right_output = None,
-            _ => right_output = Some(right),
+        let right_output = match right.get_entries().await?.len() {
+            0 => None,
+            _ => Some(right),
         };
+
         Ok((left_output, right_output))
     }
 
@@ -1231,7 +1194,7 @@ impl MST {
         let entries = self.get_entries().await?;
         let maybe_index = entries.iter().position(|entry| match entry {
             NodeEntry::MST(_) => false,
-            NodeEntry::Leaf(entry) => entry.key >= key.to_string(),
+            NodeEntry::Leaf(entry) => entry.key.as_str() >= key,
         });
         // if we can't find, we're on the end
         if let Some(i) = maybe_index {
@@ -1261,9 +1224,8 @@ impl MST {
                 }
             }
         }
-        for i in index..entries.len() {
-            let entry = entries[i].clone();
-            match entry {
+        for entry in entries.iter().skip(index) {
+            match entry.clone() {
                 NodeEntry::Leaf(e) => iter.push(e),
                 NodeEntry::MST(mut e) => {
                     for leaf in e.walk_leaves_from(key).await {
@@ -1427,7 +1389,7 @@ impl MST {
                 let storage_guard = self.storage.read().await;
                 storage_guard.get_blocks(to_fetch.to_list()).await?
             };
-            if fetched.missing.len() > 0 {
+            if !fetched.missing.is_empty() {
                 return Err(anyhow::Error::new(DataStoreError::MissingBlocks(
                     "mst node".to_owned(),
                     fetched.missing,
@@ -1436,10 +1398,7 @@ impl MST {
             for cid in to_fetch.to_list() {
                 let found: ObjAndBytes =
                     parse::get_and_parse_by_kind(&fetched.blocks, cid, |obj: CborValue| {
-                        match serde_cbor::value::from_value::<NodeData>(obj.clone()) {
-                            Ok(_) => true,
-                            Err(_) => false,
-                        }
+                        serde_cbor::value::from_value::<NodeData>(obj.clone()).is_ok()
                     })?;
                 car.write(cid, found.bytes).await?;
                 let node_data: NodeData = serde_cbor::value::from_value(found.obj)?;
@@ -1458,7 +1417,7 @@ impl MST {
             let storage_guard = self.storage.read().await;
             storage_guard.get_blocks(leaves.to_list()).await?
         };
-        if leaf_data.missing.len() > 0 {
+        if !leaf_data.missing.is_empty() {
             return Err(anyhow::Error::new(DataStoreError::MissingBlocks(
                 "mst leaf".to_owned(),
                 leaf_data.missing,

--- a/rsky-repo/src/mst/util.rs
+++ b/rsky-repo/src/mst/util.rs
@@ -29,17 +29,17 @@ fn is_valid_chars(input: &str) -> bool {
 pub fn is_valid_repo_mst_path(key: &str) -> Result<bool> {
     let split: Vec<&str> = key.split("/").collect();
 
-    return if key.len() <= 256
+    if key.len() <= 256
         && split.len() == 2
-        && split[0].len() > 0
-        && split[1].len() > 0
+        && !split[0].is_empty()
+        && !split[1].is_empty()
         && is_valid_chars(split[0])
         && is_valid_chars(split[1])
     {
         Ok(true)
     } else {
         Ok(false)
-    };
+    }
 }
 
 pub fn ensure_valid_mst_key(key: &str) -> Result<()> {
@@ -72,7 +72,7 @@ pub async fn serialize_node_data(entries: &[NodeEntry]) -> Result<NodeData> {
         e: Vec::new(),
     };
     let mut i = 0;
-    if let Some(NodeEntry::MST(e)) = entries.get(0) {
+    if let Some(NodeEntry::MST(e)) = entries.first() {
         i += 1;
         let cid_guard = e.pointer.read().await;
         data.l = Some(*cid_guard);
@@ -84,13 +84,10 @@ pub async fn serialize_node_data(entries: &[NodeEntry]) -> Result<NodeData> {
         if let NodeEntry::Leaf(l) = leaf {
             i += 1;
             let mut subtree: Option<Cid> = None;
-            match next {
-                Some(NodeEntry::MST(tree)) => {
-                    let cid_guard = tree.pointer.read().await;
-                    subtree = Some(*cid_guard);
-                    i += 1;
-                }
-                _ => (),
+            if let Some(NodeEntry::MST(tree)) = next {
+                let cid_guard = tree.pointer.read().await;
+                subtree = Some(*cid_guard);
+                i += 1;
             };
             ensure_valid_mst_key(&l.key)?;
             let prefix_len = count_prefix_len(last_key.to_owned(), l.key.to_owned())?;
@@ -128,7 +125,7 @@ pub fn deserialize_node_data(
     let mut last_key: String = "".to_owned();
     for entry in &data.e {
         let key_str = str::from_utf8(entry.k.as_ref())?;
-        let p = usize::try_from(entry.p)?;
+        let p = entry.p as usize;
         let key = format!("{}{}", &last_key[0..p], key_str);
         ensure_valid_mst_key(&key)?;
         entries.push(NodeEntry::Leaf(Leaf {
@@ -152,19 +149,19 @@ pub fn deserialize_node_data(
 }
 
 pub fn layer_for_entries(entries: &[NodeEntry]) -> Result<Option<u32>> {
-    let first_leaf = entries.into_iter().find(|entry| entry.is_leaf());
+    let first_leaf = entries.iter().find(|entry| entry.is_leaf());
     if let Some(f) = first_leaf {
         match f {
             NodeEntry::MST(_) => Ok(None),
             NodeEntry::Leaf(l) => Ok(Some(leading_zeros_on_hash(&l.key.to_owned().into_bytes())?)),
         }
     } else {
-        return Ok(None);
+        Ok(None)
     }
 }
 
 pub fn leading_zeros_on_hash(key: &[u8]) -> Result<u32> {
-    let digest = Sha256::digest(&*key);
+    let digest = Sha256::digest(key);
     let hash: &[u8] = digest.as_ref();
     let mut leading_zeros = 0;
     for byte in hash {

--- a/rsky-repo/src/mst/walker.rs
+++ b/rsky-repo/src/mst/walker.rs
@@ -93,7 +93,7 @@ impl MstWalker {
         match self.status {
             WalkerStatus::WalkerStatusDone(_) => return Ok(()),
             WalkerStatus::WalkerStatusProgress(ref mut p) => {
-                if let Some(_) = p.walking {
+                if p.walking.is_some() {
                     if let NodeEntry::MST(ref mut curr) = p.curr {
                         let next = curr.at_index(0).await?;
                         if let Some(next) = next {
@@ -107,23 +107,20 @@ impl MstWalker {
                     } else {
                         bail!("No tree at pointer, cannot step into");
                     }
-                } else {
-                    if let NodeEntry::MST(ref mut mst) = p.curr {
-                        let next = mst.at_index(0).await?;
-                        if let Some(next) = next {
-                            self.status =
-                                WalkerStatus::WalkerStatusProgress(WalkerStatusProgress {
-                                    done: false,
-                                    walking: Some(mst.clone()),
-                                    curr: next,
-                                    index: 0,
-                                });
-                        } else {
-                            self.status = WalkerStatus::WalkerStatusDone(WalkerStatusDone(true));
-                        }
+                } else if let NodeEntry::MST(ref mut mst) = p.curr {
+                    let next = mst.at_index(0).await?;
+                    if let Some(next) = next {
+                        self.status = WalkerStatus::WalkerStatusProgress(WalkerStatusProgress {
+                            done: false,
+                            walking: Some(mst.clone()),
+                            curr: next,
+                            index: 0,
+                        });
                     } else {
-                        bail!("The root of the tree cannot be a leaf");
+                        self.status = WalkerStatus::WalkerStatusDone(WalkerStatusDone(true));
                     }
+                } else {
+                    bail!("The root of the tree cannot be a leaf");
                 }
             }
         }

--- a/rsky-repo/src/parse.rs
+++ b/rsky-repo/src/parse.rs
@@ -14,7 +14,7 @@ pub struct RecordAndBytes {
 
 pub fn get_and_parse_record(blocks: &BlockMap, cid: Cid) -> Result<RecordAndBytes> {
     let bytes = blocks.get(cid);
-    return if let Some(b) = bytes {
+    if let Some(b) = bytes {
         let record = cbor_to_lex_record(b.clone())?;
         Ok(RecordAndBytes {
             record,
@@ -24,7 +24,7 @@ pub fn get_and_parse_record(blocks: &BlockMap, cid: Cid) -> Result<RecordAndByte
         Err(anyhow::Error::new(DataStoreError::MissingBlock(
             cid.to_string(),
         )))
-    };
+    }
 }
 
 pub fn get_and_parse_by_kind(
@@ -33,13 +33,13 @@ pub fn get_and_parse_by_kind(
     check: impl FnOnce(CborValue) -> bool,
 ) -> Result<ObjAndBytes> {
     let bytes = blocks.get(cid);
-    return if let Some(b) = bytes {
+    if let Some(b) = bytes {
         Ok(parse_obj_by_kind(b.clone(), cid, check)?)
     } else {
         Err(anyhow::Error::new(DataStoreError::MissingBlock(
             cid.to_string(),
         )))
-    };
+    }
 }
 
 pub fn parse_obj_by_kind(

--- a/rsky-repo/src/readable_repo.rs
+++ b/rsky-repo/src/readable_repo.rs
@@ -33,10 +33,7 @@ impl ReadableRepo {
                 .read_obj(
                     &commit_cid,
                     Box::new(|obj: CborValue| {
-                        match serde_cbor::value::from_value::<VersionedCommit>(obj.clone()) {
-                            Ok(_) => true,
-                            Err(_) => false,
-                        }
+                        serde_cbor::value::from_value::<VersionedCommit>(obj.clone()).is_ok()
                     }),
                 )
                 .await?

--- a/rsky-repo/src/repo.rs
+++ b/rsky-repo/src/repo.rs
@@ -20,6 +20,8 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+// todo: determine which of these fields are necessary to keep around
+#[allow(dead_code)]
 pub struct CommitRecord {
     collection: String,
     rkey: String,
@@ -128,7 +130,7 @@ impl Repo {
             .collect::<Vec<Cid>>();
         let storage_guard = self.storage.read().await;
         let found = storage_guard.get_blocks(cids).await?;
-        if found.missing.len() > 0 {
+        if !found.missing.is_empty() {
             return Err(anyhow::Error::new(DataStoreError::MissingBlocks(
                 "getContents record".to_owned(),
                 found.missing,
@@ -137,7 +139,7 @@ impl Repo {
         let mut contents: RepoContents = BTreeMap::new();
         for entry in entries {
             let path = util::parse_data_key(&entry.key)?;
-            if contents.get(&path.collection).is_none() {
+            if !contents.contains_key(&path.collection) {
                 contents.insert(path.collection.clone(), CollectionContents::new());
             }
             let parsed = crate::parse::get_and_parse_record(&found.blocks, entry.value)?;
@@ -157,7 +159,7 @@ impl Repo {
     ) -> Result<CommitData> {
         let mut new_blocks = BlockMap::new();
         let mut data = MST::create(storage, None, None).await?;
-        for record in initial_writes.unwrap_or(Vec::new()) {
+        for record in initial_writes.unwrap_or_default() {
             let cid = new_blocks.add(record.record)?;
             let data_key = util::format_data_key(record.collection, record.rkey);
             data = data.add(&data_key, cid, None).await?;
@@ -259,7 +261,7 @@ impl Repo {
         }
 
         let added_leaves = leaves.get_many(diff.new_leaf_cids.to_list())?;
-        if added_leaves.missing.len() > 0 {
+        if !added_leaves.missing.is_empty() {
             bail!("Missing leaf blocks: {:?}", added_leaves.missing);
         }
         new_blocks.add_map(added_leaves.blocks.clone())?;
@@ -298,7 +300,7 @@ impl Repo {
     }
 
     pub async fn apply_commit(&self, commit_data: CommitData) -> Result<Self> {
-        let commit_data_cid = commit_data.cid.clone();
+        let commit_data_cid = commit_data.cid;
         {
             let storage_guard = self.storage.read().await;
             storage_guard.apply_commit(commit_data, None).await?;

--- a/rsky-repo/src/storage/memory_blockstore.rs
+++ b/rsky-repo/src/storage/memory_blockstore.rs
@@ -89,7 +89,8 @@ impl RepoStorage for MemoryBlockstore {
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + Sync + 'a>> {
         Box::pin(async move {
             let mut block_guard = self.blocks.write().await;
-            Ok(block_guard.set(cid, bytes))
+            block_guard.set(cid, bytes);
+            Ok(())
         })
     }
 

--- a/rsky-repo/src/storage/readable_blockstore.rs
+++ b/rsky-repo/src/storage/readable_blockstore.rs
@@ -10,6 +10,7 @@ use serde_cbor::Value as CborValue;
 use std::future::Future;
 use std::pin::Pin;
 
+#[allow(clippy::type_complexity)]
 pub trait ReadableBlockstore: Send + Sync {
     fn get_bytes<'a>(
         &'a self,
@@ -34,9 +35,7 @@ pub trait ReadableBlockstore: Send + Sync {
                 Ok(Some(bytes)) => bytes,
                 _ => return Ok(None),
             };
-            parse::parse_obj_by_kind(bytes, *cid, move |v| check(v))
-                .map(Some)
-                .map_err(Into::into)
+            parse::parse_obj_by_kind(bytes, *cid, check).map(Some)
         })
     }
 
@@ -64,12 +63,7 @@ pub trait ReadableBlockstore: Send + Sync {
         &'a self,
         cid: &'a Cid,
     ) -> Pin<Box<dyn Future<Output = Option<RepoRecord>> + Send + Sync + 'a>> {
-        Box::pin(async move {
-            match self.read_record(cid).await {
-                Ok(res) => Some(res),
-                Err(_) => None,
-            }
-        })
+        Box::pin(async move { (self.read_record(cid).await).ok() })
     }
 
     fn read_record<'a>(
@@ -79,7 +73,7 @@ pub trait ReadableBlockstore: Send + Sync {
         Box::pin(async move {
             let bytes = self.get_bytes(cid).await?;
             bytes
-                .map(|bytes| cbor_to_lex_record(bytes))
+                .map(cbor_to_lex_record)
                 .transpose()?
                 .ok_or_else(|| DataStoreError::MissingBlock(cid.to_string()).into())
         })

--- a/rsky-repo/src/sync/consumer.rs
+++ b/rsky-repo/src/sync/consumer.rs
@@ -80,7 +80,7 @@ pub async fn verify_diff(
     let writes = util::diff_to_write_descripts(&diff).await?;
     let mut new_blocks = diff.new_mst_blocks;
     let leaves = update_blocks.get_many(diff.new_leaf_cids.to_list())?;
-    if leaves.missing.len() > 0 && ensure_leaves {
+    if !leaves.missing.is_empty() && ensure_leaves {
         bail!("missing leaf blocks: {:?}", leaves.missing);
     }
     new_blocks.add_map(leaves.blocks)?;
@@ -99,14 +99,8 @@ pub async fn verify_diff(
         commit: CommitData {
             cid: updated.cid,
             rev: updated.commit.rev.clone(),
-            since: match repo {
-                None => None,
-                Some(ref repo) => Some(repo.commit.rev.clone()),
-            },
-            prev: match repo {
-                None => None,
-                Some(ref repo) => Some(repo.cid),
-            },
+            since: repo.as_ref().map(|repo| repo.commit.rev.clone()),
+            prev: repo.as_ref().map(|repo| repo.cid),
             relevant_blocks: new_blocks.clone(),
             new_blocks,
             removed_cids,
@@ -135,7 +129,7 @@ pub async fn verify_repo_root(
         if !valid_sig {
             return Err(ConsumerError::RepoVerificationError(format!(
                 "Invalid signature on commit: {}",
-                repo.cid.to_string()
+                repo.cid
             ))
             .into());
         }
@@ -154,12 +148,7 @@ pub async fn verify_proofs(
     let data: CborValue = blockstore
         .read_obj(
             &car.root,
-            Box::new(
-                |obj: CborValue| match serde_cbor::value::from_value::<Commit>(obj.clone()) {
-                    Ok(_) => true,
-                    Err(_) => false,
-                },
-            ),
+            Box::new(|obj: CborValue| serde_cbor::value::from_value::<Commit>(obj.clone()).is_ok()),
         )
         .await?;
     let commit: Commit = serde_cbor::value::from_value(data)?;
@@ -171,13 +160,11 @@ pub async fn verify_proofs(
         .into());
     }
     match verify_commit_sig(commit.clone(), did_key)? {
-        false => {
-            return Err(ConsumerError::RepoVerificationError(format!(
-                "Invalid signature on commit: {}",
-                car.root.to_string()
-            ))
-            .into());
-        }
+        false => Err(ConsumerError::RepoVerificationError(format!(
+            "Invalid signature on commit: {}",
+            car.root
+        ))
+        .into()),
         true => {
             let mut mst = MST::load(Arc::new(RwLock::new(blockstore)), commit.data, None)?;
             let mut verified: Vec<RecordCidClaim> = Default::default();
@@ -229,12 +216,7 @@ pub async fn verify_records(
     let data: CborValue = blockstore
         .read_obj(
             &car.root,
-            Box::new(
-                |obj: CborValue| match serde_cbor::value::from_value::<Commit>(obj.clone()) {
-                    Ok(_) => true,
-                    Err(_) => false,
-                },
-            ),
+            Box::new(|obj: CborValue| serde_cbor::value::from_value::<Commit>(obj.clone()).is_ok()),
         )
         .await?;
     let commit: Commit = serde_cbor::value::from_value(data)?;
@@ -246,13 +228,11 @@ pub async fn verify_records(
         .into());
     }
     match verify_commit_sig(commit.clone(), signing_key)? {
-        false => {
-            return Err(ConsumerError::RepoVerificationError(format!(
-                "Invalid signature on commit: {}",
-                car.root.to_string()
-            ))
-            .into());
-        }
+        false => Err(ConsumerError::RepoVerificationError(format!(
+            "Invalid signature on commit: {}",
+            car.root
+        ))
+        .into()),
         true => {
             let mst = MST::load(Arc::new(RwLock::new(blockstore)), commit.data, None)?;
 

--- a/rsky-repo/src/sync/provider.rs
+++ b/rsky-repo/src/sync/provider.rs
@@ -63,10 +63,7 @@ pub async fn get_records(
             .read_obj_and_bytes(
                 &commit_cid,
                 Box::new(|obj: CborValue| {
-                    match serde_cbor::value::from_value::<Commit>(obj.clone()) {
-                        Ok(_) => true,
-                        Err(_) => false,
-                    }
+                    serde_cbor::value::from_value::<Commit>(obj.clone()).is_ok()
                 }),
             )
             .await?
@@ -78,11 +75,9 @@ pub async fn get_records(
         .then(|p| {
             let mut mst_clone = mst.clone();
             async move {
-                Ok::<Vec<Cid>, anyhow::Error>(
-                    mst_clone
-                        .cids_for_path(util::format_data_key(p.collection, p.rkey))
-                        .await?,
-                )
+                mst_clone
+                    .cids_for_path(util::format_data_key(p.collection, p.rkey))
+                    .await
             }
         })
         .collect::<Vec<_>>()
@@ -98,7 +93,7 @@ pub async fn get_records(
             });
     let storage_guard = storage.read().await;
     let found = storage_guard.get_blocks(all_cids.to_list()).await?;
-    if found.missing.len() > 0 {
+    if !found.missing.is_empty() {
         return Err(anyhow::Error::new(DataStoreError::MissingBlocks(
             "writeRecordsToCarStream".to_owned(),
             found.missing,

--- a/rsky-repo/src/types.rs
+++ b/rsky-repo/src/types.rs
@@ -163,10 +163,10 @@ impl PreparedWrite {
 
 impl From<&PreparedWrite> for CommitAction {
     fn from(value: &PreparedWrite) -> Self {
-        match value {
-            &PreparedWrite::Create(_) => CommitAction::Create,
-            &PreparedWrite::Update(_) => CommitAction::Update,
-            &PreparedWrite::Delete(_) => CommitAction::Delete,
+        match *value {
+            PreparedWrite::Create(_) => CommitAction::Create,
+            PreparedWrite::Update(_) => CommitAction::Update,
+            PreparedWrite::Delete(_) => CommitAction::Delete,
         }
     }
 }
@@ -202,10 +202,10 @@ impl From<WriteOpAction> for CommitAction {
 
 impl From<&WriteOpAction> for CommitAction {
     fn from(value: &WriteOpAction) -> Self {
-        match value {
-            &WriteOpAction::Create => CommitAction::Create,
-            &WriteOpAction::Update => CommitAction::Update,
-            &WriteOpAction::Delete => CommitAction::Delete,
+        match *value {
+            WriteOpAction::Create => CommitAction::Create,
+            WriteOpAction::Update => CommitAction::Update,
+            WriteOpAction::Delete => CommitAction::Delete,
         }
     }
 }
@@ -252,37 +252,31 @@ impl RecordWriteOp {
 
 pub fn create_write_to_op(write: PreparedCreateOrUpdate) -> Result<RecordWriteOp> {
     let write_at_uri: AtUri = write.uri.try_into()?;
-    Ok(RecordWriteOp::Create {
-        0: RecordCreateOrUpdateOp {
-            action: WriteOpAction::Create,
-            collection: write_at_uri.get_collection(),
-            rkey: write_at_uri.get_rkey(),
-            record: write.record,
-        },
-    })
+    Ok(RecordWriteOp::Create(RecordCreateOrUpdateOp {
+        action: WriteOpAction::Create,
+        collection: write_at_uri.get_collection(),
+        rkey: write_at_uri.get_rkey(),
+        record: write.record,
+    }))
 }
 
 pub fn update_write_to_op(write: PreparedCreateOrUpdate) -> Result<RecordWriteOp> {
     let write_at_uri: AtUri = write.uri.try_into()?;
-    Ok(RecordWriteOp::Update {
-        0: RecordCreateOrUpdateOp {
-            action: WriteOpAction::Update,
-            collection: write_at_uri.get_collection(),
-            rkey: write_at_uri.get_rkey(),
-            record: write.record,
-        },
-    })
+    Ok(RecordWriteOp::Update(RecordCreateOrUpdateOp {
+        action: WriteOpAction::Update,
+        collection: write_at_uri.get_collection(),
+        rkey: write_at_uri.get_rkey(),
+        record: write.record,
+    }))
 }
 
 pub fn delete_write_to_op(write: PreparedDelete) -> Result<RecordWriteOp> {
     let write_at_uri: AtUri = write.uri.try_into()?;
-    Ok(RecordWriteOp::Delete {
-        0: RecordDeleteOp {
-            action: WriteOpAction::Delete,
-            collection: write_at_uri.get_collection(),
-            rkey: write_at_uri.get_rkey(),
-        },
-    })
+    Ok(RecordWriteOp::Delete(RecordDeleteOp {
+        action: WriteOpAction::Delete,
+        collection: write_at_uri.get_collection(),
+        rkey: write_at_uri.get_rkey(),
+    }))
 }
 
 pub fn write_to_op(write: PreparedWrite) -> Result<RecordWriteOp> {
@@ -824,6 +818,7 @@ impl Ids {
         }
     }
 
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Result<Self> {
         match s {
             "com.atproto.admin.defs" => Ok(Ids::ComAtprotoAdminDefs),

--- a/rsky-repo/src/util.rs
+++ b/rsky-repo/src/util.rs
@@ -49,11 +49,7 @@ pub fn format_data_key<T: FromStr + Display>(collection: T, rkey: T) -> String {
 
 pub fn lex_to_ipld(val: Lex) -> Ipld {
     match val {
-        Lex::List(list) => Ipld::List(
-            list.into_iter()
-                .map(|item| lex_to_ipld(item))
-                .collect::<Vec<Ipld>>(),
-        ),
+        Lex::List(list) => Ipld::List(list.into_iter().map(lex_to_ipld).collect::<Vec<Ipld>>()),
         Lex::Map(map) => {
             let mut to_return: BTreeMap<String, Ipld> = BTreeMap::new();
             for key in map.keys() {
@@ -76,11 +72,7 @@ pub fn lex_to_ipld(val: Lex) -> Ipld {
 
 pub fn ipld_to_lex(val: Ipld) -> Lex {
     match val {
-        Ipld::List(list) => Lex::List(
-            list.into_iter()
-                .map(|item| ipld_to_lex(item))
-                .collect::<Vec<Lex>>(),
-        ),
+        Ipld::List(list) => Lex::List(list.into_iter().map(ipld_to_lex).collect::<Vec<Lex>>()),
         Ipld::Map(map) => {
             let mut to_return: BTreeMap<String, Lex> = BTreeMap::new();
             for key in map.keys() {


### PR DESCRIPTION
## Summary

some basic cleanup with `cargo clippy`. silences warnings for `dead_code` and some `deprecated` -- adding `todo` comments to resolve later.

this could be a precursor to going full `clippy::pedantic` which would probably be beneficial if the community decides that generating code with LLMs is valid for this project.

a lot of these fixes have minor impacts on performance or get us closer to more idiomatic Rust usage, but `clippy::pedantic` can help with even more aggressive perf optimization lints (discouraging needless `.clone()` or passing by value where a reference will do).

it might also be worth adding `cargo clippy` command as a quality gate for PR approval after all the warnings have been addressed.

EDIT: also as a tip for maintainers -- depending on your editor or IDE you can set on-the-fly syntax checking to `cargo clippy` instead of `cargo check` so that you can see the hints inline 

blocked by https://github.com/blacksky-algorithms/rsky/pull/179

## Related Issues
<!-- Link any relevant issues -->

https://github.com/blacksky-algorithms/rsky/pull/181

## Changes
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [x] Other (please specify): perf/lints

## Checklist
- [x] I have tested the changes (including writing unit tests).
- [x] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [ ] I have updated relevant documentation.
- [x] I have formatted my code correctly
- [ ] I have provided examples for how this code works or will be used