### PR TITLE
Eliminate AppView slow-tail 502s: rsky-graph + handle-resolution split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,6 +1125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0669d5a35b64fdb5ab7fb19cae13148b6b5cbdf4b8247faf54ece47f699c8cef"
 
 [[package]]
+name = "bit-vec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
+
+[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,6 +1261,17 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "bloomfilter"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c541c70a910b485670304fd420f0eab8f7bde68439db6a8d98819c3d2774d7e2"
+dependencies = [
+ "bit-vec",
+ "getrandom 0.2.16",
+ "siphasher 1.0.1",
 ]
 
 [[package]]
@@ -7827,6 +7844,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.10.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "rocket"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8078,6 +8105,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsky-graph"
+version = "0.1.0"
+dependencies = [
+ "bloomfilter",
+ "bytes",
+ "chrono",
+ "ciborium",
+ "clap",
+ "color-eyre",
+ "dashmap 6.1.0",
+ "deadpool-postgres",
+ "futures",
+ "heed",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "iroh-car",
+ "mimalloc",
+ "prometheus",
+ "roaring",
+ "rsky-repo",
+ "rustls 0.23.31",
+ "serde",
+ "serde_bytes",
+ "serde_ipld_dagcbor 0.6.3",
+ "serde_json",
+ "signal-hook",
+ "tokio",
+ "tokio-postgres",
+ "tokio-tungstenite 0.24.0",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "rsky-identity"
 version = "0.1.0"
 dependencies = [
@@ -8281,6 +8344,7 @@ dependencies = [
  "url",
  "urlencoding",
  "vec1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "rsky-syntax",
   "rsky-video",
   "rsky-wintermute",
+  "rsky-graph",
 ]
 resolver = "2"
 

--- a/rsky-graph/Cargo.toml
+++ b/rsky-graph/Cargo.toml
@@ -1,0 +1,77 @@
+[package]
+name = "rsky-graph"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "rsky-graph"
+path = "src/main.rs"
+
+[dependencies]
+# Roaring bitmaps for follow graph
+roaring = "0.10"
+
+# Bloom filters for fast rejection
+bloomfilter = "1.0"
+
+# Concurrent hashmaps
+dashmap = "6"
+
+# Async runtime
+tokio = { workspace = true }
+
+# PostgreSQL for bulk load
+tokio-postgres = { version = "0.7", features = ["with-chrono-0_4"] }
+deadpool-postgres = "0.13"
+
+# HTTP server
+hyper = { version = "1", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+http-body-util = "0.1"
+bytes = "1"
+
+# WebSocket for firehose
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots", "url"] }
+futures = "0.3"
+
+# TLS
+rustls = { version = "0.23", features = ["aws_lc_rs"] }
+
+# Serialization
+serde = { workspace = true }
+serde_json = "1"
+ciborium = "0.2"
+serde_ipld_dagcbor = { workspace = true }
+
+# LMDB persistence
+heed = "0.20"
+
+# CLI
+clap = { version = "4", features = ["derive", "env"] }
+
+# Logging
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Metrics
+prometheus = "0.13"
+
+# Memory allocator
+mimalloc = "0.1"
+
+# Error handling
+color-eyre = "0.6"
+
+# Signal handling
+signal-hook = { version = "0.3", features = ["extended-siginfo"] }
+
+# URL parsing
+url = "2"
+
+# Timestamp
+chrono = "0.4"
+
+# AT Protocol parsing
+rsky-repo = { path = "../rsky-repo" }
+iroh-car = "0.5"
+serde_bytes = "0.11"

--- a/rsky-graph/src/api.rs
+++ b/rsky-graph/src/api.rs
@@ -1,0 +1,164 @@
+use crate::graph::FollowGraph;
+use crate::metrics;
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::net::TcpListener;
+
+pub async fn serve(
+    port: u16,
+    graph: Arc<FollowGraph>,
+    shutdown: Arc<AtomicBool>,
+) -> color_eyre::Result<()> {
+    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
+    let listener = TcpListener::bind(addr).await?;
+    tracing::info!("HTTP API listening on {addr}");
+
+    loop {
+        if shutdown.load(Ordering::Relaxed) {
+            break;
+        }
+
+        let conn = tokio::select! {
+            result = listener.accept() => {
+                match result {
+                    Ok((stream, _)) => stream,
+                    Err(e) => {
+                        tracing::error!("accept error: {e}");
+                        continue;
+                    }
+                }
+            }
+            () = tokio::time::sleep(std::time::Duration::from_millis(100)) => continue,
+        };
+
+        let graph = Arc::clone(&graph);
+        tokio::spawn(async move {
+            let service = service_fn(move |req: Request<hyper::body::Incoming>| {
+                let graph = Arc::clone(&graph);
+                async move { handle_request(req, &graph).await }
+            });
+            if let Err(e) = http1::Builder::new()
+                .serve_connection(TokioIo::new(conn), service)
+                .await
+            {
+                tracing::error!("connection error: {e}");
+            }
+        });
+    }
+
+    Ok(())
+}
+
+async fn handle_request(
+    req: Request<hyper::body::Incoming>,
+    graph: &FollowGraph,
+) -> Result<Response<Full<Bytes>>, hyper::Error> {
+    let path = req.uri().path();
+
+    match path {
+        "/_health" => Ok(Response::builder()
+            .status(StatusCode::OK)
+            .body(Full::new(Bytes::from("ok")))
+            .unwrap()),
+
+        "/metrics" => {
+            let body = metrics::encode_metrics();
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", "text/plain; version=0.0.4")
+                .body(Full::new(Bytes::from(body)))
+                .unwrap())
+        }
+
+        "/v1/follows-following" => {
+            let start = Instant::now();
+            let query = req.uri().query().unwrap_or("");
+            let params: Vec<(String, String)> = url::form_urlencoded::parse(query.as_bytes())
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+
+            let viewer = params
+                .iter()
+                .find(|(k, _)| k == "viewer")
+                .map(|(_, v)| v.as_str())
+                .unwrap_or("");
+
+            let targets: Vec<&str> = params
+                .iter()
+                .find(|(k, _)| k == "targets")
+                .map(|(_, v)| v.split(',').collect())
+                .unwrap_or_default();
+
+            if viewer.is_empty() || targets.is_empty() {
+                return Ok(Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .header("Content-Type", "application/json")
+                    .body(Full::new(Bytes::from(
+                        r#"{"error":"viewer and targets required"}"#,
+                    )))
+                    .unwrap());
+            }
+
+            let mut results = Vec::with_capacity(targets.len());
+            for target in &targets {
+                let dids = graph.get_follows_following(viewer, target);
+                results.push(serde_json::json!({
+                    "targetDid": target,
+                    "dids": dids,
+                }));
+            }
+
+            let body = serde_json::json!({ "results": results });
+            let elapsed = start.elapsed();
+
+            metrics::GRAPH_QUERY_DURATION.observe(elapsed.as_secs_f64());
+            metrics::GRAPH_QUERIES_TOTAL.inc();
+
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", "application/json")
+                .header("X-Query-Time-Ms", elapsed.as_millis().to_string())
+                .body(Full::new(Bytes::from(body.to_string())))
+                .unwrap())
+        }
+
+        "/v1/is-following" => {
+            let query = req.uri().query().unwrap_or("");
+            let params: Vec<(String, String)> = url::form_urlencoded::parse(query.as_bytes())
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+
+            let actor = params
+                .iter()
+                .find(|(k, _)| k == "actor")
+                .map(|(_, v)| v.as_str())
+                .unwrap_or("");
+            let target = params
+                .iter()
+                .find(|(k, _)| k == "target")
+                .map(|(_, v)| v.as_str())
+                .unwrap_or("");
+
+            let following = graph.is_following(actor, target);
+            let body = serde_json::json!({ "following": following });
+
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", "application/json")
+                .body(Full::new(Bytes::from(body.to_string())))
+                .unwrap())
+        }
+
+        _ => Ok(Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Full::new(Bytes::from("Not Found")))
+            .unwrap()),
+    }
+}

--- a/rsky-graph/src/bloom.rs
+++ b/rsky-graph/src/bloom.rs
@@ -1,0 +1,35 @@
+use crate::graph::FollowGraph;
+use bloomfilter::Bloom;
+
+/// Create a new bloom filter sized for the expected number of items.
+/// Uses 10 bits per element for ~1% false positive rate.
+pub fn new_bloom_filter(expected_items: usize) -> Bloom<u32> {
+    let items = expected_items.max(10);
+    let bits = items * 10;
+    let hashes = 7; // optimal for 10 bits/element
+    Bloom::new(bits, hashes)
+}
+
+/// Rebuild all bloom filters from the current follower bitmaps.
+/// Called after bulk load and periodically to correct for removals
+/// (bloom filters don't support deletion).
+pub fn build_all_bloom_filters(graph: &FollowGraph) {
+    let mut rebuilt = 0u64;
+    for entry in graph.followers.iter() {
+        let uid = *entry.key();
+        let followers_bm = entry.value();
+        let count = followers_bm.len() as usize;
+
+        if count == 0 {
+            continue;
+        }
+
+        let mut bloom = new_bloom_filter(count);
+        for follower_uid in followers_bm.iter() {
+            bloom.set(&follower_uid);
+        }
+        graph.follower_blooms.insert(uid, bloom);
+        rebuilt += 1;
+    }
+    tracing::info!("rebuilt bloom filters for {rebuilt} users");
+}

--- a/rsky-graph/src/bulk_load.rs
+++ b/rsky-graph/src/bulk_load.rs
@@ -1,9 +1,177 @@
 use crate::graph::FollowGraph;
 use crate::types::GraphError;
 use deadpool_postgres::{Config, ManagerConfig, RecyclingMethod, Runtime};
+use std::path::Path;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio_postgres::NoTls;
 
-pub async fn bulk_load_follows(database_url: &str, graph: &FollowGraph) -> Result<(), GraphError> {
+const PROGRESS_EVERY: u64 = 1_000_000;
+
+fn report_progress(total: u64, start: std::time::Instant, graph: &FollowGraph) {
+    let elapsed = start.elapsed().as_secs();
+    let rate = if elapsed > 0 { total / elapsed } else { 0 };
+    tracing::info!(
+        "bulk load: {} follows loaded ({} follows/sec), {} users",
+        total,
+        rate,
+        graph.user_count()
+    );
+    crate::metrics::GRAPH_USERS_TOTAL.set(graph.user_count() as i64);
+    crate::metrics::GRAPH_FOLLOWS_TOTAL.set(total as i64);
+}
+
+fn finalize(total: u64, start: std::time::Instant, graph: &FollowGraph) {
+    let elapsed = start.elapsed();
+    tracing::info!(
+        "bulk load complete: {} follows in {:.1}s ({} follows/sec)",
+        total,
+        elapsed.as_secs_f64(),
+        total / elapsed.as_secs().max(1)
+    );
+    crate::metrics::GRAPH_USERS_TOTAL.set(graph.user_count() as i64);
+    crate::metrics::GRAPH_FOLLOWS_TOTAL.set(total as i64);
+}
+
+/// Load follows from a CSV file produced by `\copy` from PostgreSQL.
+///
+/// This is the preferred load path. It performs zero PostgreSQL work at load time —
+/// the CSV is built once via `\copy` (a short-lived read snapshot, no row locks) and
+/// can then be consumed at full local-disk speed without any further DB pressure.
+///
+/// Supports two CSV shapes (no header, comma-separated):
+/// - **2 columns**: `creator,subjectDid`
+/// - **3 columns**: `creator,rkey,subjectDid` — recommended, lets firehose
+///   delete events resolve the subject to remove.
+pub async fn bulk_load_from_file(path: &Path, graph: &FollowGraph) -> Result<(), GraphError> {
+    tracing::info!("bulk-loading follows from file: {}", path.display());
+
+    let file = tokio::fs::File::open(path)
+        .await
+        .map_err(|e| GraphError::Other(format!("open {} failed: {e}", path.display())))?;
+
+    let reader = BufReader::new(file);
+    let mut lines = reader.lines();
+
+    let mut total: u64 = 0;
+    let mut with_rkey: u64 = 0;
+    let start = std::time::Instant::now();
+
+    while let Some(line) = lines
+        .next_line()
+        .await
+        .map_err(|e| GraphError::Other(format!("csv read failed: {e}")))?
+    {
+        if line.is_empty() {
+            continue;
+        }
+        match parse_csv_line(&line) {
+            Some(CsvFollow::TwoCol { creator, subject }) => {
+                graph.add_follow(creator, subject);
+            }
+            Some(CsvFollow::ThreeCol {
+                creator,
+                rkey,
+                subject,
+            }) => {
+                graph.add_follow_with_rkey(creator, rkey, subject);
+                with_rkey += 1;
+            }
+            None => {
+                tracing::warn!("skipping malformed CSV line: {line}");
+                continue;
+            }
+        }
+        total += 1;
+        if total % PROGRESS_EVERY == 0 {
+            report_progress(total, start, graph);
+        }
+    }
+
+    if with_rkey > 0 {
+        tracing::info!("indexed {with_rkey} follows by rkey for delete resolution");
+    } else {
+        tracing::warn!(
+            "CSV had no rkey column -- pre-snapshot follows will not be deletable via firehose \
+             until the next snapshot rebuild"
+        );
+    }
+
+    finalize(total, start, graph);
+    Ok(())
+}
+
+enum CsvFollow<'a> {
+    TwoCol {
+        creator: &'a str,
+        subject: &'a str,
+    },
+    ThreeCol {
+        creator: &'a str,
+        rkey: &'a str,
+        subject: &'a str,
+    },
+}
+
+fn parse_csv_line(line: &str) -> Option<CsvFollow<'_>> {
+    // DIDs and rkeys we care about never contain commas or quotes, so a fast
+    // split is correct. Strip surrounding quotes defensively.
+    let mut parts = line.split(',');
+    let a = strip_csv_quotes(parts.next()?);
+    let b = strip_csv_quotes(parts.next()?);
+    match parts.next() {
+        Some(c) => {
+            let c = strip_csv_quotes(c);
+            if parts.next().is_some() {
+                return None;
+            }
+            Some(CsvFollow::ThreeCol {
+                creator: a,
+                rkey: b,
+                subject: c,
+            })
+        }
+        None => Some(CsvFollow::TwoCol {
+            creator: a,
+            subject: b,
+        }),
+    }
+}
+
+fn strip_csv_quotes(s: &str) -> &str {
+    let s = s.trim();
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+/// Load follows from PostgreSQL using **keyset pagination with short transactions**.
+///
+/// This replaces the prior `DECLARE CURSOR ... FETCH` approach which held a single
+/// long-running transaction across the entire 3.4 B-row table — that snapshot
+/// blocked `VACUUM` and stressed IO unboundedly, hurting the live appview.
+///
+/// Each iteration runs an autonomous short query bounded by `LIMIT batch_size`,
+/// keyset-paged on `(creator, "subjectDid")`. Between batches we sleep
+/// `throttle_ms` to cap IO. Either may be tuned via env vars.
+pub async fn bulk_load_keyset(database_url: &str, graph: &FollowGraph) -> Result<(), GraphError> {
+    let batch_size: i64 = std::env::var("GRAPH_LOAD_BATCH_SIZE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(50_000);
+    let throttle_ms: u64 = std::env::var("GRAPH_LOAD_THROTTLE_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(50);
+
+    tracing::info!(
+        "starting keyset bulk load (batch_size={}, throttle_ms={})",
+        batch_size,
+        throttle_ms
+    );
+
     let mut pg_config = Config::new();
     pg_config.url = Some(database_url.to_owned());
     pg_config.manager = Some(ManagerConfig {
@@ -20,42 +188,51 @@ pub async fn bulk_load_follows(database_url: &str, graph: &FollowGraph) -> Resul
         .await
         .map_err(|e| GraphError::Other(format!("pool get failed: {e}")))?;
 
-    // Set search path and statement timeout
     client
         .execute("SET search_path TO bsky", &[])
         .await
         .map_err(|e| GraphError::Other(format!("set search_path failed: {e}")))?;
+    // Generous per-statement cap, but each query reads at most batch_size rows
+    // and finishes well within this. Prevents a single bad batch from running away.
     client
-        .execute("SET statement_timeout = '0'", &[])
+        .execute("SET statement_timeout = '60s'", &[])
         .await
         .map_err(|e| GraphError::Other(format!("set timeout failed: {e}")))?;
 
-    tracing::info!("starting bulk load from PostgreSQL follow table");
+    let mut total: u64 = 0;
+    let start = std::time::Instant::now();
+    let mut last_creator = String::new();
+    let mut last_subject = String::new();
 
-    // Begin transaction for cursor
-    client
-        .execute("BEGIN", &[])
-        .await
-        .map_err(|e| GraphError::Other(format!("begin failed: {e}")))?;
-
-    // Stream follows using a cursor to avoid loading everything into memory
-    client
-        .execute(
-            "DECLARE follow_cursor CURSOR FOR SELECT creator, \"subjectDid\" FROM follow",
-            &[],
+    let initial_stmt = client
+        .prepare(
+            "SELECT creator, \"subjectDid\" FROM follow \
+             ORDER BY creator, \"subjectDid\" LIMIT $1::bigint",
         )
         .await
-        .map_err(|e| GraphError::Other(format!("declare cursor failed: {e}")))?;
+        .map_err(|e| GraphError::Other(format!("prepare initial failed: {e}")))?;
 
-    let mut total: u64 = 0;
-    let batch_size = 100_000;
-    let start = std::time::Instant::now();
+    let page_stmt = client
+        .prepare(
+            "SELECT creator, \"subjectDid\" FROM follow \
+             WHERE (creator, \"subjectDid\") > ($1, $2) \
+             ORDER BY creator, \"subjectDid\" LIMIT $3::bigint",
+        )
+        .await
+        .map_err(|e| GraphError::Other(format!("prepare page failed: {e}")))?;
 
     loop {
-        let rows = client
-            .query(&format!("FETCH {batch_size} FROM follow_cursor"), &[])
-            .await
-            .map_err(|e| GraphError::Other(format!("fetch failed: {e}")))?;
+        let rows = if total == 0 {
+            client
+                .query(&initial_stmt, &[&batch_size])
+                .await
+                .map_err(|e| GraphError::Other(format!("initial query failed: {e}")))?
+        } else {
+            client
+                .query(&page_stmt, &[&last_creator, &last_subject, &batch_size])
+                .await
+                .map_err(|e| GraphError::Other(format!("page query failed: {e}")))?
+        };
 
         if rows.is_empty() {
             break;
@@ -65,38 +242,21 @@ pub async fn bulk_load_follows(database_url: &str, graph: &FollowGraph) -> Resul
             let creator: String = row.get(0);
             let subject: String = row.get(1);
             graph.add_follow(&creator, &subject);
+            last_creator = creator;
+            last_subject = subject;
         }
 
         total += rows.len() as u64;
 
-        if total % 1_000_000 == 0 {
-            let elapsed = start.elapsed().as_secs();
-            let rate = if elapsed > 0 { total / elapsed } else { 0 };
-            tracing::info!(
-                "bulk load: {} follows loaded ({} follows/sec), {} users",
-                total,
-                rate,
-                graph.user_count()
-            );
+        if total % PROGRESS_EVERY == 0 {
+            report_progress(total, start, graph);
+        }
 
-            crate::metrics::GRAPH_USERS_TOTAL.set(graph.user_count() as i64);
-            crate::metrics::GRAPH_FOLLOWS_TOTAL.set(total as i64);
+        if throttle_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(throttle_ms)).await;
         }
     }
 
-    client.execute("CLOSE follow_cursor", &[]).await.ok();
-    client.execute("COMMIT", &[]).await.ok();
-
-    let elapsed = start.elapsed();
-    tracing::info!(
-        "bulk load complete: {} follows in {:.1}s ({} follows/sec)",
-        total,
-        elapsed.as_secs_f64(),
-        total / elapsed.as_secs().max(1)
-    );
-
-    crate::metrics::GRAPH_USERS_TOTAL.set(graph.user_count() as i64);
-    crate::metrics::GRAPH_FOLLOWS_TOTAL.set(total as i64);
-
+    finalize(total, start, graph);
     Ok(())
 }

--- a/rsky-graph/src/bulk_load.rs
+++ b/rsky-graph/src/bulk_load.rs
@@ -32,6 +32,12 @@ pub async fn bulk_load_follows(database_url: &str, graph: &FollowGraph) -> Resul
 
     tracing::info!("starting bulk load from PostgreSQL follow table");
 
+    // Begin transaction for cursor
+    client
+        .execute("BEGIN", &[])
+        .await
+        .map_err(|e| GraphError::Other(format!("begin failed: {e}")))?;
+
     // Stream follows using a cursor to avoid loading everything into memory
     client
         .execute(
@@ -79,6 +85,7 @@ pub async fn bulk_load_follows(database_url: &str, graph: &FollowGraph) -> Resul
     }
 
     client.execute("CLOSE follow_cursor", &[]).await.ok();
+    client.execute("COMMIT", &[]).await.ok();
 
     let elapsed = start.elapsed();
     tracing::info!(

--- a/rsky-graph/src/bulk_load.rs
+++ b/rsky-graph/src/bulk_load.rs
@@ -1,0 +1,95 @@
+use crate::graph::FollowGraph;
+use crate::types::GraphError;
+use deadpool_postgres::{Config, ManagerConfig, RecyclingMethod, Runtime};
+use tokio_postgres::NoTls;
+
+pub async fn bulk_load_follows(database_url: &str, graph: &FollowGraph) -> Result<(), GraphError> {
+    let mut pg_config = Config::new();
+    pg_config.url = Some(database_url.to_owned());
+    pg_config.manager = Some(ManagerConfig {
+        recycling_method: RecyclingMethod::Fast,
+    });
+    pg_config.pool = Some(deadpool_postgres::PoolConfig::new(2));
+
+    let pool = pg_config
+        .create_pool(Some(Runtime::Tokio1), NoTls)
+        .map_err(|e| GraphError::Other(format!("pool creation failed: {e}")))?;
+
+    let client = pool
+        .get()
+        .await
+        .map_err(|e| GraphError::Other(format!("pool get failed: {e}")))?;
+
+    // Set search path and statement timeout
+    client
+        .execute("SET search_path TO bsky", &[])
+        .await
+        .map_err(|e| GraphError::Other(format!("set search_path failed: {e}")))?;
+    client
+        .execute("SET statement_timeout = '0'", &[])
+        .await
+        .map_err(|e| GraphError::Other(format!("set timeout failed: {e}")))?;
+
+    tracing::info!("starting bulk load from PostgreSQL follow table");
+
+    // Stream follows using a cursor to avoid loading everything into memory
+    client
+        .execute(
+            "DECLARE follow_cursor CURSOR FOR SELECT creator, \"subjectDid\" FROM follow",
+            &[],
+        )
+        .await
+        .map_err(|e| GraphError::Other(format!("declare cursor failed: {e}")))?;
+
+    let mut total: u64 = 0;
+    let batch_size = 100_000;
+    let start = std::time::Instant::now();
+
+    loop {
+        let rows = client
+            .query(&format!("FETCH {batch_size} FROM follow_cursor"), &[])
+            .await
+            .map_err(|e| GraphError::Other(format!("fetch failed: {e}")))?;
+
+        if rows.is_empty() {
+            break;
+        }
+
+        for row in &rows {
+            let creator: String = row.get(0);
+            let subject: String = row.get(1);
+            graph.add_follow(&creator, &subject);
+        }
+
+        total += rows.len() as u64;
+
+        if total % 1_000_000 == 0 {
+            let elapsed = start.elapsed().as_secs();
+            let rate = if elapsed > 0 { total / elapsed } else { 0 };
+            tracing::info!(
+                "bulk load: {} follows loaded ({} follows/sec), {} users",
+                total,
+                rate,
+                graph.user_count()
+            );
+
+            crate::metrics::GRAPH_USERS_TOTAL.set(graph.user_count() as i64);
+            crate::metrics::GRAPH_FOLLOWS_TOTAL.set(total as i64);
+        }
+    }
+
+    client.execute("CLOSE follow_cursor", &[]).await.ok();
+
+    let elapsed = start.elapsed();
+    tracing::info!(
+        "bulk load complete: {} follows in {:.1}s ({} follows/sec)",
+        total,
+        elapsed.as_secs_f64(),
+        total / elapsed.as_secs().max(1)
+    );
+
+    crate::metrics::GRAPH_USERS_TOTAL.set(graph.user_count() as i64);
+    crate::metrics::GRAPH_FOLLOWS_TOTAL.set(total as i64);
+
+    Ok(())
+}

--- a/rsky-graph/src/config.rs
+++ b/rsky-graph/src/config.rs
@@ -1,0 +1,1 @@
+// Configuration is handled via clap CLI args with env var fallbacks in main.rs

--- a/rsky-graph/src/firehose.rs
+++ b/rsky-graph/src/firehose.rs
@@ -107,43 +107,24 @@ fn process_firehose_message(data: &[u8], graph: &FollowGraph) {
         if parts.len() != 2 {
             continue;
         }
-        let collection = parts[0];
+        let (collection, rkey) = (parts[0], parts[1]);
         if collection != "app.bsky.graph.follow" {
             continue;
         }
 
         match op.action.as_str() {
             "create" => {
-                // Parse the record from blocks to get the subject DID
                 if let Some(subject) = extract_follow_subject(&commit.blocks, &op.cid) {
-                    graph.add_follow(&commit.repo, &subject);
-
-                    // Update bloom filter for the subject
-                    if let Some(subject_uid) = graph.get_uid(&subject) {
-                        if let Some(actor_uid) = graph.get_uid(&commit.repo) {
-                            graph
-                                .follower_blooms
-                                .entry(subject_uid)
-                                .or_insert_with(|| crate::bloom::new_bloom_filter(100))
-                                .set(&actor_uid);
-                        }
-                    }
-
+                    graph.add_follow_with_rkey(&commit.repo, rkey, &subject);
                     crate::metrics::GRAPH_FIREHOSE_EVENTS.inc();
                 }
             }
             "delete" => {
-                // For deletes, we need the subject DID. Since the firehose doesn't
-                // include the record content for deletes, we check if we can find
-                // the subject from our graph data.
-                // The path is "app.bsky.graph.follow/{rkey}" -- we don't know the subject.
-                // For now, skip deletes. The graph will have stale follows until
-                // a periodic full rebuild or a PostgreSQL lookup is added.
-                // This is acceptable because:
-                // 1. Unfollows are less frequent than follows
-                // 2. A stale follow in the graph means we might show a "known follower"
-                //    who actually unfollowed -- a minor inaccuracy
-                // 3. Periodic LMDB persistence + bloom rebuild corrects over time
+                if graph.remove_follow_by_rkey(&commit.repo, rkey) {
+                    crate::metrics::GRAPH_FIREHOSE_EVENTS.inc();
+                }
+                // If we don't know the rkey (pre-snapshot follow), the bitmap
+                // entry stays until the next snapshot rebuild. Acceptable.
             }
             _ => {}
         }
@@ -157,13 +138,10 @@ fn extract_follow_subject(blocks: &[u8], _cid: &Option<serde_json::Value>) -> Op
     // that starts with "did:". This is a pragmatic approach that avoids
     // full CAR parsing overhead in the hot path.
 
-    // Try DAG-CBOR parse of the blocks looking for follow records
+    // Try DAG-CBOR parse of the blocks looking for follow records.
     // The blocks may contain multiple CBOR items; we scan for any
-    // that have a "subject" field starting with "did:"
-    let block_str = String::from_utf8_lossy(blocks);
-
-    // Quick scan for "did:plc:" or "did:web:" substrings near a "subject" key
-    // This is a fast heuristic -- the proper approach would be CAR parsing
+    // that have a "subject" field starting with "did:". This is a fast heuristic --
+    // the proper approach would be full CAR parsing.
     for window in blocks.windows(200) {
         // Look for CBOR string "subject" followed by a DID
         if let Ok(val) = serde_ipld_dagcbor::from_slice::<serde_json::Value>(window) {

--- a/rsky-graph/src/firehose.rs
+++ b/rsky-graph/src/firehose.rs
@@ -1,0 +1,188 @@
+use crate::graph::FollowGraph;
+use futures::StreamExt;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+use tokio_tungstenite::tungstenite::Message;
+
+pub async fn tail_firehose(relay_host: &str, graph: &FollowGraph, shutdown: &AtomicBool) {
+    let mut backoff_ms = 1000u64;
+
+    loop {
+        if shutdown.load(Ordering::Relaxed) {
+            tracing::info!("firehose: shutdown requested");
+            return;
+        }
+
+        let url = format!("{relay_host}/xrpc/com.atproto.sync.subscribeRepos");
+        tracing::info!("firehose: connecting to {url}");
+
+        match tokio_tungstenite::connect_async(&url).await {
+            Ok((ws_stream, _)) => {
+                backoff_ms = 1000;
+                tracing::info!("firehose: connected");
+                let (_, mut read) = ws_stream.split();
+
+                loop {
+                    if shutdown.load(Ordering::Relaxed) {
+                        return;
+                    }
+
+                    let msg = tokio::select! {
+                        msg = read.next() => {
+                            match msg {
+                                Some(Ok(m)) => m,
+                                Some(Err(e)) => {
+                                    tracing::warn!("firehose: read error: {e}");
+                                    break;
+                                }
+                                None => break,
+                            }
+                        }
+                        () = tokio::time::sleep(Duration::from_millis(100)) => continue,
+                    };
+
+                    if let Message::Binary(data) = msg {
+                        process_firehose_message(&data, graph);
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!("firehose: connect error: {e}");
+            }
+        }
+
+        if shutdown.load(Ordering::Relaxed) {
+            return;
+        }
+
+        tracing::warn!("firehose: reconnecting in {backoff_ms}ms");
+        tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+        backoff_ms = (backoff_ms * 2).min(60_000);
+    }
+}
+
+fn process_firehose_message(data: &[u8], graph: &FollowGraph) {
+    // Parse AT Protocol CBOR frame: header + body
+    #[derive(serde::Deserialize)]
+    struct Header {
+        #[serde(rename = "t")]
+        type_: String,
+        #[serde(rename = "op")]
+        _operation: i8,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Commit {
+        repo: String,
+        ops: Vec<Op>,
+        #[serde(with = "serde_bytes")]
+        blocks: Vec<u8>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Op {
+        action: String,
+        path: String,
+        cid: Option<serde_json::Value>,
+    }
+
+    let mut cursor = std::io::Cursor::new(data);
+
+    let header: Header = match ciborium::from_reader(&mut cursor) {
+        Ok(h) => h,
+        Err(_) => return,
+    };
+
+    if header.type_ != "#commit" {
+        return;
+    }
+
+    let commit: Commit = match serde_ipld_dagcbor::from_reader(&mut cursor) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    for op in &commit.ops {
+        let parts: Vec<&str> = op.path.split('/').collect();
+        if parts.len() != 2 {
+            continue;
+        }
+        let collection = parts[0];
+        if collection != "app.bsky.graph.follow" {
+            continue;
+        }
+
+        match op.action.as_str() {
+            "create" => {
+                // Parse the record from blocks to get the subject DID
+                if let Some(subject) = extract_follow_subject(&commit.blocks, &op.cid) {
+                    graph.add_follow(&commit.repo, &subject);
+
+                    // Update bloom filter for the subject
+                    if let Some(subject_uid) = graph.get_uid(&subject) {
+                        if let Some(actor_uid) = graph.get_uid(&commit.repo) {
+                            graph
+                                .follower_blooms
+                                .entry(subject_uid)
+                                .or_insert_with(|| crate::bloom::new_bloom_filter(100))
+                                .set(&actor_uid);
+                        }
+                    }
+
+                    crate::metrics::GRAPH_FIREHOSE_EVENTS.inc();
+                }
+            }
+            "delete" => {
+                // For deletes, we need the subject DID. Since the firehose doesn't
+                // include the record content for deletes, we check if we can find
+                // the subject from our graph data.
+                // The path is "app.bsky.graph.follow/{rkey}" -- we don't know the subject.
+                // For now, skip deletes. The graph will have stale follows until
+                // a periodic full rebuild or a PostgreSQL lookup is added.
+                // This is acceptable because:
+                // 1. Unfollows are less frequent than follows
+                // 2. A stale follow in the graph means we might show a "known follower"
+                //    who actually unfollowed -- a minor inaccuracy
+                // 3. Periodic LMDB persistence + bloom rebuild corrects over time
+            }
+            _ => {}
+        }
+    }
+}
+
+fn extract_follow_subject(blocks: &[u8], _cid: &Option<serde_json::Value>) -> Option<String> {
+    // The blocks field in a commit contains CAR-encoded data.
+    // For follow records, the record has a "subject" field with the DID.
+    // We scan the raw bytes for a CBOR-encoded record with a "subject" key
+    // that starts with "did:". This is a pragmatic approach that avoids
+    // full CAR parsing overhead in the hot path.
+
+    // Try DAG-CBOR parse of the blocks looking for follow records
+    // The blocks may contain multiple CBOR items; we scan for any
+    // that have a "subject" field starting with "did:"
+    let block_str = String::from_utf8_lossy(blocks);
+
+    // Quick scan for "did:plc:" or "did:web:" substrings near a "subject" key
+    // This is a fast heuristic -- the proper approach would be CAR parsing
+    for window in blocks.windows(200) {
+        // Look for CBOR string "subject" followed by a DID
+        if let Ok(val) = serde_ipld_dagcbor::from_slice::<serde_json::Value>(window) {
+            if let Some(subject) = val.get("subject").and_then(|s| s.as_str()) {
+                if subject.starts_with("did:") {
+                    return Some(subject.to_owned());
+                }
+            }
+        }
+    }
+
+    // Fallback: try parsing the entire blocks as a single CBOR value
+    if let Ok(val) = serde_ipld_dagcbor::from_slice::<serde_json::Value>(blocks) {
+        if let Some(subject) = val.get("subject").and_then(|s| s.as_str()) {
+            if subject.starts_with("did:") {
+                return Some(subject.to_owned());
+            }
+        }
+    }
+
+    None
+}

--- a/rsky-graph/src/graph.rs
+++ b/rsky-graph/src/graph.rs
@@ -1,0 +1,179 @@
+use dashmap::DashMap;
+use roaring::RoaringBitmap;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+use crate::bloom;
+
+pub struct FollowGraph {
+    // DID <-> UID bidirectional mapping
+    pub did_to_uid: DashMap<String, u32>,
+    pub uid_to_did: DashMap<u32, String>,
+    next_uid: AtomicU32,
+
+    // Per-user bitmaps
+    pub followers: DashMap<u32, RoaringBitmap>,
+    pub following: DashMap<u32, RoaringBitmap>,
+
+    // Per-user bloom filter of followers for fast rejection
+    pub follower_blooms: DashMap<u32, bloomfilter::Bloom<u32>>,
+
+    // Stats
+    follow_count: AtomicU64,
+}
+
+impl FollowGraph {
+    pub fn new() -> Self {
+        Self {
+            did_to_uid: DashMap::new(),
+            uid_to_did: DashMap::new(),
+            next_uid: AtomicU32::new(1),
+            followers: DashMap::new(),
+            following: DashMap::new(),
+            follower_blooms: DashMap::new(),
+            follow_count: AtomicU64::new(0),
+        }
+    }
+
+    /// Get or assign a UID for a DID.
+    pub fn get_or_assign_uid(&self, did: &str) -> u32 {
+        if let Some(uid) = self.did_to_uid.get(did) {
+            return *uid;
+        }
+        let uid = self.next_uid.fetch_add(1, Ordering::Relaxed);
+        self.did_to_uid.insert(did.to_owned(), uid);
+        self.uid_to_did.insert(uid, did.to_owned());
+        uid
+    }
+
+    /// Get UID for a DID without assigning.
+    pub fn get_uid(&self, did: &str) -> Option<u32> {
+        self.did_to_uid.get(did).map(|v| *v)
+    }
+
+    /// Get DID for a UID.
+    pub fn get_did(&self, uid: u32) -> Option<String> {
+        self.uid_to_did.get(&uid).map(|v| v.clone())
+    }
+
+    /// Add a follow relationship: actor follows subject.
+    pub fn add_follow(&self, actor_did: &str, subject_did: &str) {
+        let actor_uid = self.get_or_assign_uid(actor_did);
+        let subject_uid = self.get_or_assign_uid(subject_did);
+
+        // Update following bitmap for actor
+        self.following
+            .entry(actor_uid)
+            .or_insert_with(RoaringBitmap::new)
+            .insert(subject_uid);
+
+        // Update followers bitmap for subject
+        self.followers
+            .entry(subject_uid)
+            .or_insert_with(RoaringBitmap::new)
+            .insert(actor_uid);
+
+        // Update bloom filter for subject's followers
+        self.follower_blooms
+            .entry(subject_uid)
+            .or_insert_with(|| bloom::new_bloom_filter(100))
+            .set(&actor_uid);
+
+        self.follow_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Remove a follow relationship: actor unfollows subject.
+    pub fn remove_follow(&self, actor_did: &str, subject_did: &str) {
+        let Some(actor_uid) = self.get_uid(actor_did) else {
+            return;
+        };
+        let Some(subject_uid) = self.get_uid(subject_did) else {
+            return;
+        };
+
+        if let Some(mut bm) = self.following.get_mut(&actor_uid) {
+            bm.remove(subject_uid);
+        }
+        if let Some(mut bm) = self.followers.get_mut(&subject_uid) {
+            bm.remove(actor_uid);
+        }
+
+        // Bloom filters don't support removal -- rebuild periodically
+        // For now, the bloom may have false positives for removed follows,
+        // which is acceptable (it just means we do the bitmap check unnecessarily)
+
+        self.follow_count.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    /// Find mutual follows: people the viewer follows who also follow the target.
+    /// This is the hot path -- must be sub-millisecond.
+    pub fn get_follows_following(&self, viewer_did: &str, target_did: &str) -> Vec<String> {
+        let Some(viewer_uid) = self.get_uid(viewer_did) else {
+            return vec![];
+        };
+        let Some(target_uid) = self.get_uid(target_did) else {
+            return vec![];
+        };
+
+        let Some(viewer_following) = self.following.get(&viewer_uid) else {
+            return vec![];
+        };
+
+        // Layer 1: Bloom filter fast rejection
+        // If none of the viewer's following set could possibly be in target's followers,
+        // skip the bitmap intersection entirely.
+        if let Some(bloom) = self.follower_blooms.get(&target_uid) {
+            let mut any_maybe = false;
+            for uid in viewer_following.iter() {
+                if bloom.check(&uid) {
+                    any_maybe = true;
+                    break;
+                }
+            }
+            if !any_maybe {
+                crate::metrics::GRAPH_BLOOM_REJECTIONS.inc();
+                return vec![];
+            }
+        }
+
+        // Layer 2: Roaring bitmap intersection
+        let Some(target_followers) = self.followers.get(&target_uid) else {
+            return vec![];
+        };
+
+        let intersection = viewer_following.value() & target_followers.value();
+
+        intersection
+            .iter()
+            .filter_map(|uid| self.get_did(uid))
+            .collect()
+    }
+
+    /// Check if actor follows subject.
+    pub fn is_following(&self, actor_did: &str, subject_did: &str) -> bool {
+        let Some(actor_uid) = self.get_uid(actor_did) else {
+            return false;
+        };
+        let Some(subject_uid) = self.get_uid(subject_did) else {
+            return false;
+        };
+        self.following
+            .get(&actor_uid)
+            .map_or(false, |bm| bm.contains(subject_uid))
+    }
+
+    pub fn user_count(&self) -> usize {
+        self.did_to_uid.len()
+    }
+
+    pub fn follow_count(&self) -> u64 {
+        self.follow_count.load(Ordering::Relaxed)
+    }
+
+    pub fn next_uid(&self) -> u32 {
+        self.next_uid.load(Ordering::Relaxed)
+    }
+
+    pub fn set_next_uid(&self, uid: u32) {
+        self.next_uid.store(uid, Ordering::Relaxed);
+    }
+}

--- a/rsky-graph/src/graph.rs
+++ b/rsky-graph/src/graph.rs
@@ -17,6 +17,14 @@ pub struct FollowGraph {
     // Per-user bloom filter of followers for fast rejection
     pub follower_blooms: DashMap<u32, bloomfilter::Bloom<u32>>,
 
+    // (actor_uid, rkey) -> subject_uid. The firehose delete event for a follow
+    // record carries only the rkey, not the subject DID, so to remove a follow
+    // we must remember which subject the rkey pointed at when it was created.
+    // Populated by add_follow_with_rkey on firehose creates and (optionally) by
+    // a 3-column bulk-load CSV. Not persisted -- we accept that pre-snapshot
+    // follows are not reversible until the next snapshot rebuild.
+    pub follow_rkeys: DashMap<(u32, String), u32>,
+
     // Stats
     follow_count: AtomicU64,
 }
@@ -30,6 +38,7 @@ impl FollowGraph {
             followers: DashMap::new(),
             following: DashMap::new(),
             follower_blooms: DashMap::new(),
+            follow_rkeys: DashMap::new(),
             follow_count: AtomicU64::new(0),
         }
     }
@@ -79,6 +88,36 @@ impl FollowGraph {
             .set(&actor_uid);
 
         self.follow_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Add a follow relationship and remember the rkey so a later firehose
+    /// delete event (which carries only the rkey) can resolve back to the subject.
+    pub fn add_follow_with_rkey(&self, actor_did: &str, rkey: &str, subject_did: &str) {
+        self.add_follow(actor_did, subject_did);
+        let actor_uid = self.get_or_assign_uid(actor_did);
+        let subject_uid = self.get_or_assign_uid(subject_did);
+        self.follow_rkeys
+            .insert((actor_uid, rkey.to_owned()), subject_uid);
+    }
+
+    /// Remove a follow by rkey, looking up the subject we recorded at create time.
+    /// Returns true if the follow was known and removed; false if the rkey was
+    /// never seen (e.g. follow predates rsky-graph's rkey index).
+    pub fn remove_follow_by_rkey(&self, actor_did: &str, rkey: &str) -> bool {
+        let Some(actor_uid) = self.get_uid(actor_did) else {
+            return false;
+        };
+        let Some((_, subject_uid)) = self.follow_rkeys.remove(&(actor_uid, rkey.to_owned())) else {
+            return false;
+        };
+        if let Some(mut bm) = self.following.get_mut(&actor_uid) {
+            bm.remove(subject_uid);
+        }
+        if let Some(mut bm) = self.followers.get_mut(&subject_uid) {
+            bm.remove(actor_uid);
+        }
+        self.follow_count.fetch_sub(1, Ordering::Relaxed);
+        true
     }
 
     /// Remove a follow relationship: actor unfollows subject.

--- a/rsky-graph/src/main.rs
+++ b/rsky-graph/src/main.rs
@@ -35,6 +35,11 @@ struct Args {
 
     #[clap(long, env = "DATABASE_URL")]
     database_url: Option<String>,
+
+    /// Path to a CSV (creator,subjectDid) produced by `\copy`. When set, this
+    /// is preferred over a live PG load -- see plan recursive-honking-sprout.
+    #[clap(long, env = "GRAPH_LOAD_FROM_FILE")]
+    load_from_file: Option<String>,
 }
 
 #[tokio::main]
@@ -68,23 +73,35 @@ async fn main() -> Result<()> {
             tracing::info!("loaded {} users from LMDB", count);
         }
         Ok(_) => {
-            // Empty LMDB -- do bulk load if database_url is provided
-            if let Some(ref db_url) = args.database_url {
-                tracing::info!("LMDB empty, starting bulk load from PostgreSQL");
-                bulk_load::bulk_load_follows(db_url, &graph).await?;
+            // Empty LMDB -- prefer file load (zero PG transaction) over a live PG load.
+            if let Some(ref path) = args.load_from_file {
+                tracing::info!("LMDB empty, bulk-loading from file: {path}");
+                bulk_load::bulk_load_from_file(std::path::Path::new(path), &graph).await?;
                 tracing::info!(
                     "bulk load complete: {} users, {} follows",
                     graph.user_count(),
                     graph.follow_count()
                 );
-                // Build bloom filters after bulk load
                 bloom::build_all_bloom_filters(&graph);
                 tracing::info!("bloom filters built");
-                // Persist to LMDB
+                persistence::save_to_lmdb(&args.db_path, &graph).await?;
+                tracing::info!("persisted to LMDB");
+            } else if let Some(ref db_url) = args.database_url {
+                tracing::info!("LMDB empty, starting keyset bulk load from PostgreSQL");
+                bulk_load::bulk_load_keyset(db_url, &graph).await?;
+                tracing::info!(
+                    "bulk load complete: {} users, {} follows",
+                    graph.user_count(),
+                    graph.follow_count()
+                );
+                bloom::build_all_bloom_filters(&graph);
+                tracing::info!("bloom filters built");
                 persistence::save_to_lmdb(&args.db_path, &graph).await?;
                 tracing::info!("persisted to LMDB");
             } else {
-                tracing::warn!("LMDB empty and no DATABASE_URL -- starting with empty graph");
+                tracing::warn!(
+                    "LMDB empty and no GRAPH_LOAD_FROM_FILE / DATABASE_URL -- starting with empty graph"
+                );
             }
         }
         Err(e) => {

--- a/rsky-graph/src/main.rs
+++ b/rsky-graph/src/main.rs
@@ -1,0 +1,140 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use clap::Parser;
+use color_eyre::Result;
+use mimalloc::MiMalloc;
+
+mod api;
+mod bloom;
+mod bulk_load;
+mod config;
+mod firehose;
+mod graph;
+mod metrics;
+mod persistence;
+mod types;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
+static SHUTDOWN: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Parser)]
+#[command(name = "rsky-graph")]
+#[command(about = "AT Protocol follow graph service using roaring bitmaps and bloom filters")]
+struct Args {
+    #[clap(long, env = "GRAPH_PORT", default_value = "3890")]
+    port: u16,
+
+    #[clap(long, env = "GRAPH_DB_PATH", default_value = "/data/graph")]
+    db_path: String,
+
+    #[clap(long, env = "RELAY_HOST", default_value = "wss://bsky.network")]
+    relay_host: String,
+
+    #[clap(long, env = "DATABASE_URL")]
+    database_url: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    color_eyre::install()?;
+
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls crypto provider");
+
+    let args = Args::parse();
+
+    tracing::info!("starting rsky-graph");
+    tracing::info!("port: {}", args.port);
+    tracing::info!("db_path: {}", args.db_path);
+    tracing::info!("relay: {}", args.relay_host);
+
+    // Initialize graph
+    let graph = Arc::new(graph::FollowGraph::new());
+
+    // Load from LMDB if available
+    let loaded = persistence::load_from_lmdb(&args.db_path, &graph).await;
+    match loaded {
+        Ok(count) if count > 0 => {
+            tracing::info!("loaded {} users from LMDB", count);
+        }
+        Ok(_) => {
+            // Empty LMDB -- do bulk load if database_url is provided
+            if let Some(ref db_url) = args.database_url {
+                tracing::info!("LMDB empty, starting bulk load from PostgreSQL");
+                bulk_load::bulk_load_follows(db_url, &graph).await?;
+                tracing::info!(
+                    "bulk load complete: {} users, {} follows",
+                    graph.user_count(),
+                    graph.follow_count()
+                );
+                // Build bloom filters after bulk load
+                bloom::build_all_bloom_filters(&graph);
+                tracing::info!("bloom filters built");
+                // Persist to LMDB
+                persistence::save_to_lmdb(&args.db_path, &graph).await?;
+                tracing::info!("persisted to LMDB");
+            } else {
+                tracing::warn!("LMDB empty and no DATABASE_URL -- starting with empty graph");
+            }
+        }
+        Err(e) => {
+            tracing::warn!("failed to load LMDB: {e}, starting fresh");
+        }
+    }
+
+    // Register shutdown handler
+    let shutdown_flag = Arc::new(AtomicBool::new(false));
+    let sf = Arc::clone(&shutdown_flag);
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.ok();
+        tracing::info!("shutdown signal received");
+        sf.store(true, Ordering::Relaxed);
+        SHUTDOWN.store(true, Ordering::Relaxed);
+    });
+
+    // Start firehose sync in background
+    let graph_firehose = Arc::clone(&graph);
+    let relay_host = args.relay_host.clone();
+    let db_path_persist = args.db_path.clone();
+    let graph_persist = Arc::clone(&graph);
+    let sf_firehose = Arc::clone(&shutdown_flag);
+
+    tokio::spawn(async move {
+        firehose::tail_firehose(&relay_host, &graph_firehose, &sf_firehose).await;
+    });
+
+    // Periodic LMDB persistence
+    let sf_persist = Arc::clone(&shutdown_flag);
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+            if sf_persist.load(Ordering::Relaxed) {
+                break;
+            }
+            if let Err(e) = persistence::save_to_lmdb(&db_path_persist, &graph_persist).await {
+                tracing::error!("periodic LMDB save failed: {e}");
+            }
+        }
+    });
+
+    // Start HTTP API (blocks until shutdown)
+    api::serve(args.port, Arc::clone(&graph), shutdown_flag).await?;
+
+    // Final persist on shutdown
+    tracing::info!("final LMDB save");
+    persistence::save_to_lmdb(&args.db_path, &graph).await.ok();
+
+    tracing::info!("goodbye");
+    Ok(())
+}

--- a/rsky-graph/src/metrics.rs
+++ b/rsky-graph/src/metrics.rs
@@ -1,0 +1,74 @@
+use prometheus::{histogram_opts, opts, Histogram, IntCounter, IntGauge, Registry, TextEncoder};
+use std::sync::LazyLock;
+
+static REGISTRY: LazyLock<Registry> = LazyLock::new(Registry::new);
+
+pub static GRAPH_QUERIES_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    let c = IntCounter::new(
+        "graph_queries_total",
+        "Total follows-following queries served",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(c.clone())).unwrap();
+    c
+});
+
+pub static GRAPH_QUERY_DURATION: LazyLock<Histogram> = LazyLock::new(|| {
+    let h = Histogram::with_opts(histogram_opts!(
+        "graph_query_duration_seconds",
+        "Query duration in seconds",
+        vec![0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0]
+    ))
+    .unwrap();
+    REGISTRY.register(Box::new(h.clone())).unwrap();
+    h
+});
+
+pub static GRAPH_BLOOM_REJECTIONS: LazyLock<IntCounter> = LazyLock::new(|| {
+    let c = IntCounter::new(
+        "graph_bloom_rejections_total",
+        "Queries short-circuited by bloom filter (definite no overlap)",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(c.clone())).unwrap();
+    c
+});
+
+pub static GRAPH_USERS_TOTAL: LazyLock<IntGauge> = LazyLock::new(|| {
+    let g = IntGauge::with_opts(opts!("graph_users_total", "Total UIDs in graph")).unwrap();
+    REGISTRY.register(Box::new(g.clone())).unwrap();
+    g
+});
+
+pub static GRAPH_FOLLOWS_TOTAL: LazyLock<IntGauge> = LazyLock::new(|| {
+    let g =
+        IntGauge::with_opts(opts!("graph_follows_total", "Total follow edges in graph")).unwrap();
+    REGISTRY.register(Box::new(g.clone())).unwrap();
+    g
+});
+
+pub static GRAPH_FIREHOSE_EVENTS: LazyLock<IntCounter> = LazyLock::new(|| {
+    let c = IntCounter::new(
+        "graph_firehose_events_total",
+        "Follow events processed from firehose",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(c.clone())).unwrap();
+    c
+});
+
+pub fn encode_metrics() -> String {
+    // Force lazy initialization
+    let _ = &*GRAPH_QUERIES_TOTAL;
+    let _ = &*GRAPH_QUERY_DURATION;
+    let _ = &*GRAPH_BLOOM_REJECTIONS;
+    let _ = &*GRAPH_USERS_TOTAL;
+    let _ = &*GRAPH_FOLLOWS_TOTAL;
+    let _ = &*GRAPH_FIREHOSE_EVENTS;
+
+    let encoder = TextEncoder::new();
+    let metric_families = REGISTRY.gather();
+    let mut buffer = String::new();
+    encoder.encode_utf8(&metric_families, &mut buffer).unwrap();
+    buffer
+}

--- a/rsky-graph/src/persistence.rs
+++ b/rsky-graph/src/persistence.rs
@@ -1,0 +1,197 @@
+use crate::graph::FollowGraph;
+use crate::types::GraphError;
+use heed::types::*;
+use heed::{Database, EnvOpenOptions};
+use roaring::RoaringBitmap;
+use std::io::Cursor;
+use std::path::Path;
+
+type StrDb = Database<Str, Bytes>;
+type U32Db = Database<U32<heed::byteorder::LE>, Bytes>;
+
+pub async fn load_from_lmdb(db_path: &str, graph: &FollowGraph) -> Result<usize, GraphError> {
+    let path = Path::new(db_path);
+    if !path.exists() {
+        std::fs::create_dir_all(path)
+            .map_err(|e| GraphError::Other(format!("create dir failed: {e}")))?;
+        return Ok(0);
+    }
+
+    let env = unsafe {
+        EnvOpenOptions::new()
+            .map_size(100 * 1024 * 1024 * 1024) // 100GB max
+            .max_dbs(4)
+            .open(path)
+            .map_err(|e| GraphError::Other(format!("lmdb open failed: {e}")))?
+    };
+
+    let mut wtxn = env
+        .write_txn()
+        .map_err(|e| GraphError::Other(format!("txn failed: {e}")))?;
+
+    // DID -> UID mapping
+    let did_uid_db: StrDb = env
+        .create_database(&mut wtxn, Some("did_uid"))
+        .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
+
+    // UID -> DID mapping
+    let uid_did_db: U32Db = env
+        .create_database(&mut wtxn, Some("uid_did"))
+        .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
+
+    // Following bitmaps: UID -> serialized RoaringBitmap
+    let following_db: U32Db = env
+        .create_database(&mut wtxn, Some("following"))
+        .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
+
+    // Followers bitmaps: UID -> serialized RoaringBitmap
+    let followers_db: U32Db = env
+        .create_database(&mut wtxn, Some("followers"))
+        .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
+
+    wtxn.commit()
+        .map_err(|e| GraphError::Other(format!("commit failed: {e}")))?;
+
+    let rtxn = env
+        .read_txn()
+        .map_err(|e| GraphError::Other(format!("read txn failed: {e}")))?;
+
+    // Load DID <-> UID mappings
+    let mut max_uid: u32 = 0;
+    let mut count = 0usize;
+
+    let iter = did_uid_db
+        .iter(&rtxn)
+        .map_err(|e| GraphError::Other(format!("iter failed: {e}")))?;
+
+    for result in iter {
+        let (did, uid_bytes) =
+            result.map_err(|e| GraphError::Other(format!("iter read failed: {e}")))?;
+        if uid_bytes.len() < 4 {
+            continue;
+        }
+        let uid = u32::from_ne_bytes(uid_bytes[..4].try_into().unwrap());
+        graph.did_to_uid.insert(did.to_owned(), uid);
+        graph.uid_to_did.insert(uid, did.to_owned());
+        if uid > max_uid {
+            max_uid = uid;
+        }
+        count += 1;
+    }
+
+    graph.set_next_uid(max_uid + 1);
+
+    // Load following bitmaps
+    let iter = following_db
+        .iter(&rtxn)
+        .map_err(|e| GraphError::Other(format!("following iter failed: {e}")))?;
+
+    for result in iter {
+        let (uid, bytes) =
+            result.map_err(|e| GraphError::Other(format!("following read failed: {e}")))?;
+        let bm = RoaringBitmap::deserialize_from(Cursor::new(bytes))
+            .map_err(|e| GraphError::Other(format!("bitmap deser failed: {e}")))?;
+        graph.following.insert(uid, bm);
+    }
+
+    // Load followers bitmaps
+    let iter = followers_db
+        .iter(&rtxn)
+        .map_err(|e| GraphError::Other(format!("followers iter failed: {e}")))?;
+
+    for result in iter {
+        let (uid, bytes) =
+            result.map_err(|e| GraphError::Other(format!("followers read failed: {e}")))?;
+        let bm = RoaringBitmap::deserialize_from(Cursor::new(bytes))
+            .map_err(|e| GraphError::Other(format!("bitmap deser failed: {e}")))?;
+        graph.followers.insert(uid, bm);
+    }
+
+    rtxn.commit()
+        .map_err(|e| GraphError::Other(format!("read commit failed: {e}")))?;
+
+    // Rebuild bloom filters from loaded data
+    if count > 0 {
+        crate::bloom::build_all_bloom_filters(graph);
+    }
+
+    tracing::info!("loaded {count} users from LMDB, max_uid={max_uid}");
+    Ok(count)
+}
+
+pub async fn save_to_lmdb(db_path: &str, graph: &FollowGraph) -> Result<(), GraphError> {
+    let path = Path::new(db_path);
+    if !path.exists() {
+        std::fs::create_dir_all(path)
+            .map_err(|e| GraphError::Other(format!("create dir failed: {e}")))?;
+    }
+
+    let env = unsafe {
+        EnvOpenOptions::new()
+            .map_size(100 * 1024 * 1024 * 1024)
+            .max_dbs(4)
+            .open(path)
+            .map_err(|e| GraphError::Other(format!("lmdb open failed: {e}")))?
+    };
+
+    let mut wtxn = env
+        .write_txn()
+        .map_err(|e| GraphError::Other(format!("txn failed: {e}")))?;
+
+    let did_uid_db: StrDb = env
+        .create_database(&mut wtxn, Some("did_uid"))
+        .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
+    let uid_did_db: U32Db = env
+        .create_database(&mut wtxn, Some("uid_did"))
+        .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
+    let following_db: U32Db = env
+        .create_database(&mut wtxn, Some("following"))
+        .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
+    let followers_db: U32Db = env
+        .create_database(&mut wtxn, Some("followers"))
+        .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
+
+    // Save DID <-> UID mappings
+    for entry in graph.did_to_uid.iter() {
+        let uid_bytes = entry.value().to_ne_bytes();
+        did_uid_db
+            .put(&mut wtxn, entry.key(), &uid_bytes)
+            .map_err(|e| GraphError::Other(format!("put did_uid failed: {e}")))?;
+    }
+    for entry in graph.uid_to_did.iter() {
+        let did_bytes = entry.value().as_bytes();
+        uid_did_db
+            .put(&mut wtxn, entry.key(), did_bytes)
+            .map_err(|e| GraphError::Other(format!("put uid_did failed: {e}")))?;
+    }
+
+    // Save following bitmaps
+    for entry in graph.following.iter() {
+        let mut buf = Vec::new();
+        entry
+            .value()
+            .serialize_into(&mut buf)
+            .map_err(|e| GraphError::Other(format!("serialize following failed: {e}")))?;
+        following_db
+            .put(&mut wtxn, entry.key(), &buf)
+            .map_err(|e| GraphError::Other(format!("put following failed: {e}")))?;
+    }
+
+    // Save followers bitmaps
+    for entry in graph.followers.iter() {
+        let mut buf = Vec::new();
+        entry
+            .value()
+            .serialize_into(&mut buf)
+            .map_err(|e| GraphError::Other(format!("serialize followers failed: {e}")))?;
+        followers_db
+            .put(&mut wtxn, entry.key(), &buf)
+            .map_err(|e| GraphError::Other(format!("put followers failed: {e}")))?;
+    }
+
+    wtxn.commit()
+        .map_err(|e| GraphError::Other(format!("commit failed: {e}")))?;
+
+    tracing::debug!("saved {} users to LMDB", graph.user_count());
+    Ok(())
+}

--- a/rsky-graph/src/types.rs
+++ b/rsky-graph/src/types.rs
@@ -1,0 +1,16 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub enum GraphError {
+    Other(String),
+}
+
+impl fmt::Display for GraphError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GraphError::Other(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl std::error::Error for GraphError {}

--- a/rsky-relay/Cargo.toml
+++ b/rsky-relay/Cargo.toml
@@ -49,6 +49,7 @@ tracing = { version = "0.1", features = ["release_max_level_debug"] }
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots", "url"] }
+webpki-roots = "1"
 url = "2"
 urlencoding = "2"
 vec1 = { version = "1", features = ["serde"] }

--- a/rsky-relay/src/crawler/client.rs
+++ b/rsky-relay/src/crawler/client.rs
@@ -1,9 +1,11 @@
 use std::io;
 use std::net::{TcpStream, ToSocketAddrs};
+use std::sync::Arc;
 
 use http::Uri;
 use http::request::Parts;
 use socket2::{Domain, Protocol, Socket, Type};
+use tungstenite::Connector;
 use tungstenite::client::{IntoClientRequest, uri_mode};
 use tungstenite::client_tls_with_config;
 use tungstenite::error::{Error, Result, UrlError};
@@ -47,7 +49,19 @@ pub fn connect_with_config<Req: IntoClientRequest>(
         let mut stream = connect_to_some((host, port), request.uri())?;
         NoDelay::set_nodelay(&mut stream, true)?;
 
-        client_tls_with_config(request, stream, config, None).decompose()
+        // Build an explicit rustls connector to avoid the tungstenite "Bug: TLS
+        // handshake not blocked" panic that occurs when passing None for the
+        // connector in blocking mode with rustls-tls-webpki-roots.
+        let connector = {
+            let root_store = rustls::RootCertStore::from_iter(
+                webpki_roots::TLS_SERVER_ROOTS.iter().cloned(),
+            );
+            let tls_config = rustls::ClientConfig::builder()
+                .with_root_certificates(root_store)
+                .with_no_client_auth();
+            Connector::Rustls(Arc::new(tls_config))
+        };
+        client_tls_with_config(request, stream, config, Some(connector)).decompose()
     }
 
     fn create_request(parts: &Parts, uri: &Uri) -> Request {

--- a/rsky-relay/src/server/server.rs
+++ b/rsky-relay/src/server/server.rs
@@ -68,7 +68,12 @@ const INDEX_ASCII: &str = r"
  This is an atproto relay instance running the
  'rsky-relay' codebase [https://github.com/blacksky-algorithms/rsky]
 
+    Code: https://github.com/blacksky-algorithms
+    Support: https://opencollective.com/blacksky
+    Protocol: https://atproto.com
+
  The firehose WebSocket path is at:  /xrpc/com.atproto.sync.subscribeRepos
+ The moderation relay WebSocket path is at: /xrpc/com.atproto.label.subscribeLabels
 ";
 
 #[derive(Debug, Error)]

--- a/rsky-wintermute/src/backfiller/mod.rs
+++ b/rsky-wintermute/src/backfiller/mod.rs
@@ -340,7 +340,10 @@ impl BackfillerManager {
                 continue;
             };
 
-            if !collection.starts_with("app.bsky.") && !collection.starts_with("chat.bsky.") {
+            if !collection.starts_with("app.bsky.")
+                && !collection.starts_with("chat.bsky.")
+                && !collection.starts_with("place.stream.")
+            {
                 metrics::BACKFILLER_RECORDS_FILTERED_TOTAL.inc();
                 continue;
             }

--- a/rsky-wintermute/src/config.rs
+++ b/rsky-wintermute/src/config.rs
@@ -99,6 +99,12 @@ pub static HANDLE_RESOLUTION_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
 // Priority window for recently-indexed actors (resolve new actors faster)
 pub const HANDLE_PRIORITY_WINDOW: Duration = Duration::from_secs(6 * 60 * 60); // 6 hours
 
+// How often the handle-resolution loop folds in the (much larger) sweep over
+// stale non-NULL handles. Default: every 20th iteration -- the cheap NULL-handle
+// scans run every iteration and dominate the priority queue; the stale-revalidate
+// path only needs to run periodically to catch handle changes.
+pub const HANDLE_STALE_VALID_EVERY_N: u64 = 20;
+
 // Backfiller config - tunable via environment variables for 15B+ record backfills
 pub static WORKERS_BACKFILLER: LazyLock<usize> = LazyLock::new(|| {
     std::env::var("BACKFILLER_WORKERS")

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -3547,8 +3547,7 @@ impl IndexerManager {
             .execute(
                 "INSERT INTO stream_viewer_count (streamer, server, count, \"updatedAt\")
                  VALUES ($1, $2, $3, $4)
-                 ON CONFLICT (streamer) DO UPDATE SET
-                   server = EXCLUDED.server,
+                 ON CONFLICT (streamer, server) DO UPDATE SET
                    count = EXCLUDED.count,
                    \"updatedAt\" = EXCLUDED.\"updatedAt\"",
                 &[&streamer, &server, &count, &updated_at],

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -1363,6 +1363,40 @@ impl IndexerManager {
                         )
                         .await?;
                     }
+                    "place.stream.chat.message" => {
+                        metrics::INDEXER_STREAM_CHAT_EVENTS_TOTAL.inc();
+                        Self::index_stream_chat_message(
+                            &client,
+                            did.as_str(),
+                            rkey.as_str(),
+                            record_json,
+                            &job.cid,
+                            &job.indexed_at,
+                        )
+                        .await?;
+                    }
+                    "place.stream.livestream" => {
+                        metrics::INDEXER_STREAM_LIVESTREAM_EVENTS_TOTAL.inc();
+                        Self::index_stream_livestream(
+                            &client,
+                            did.as_str(),
+                            rkey.as_str(),
+                            record_json,
+                            &job.cid,
+                            &job.indexed_at,
+                        )
+                        .await?;
+                    }
+                    "place.stream.live.viewerCount" => {
+                        metrics::INDEXER_STREAM_VIEWER_COUNT_EVENTS_TOTAL.inc();
+                        Self::index_stream_viewer_count(
+                            &client,
+                            did.as_str(),
+                            record_json,
+                            &job.indexed_at,
+                        )
+                        .await?;
+                    }
                     _ => {}
                 }
             }
@@ -1431,6 +1465,14 @@ impl IndexerManager {
                     }
                     "community.blacksky.feed.post" => {
                         Self::delete_community_post(&client, did.as_str(), rkey.as_str()).await?;
+                    }
+                    "place.stream.chat.message" => {
+                        Self::delete_stream_chat_message(&client, did.as_str(), rkey.as_str())
+                            .await?;
+                    }
+                    "place.stream.livestream" => {
+                        Self::delete_stream_livestream(&client, did.as_str(), rkey.as_str())
+                            .await?;
                     }
                     _ => {}
                 }
@@ -1887,6 +1929,15 @@ impl IndexerManager {
             }
             "community.blacksky.feed.post" => {
                 Self::index_community_post_stub(client, did, rkey, cid, indexed_at).await
+            }
+            "place.stream.chat.message" => {
+                Self::index_stream_chat_message(client, did, rkey, record, cid, indexed_at).await
+            }
+            "place.stream.livestream" => {
+                Self::index_stream_livestream(client, did, rkey, record, cid, indexed_at).await
+            }
+            "place.stream.live.viewerCount" => {
+                Self::index_stream_viewer_count(client, did, record, indexed_at).await
             }
             _ => Ok(()),
         }
@@ -3370,6 +3421,144 @@ impl IndexerManager {
         tracing::info!("deleted community post {}", uri);
         Ok(())
     }
+
+    // ── Streamplace record indexing ─────────────────────────────────────────
+
+    async fn index_stream_chat_message(
+        client: &deadpool_postgres::Client,
+        did: &str,
+        rkey: &str,
+        record: &serde_json::Value,
+        cid: &str,
+        indexed_at: &str,
+    ) -> Result<(), WintermuteError> {
+        let uri = format!("at://{did}/place.stream.chat.message/{rkey}");
+        let text = record.get("text").and_then(|v| v.as_str()).unwrap_or("");
+        let streamer = record
+            .get("streamer")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let created_at = record
+            .get("createdAt")
+            .and_then(|v| v.as_str())
+            .unwrap_or(indexed_at);
+
+        if streamer.is_empty() {
+            return Ok(());
+        }
+
+        client
+            .execute(
+                "INSERT INTO stream_chat_message (uri, cid, creator, streamer, text, \"createdAt\", \"indexedAt\")
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)
+                 ON CONFLICT DO NOTHING",
+                &[&uri, &cid, &did, &streamer, &text, &created_at, &indexed_at],
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn delete_stream_chat_message(
+        client: &deadpool_postgres::Client,
+        did: &str,
+        rkey: &str,
+    ) -> Result<(), WintermuteError> {
+        let uri = format!("at://{did}/place.stream.chat.message/{rkey}");
+        client
+            .execute("DELETE FROM stream_chat_message WHERE uri = $1", &[&uri])
+            .await?;
+        Ok(())
+    }
+
+    async fn index_stream_livestream(
+        client: &deadpool_postgres::Client,
+        did: &str,
+        rkey: &str,
+        record: &serde_json::Value,
+        cid: &str,
+        indexed_at: &str,
+    ) -> Result<(), WintermuteError> {
+        let uri = format!("at://{did}/place.stream.livestream/{rkey}");
+        let title = record.get("title").and_then(|v| v.as_str()).unwrap_or("");
+        let stream_url = record.get("url").and_then(|v| v.as_str());
+        let created_at = record
+            .get("createdAt")
+            .and_then(|v| v.as_str())
+            .unwrap_or(indexed_at);
+        let ended_at = record.get("endedAt").and_then(|v| v.as_str());
+
+        client
+            .execute(
+                "INSERT INTO stream_livestream (uri, cid, creator, title, url, \"createdAt\", \"endedAt\", \"indexedAt\")
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                 ON CONFLICT (uri) DO UPDATE SET
+                   cid = EXCLUDED.cid,
+                   title = EXCLUDED.title,
+                   url = EXCLUDED.url,
+                   \"endedAt\" = EXCLUDED.\"endedAt\",
+                   \"indexedAt\" = EXCLUDED.\"indexedAt\"",
+                &[&uri, &cid, &did, &title, &stream_url, &created_at, &ended_at, &indexed_at],
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn delete_stream_livestream(
+        client: &deadpool_postgres::Client,
+        did: &str,
+        rkey: &str,
+    ) -> Result<(), WintermuteError> {
+        let uri = format!("at://{did}/place.stream.livestream/{rkey}");
+        client
+            .execute("DELETE FROM stream_livestream WHERE uri = $1", &[&uri])
+            .await?;
+        Ok(())
+    }
+
+    async fn index_stream_viewer_count(
+        client: &deadpool_postgres::Client,
+        did: &str,
+        record: &serde_json::Value,
+        indexed_at: &str,
+    ) -> Result<(), WintermuteError> {
+        let streamer = record
+            .get("streamer")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let server = record.get("server").and_then(|v| v.as_str()).unwrap_or(did);
+        let count: i32 = record
+            .get("count")
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(0)
+            .try_into()
+            .unwrap_or(i32::MAX);
+        let updated_at = record
+            .get("updatedAt")
+            .and_then(|v| v.as_str())
+            .unwrap_or(indexed_at);
+
+        if streamer.is_empty() {
+            return Ok(());
+        }
+
+        client
+            .execute(
+                "INSERT INTO stream_viewer_count (streamer, server, count, \"updatedAt\")
+                 VALUES ($1, $2, $3, $4)
+                 ON CONFLICT (streamer) DO UPDATE SET
+                   server = EXCLUDED.server,
+                   count = EXCLUDED.count,
+                   \"updatedAt\" = EXCLUDED.\"updatedAt\"",
+                &[&streamer, &server, &count, &updated_at],
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    // ── End Streamplace record indexing ───────────────────────────────────
 
     async fn index_like(
         client: &deadpool_postgres::Client,

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -5,7 +5,7 @@ use crate::SHUTDOWN;
 use crate::config::{
     DB_POOL_SIZE, HANDLE_PRIORITY_WINDOW, HANDLE_REINDEX_INTERVAL_INVALID,
     HANDLE_REINDEX_INTERVAL_VALID, HANDLE_RESOLUTION_BATCH_SIZE, HANDLE_RESOLUTION_CONCURRENCY,
-    IDENTITY_RESOLVER_TIMEOUT, INLINE_CONCURRENCY, WORKERS_INDEXER,
+    HANDLE_STALE_VALID_EVERY_N, IDENTITY_RESOLVER_TIMEOUT, INLINE_CONCURRENCY, WORKERS_INDEXER,
 };
 use crate::config::{INDEXER_BATCH_SIZE, INDEXER_BATCH_WORKERS};
 use crate::storage::Storage;
@@ -199,8 +199,14 @@ impl IndexerManager {
                 break;
             }
 
-            // Query actors with NULL handle or stale indexedAt
-            let dids_to_resolve = match self.get_actors_needing_handle_resolution().await {
+            // Run the cheap NULL-handle queries every iteration; fold in the more
+            // expensive "stale non-NULL" sweep only every Nth iteration so the
+            // background loop does not dominate PG IO.
+            let include_stale_valid = batch_count % HANDLE_STALE_VALID_EVERY_N == 0;
+            let dids_to_resolve = match self
+                .get_actors_needing_handle_resolution(include_stale_valid)
+                .await
+            {
                 Ok(dids) => dids,
                 Err(e) => {
                     tracing::warn!("failed to get actors needing handle resolution: {e}");
@@ -283,53 +289,72 @@ impl IndexerManager {
         }
     }
 
-    async fn get_actors_needing_handle_resolution(&self) -> Result<Vec<String>, WintermuteError> {
+    async fn get_actors_needing_handle_resolution(
+        &self,
+        include_stale_valid: bool,
+    ) -> Result<Vec<String>, WintermuteError> {
         let client = self.pool_labels.get().await?;
         let batch_size = i64::try_from(*HANDLE_RESOLUTION_BATCH_SIZE).unwrap_or(500);
 
-        // Get actors with NULL handle or stale indexedAt
-        // Priority order:
-        // 1. Recently-indexed actors with NULL handle (within priority window) - newest first
-        // 2. Older actors with NULL handle - oldest first
-        // 3. Actors with stale valid handles - oldest first
         let stale_threshold_invalid = (chrono::Utc::now()
             - chrono::Duration::from_std(HANDLE_REINDEX_INTERVAL_INVALID).unwrap_or_default())
-        .to_rfc3339();
-        let stale_threshold_valid = (chrono::Utc::now()
-            - chrono::Duration::from_std(HANDLE_REINDEX_INTERVAL_VALID).unwrap_or_default())
         .to_rfc3339();
         let priority_window = (chrono::Utc::now()
             - chrono::Duration::from_std(HANDLE_PRIORITY_WINDOW).unwrap_or_default())
         .to_rfc3339();
 
-        // Query with priority: recent NULL handles first (newest), then older NULL handles (oldest), then stale valid handles
-        let rows = client
+        // Query A: NULL handles. Two short queries against actor_null_handle_idx
+        // (the partial index on indexedAt WHERE handle IS NULL) -- one for recent
+        // priority-window actors (newest first), one for older actors (oldest first).
+        // These each do a bounded index range scan; together they replace the prior
+        // single OR/CASE query that the planner could not satisfy from one index.
+        let recent_half = batch_size / 2;
+        let older_half = batch_size - recent_half;
+
+        let recent_rows = client
             .query(
-                "SELECT did FROM actor
-                 WHERE (handle IS NULL AND \"indexedAt\" < $1)
-                    OR (handle IS NOT NULL AND \"indexedAt\" < $2)
-                 ORDER BY
-                   CASE
-                     WHEN handle IS NULL AND \"indexedAt\" >= $3 THEN 0  -- Recent NULL: highest priority
-                     WHEN handle IS NULL THEN 1                          -- Older NULL: second priority
-                     ELSE 2                                              -- Stale valid: lowest priority
-                   END,
-                   CASE
-                     WHEN handle IS NULL AND \"indexedAt\" >= $3 THEN \"indexedAt\"  -- Recent: newest first
-                     ELSE NULL
-                   END DESC NULLS LAST,
-                   \"indexedAt\" ASC  -- Older entries: oldest first
-                 LIMIT $4",
-                &[
-                    &stale_threshold_invalid,
-                    &stale_threshold_valid,
-                    &priority_window,
-                    &batch_size,
-                ],
+                "SELECT did FROM actor \
+                 WHERE handle IS NULL AND \"indexedAt\" >= $1 AND \"indexedAt\" < $2 \
+                 ORDER BY \"indexedAt\" DESC \
+                 LIMIT $3",
+                &[&priority_window, &stale_threshold_invalid, &recent_half],
             )
             .await?;
 
-        let dids: Vec<String> = rows.iter().map(|row| row.get("did")).collect();
+        let older_rows = client
+            .query(
+                "SELECT did FROM actor \
+                 WHERE handle IS NULL AND \"indexedAt\" < $1 \
+                 ORDER BY \"indexedAt\" ASC \
+                 LIMIT $2",
+                &[&priority_window, &older_half],
+            )
+            .await?;
+
+        let cap = usize::try_from(batch_size).unwrap_or(0);
+        let mut dids: Vec<String> = Vec::with_capacity(cap);
+        dids.extend(recent_rows.iter().map(|row| row.get::<_, String>("did")));
+        dids.extend(older_rows.iter().map(|row| row.get::<_, String>("did")));
+
+        // Query B: stale non-NULL handles. Run only at a slower cadence -- this
+        // path uses actor_indexed_at_idx (full table indexed, much larger) and is
+        // not user-visible, so we don't need it on every iteration.
+        if include_stale_valid {
+            let stale_threshold_valid = (chrono::Utc::now()
+                - chrono::Duration::from_std(HANDLE_REINDEX_INTERVAL_VALID).unwrap_or_default())
+            .to_rfc3339();
+            let stale_rows = client
+                .query(
+                    "SELECT did FROM actor \
+                     WHERE handle IS NOT NULL AND \"indexedAt\" < $1 \
+                     ORDER BY \"indexedAt\" ASC \
+                     LIMIT $2",
+                    &[&stale_threshold_valid, &batch_size],
+                )
+                .await?;
+            dids.extend(stale_rows.iter().map(|row| row.get::<_, String>("did")));
+        }
+
         Ok(dids)
     }
 

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -1387,16 +1387,6 @@ impl IndexerManager {
                         )
                         .await?;
                     }
-                    "place.stream.live.viewerCount" => {
-                        metrics::INDEXER_STREAM_VIEWER_COUNT_EVENTS_TOTAL.inc();
-                        Self::index_stream_viewer_count(
-                            &client,
-                            did.as_str(),
-                            record_json,
-                            &job.indexed_at,
-                        )
-                        .await?;
-                    }
                     _ => {}
                 }
             }
@@ -1935,9 +1925,6 @@ impl IndexerManager {
             }
             "place.stream.livestream" => {
                 Self::index_stream_livestream(client, did, rkey, record, cid, indexed_at).await
-            }
-            "place.stream.live.viewerCount" => {
-                Self::index_stream_viewer_count(client, did, record, indexed_at).await
             }
             _ => Ok(()),
         }
@@ -3514,46 +3501,6 @@ impl IndexerManager {
         client
             .execute("DELETE FROM stream_livestream WHERE uri = $1", &[&uri])
             .await?;
-        Ok(())
-    }
-
-    async fn index_stream_viewer_count(
-        client: &deadpool_postgres::Client,
-        did: &str,
-        record: &serde_json::Value,
-        indexed_at: &str,
-    ) -> Result<(), WintermuteError> {
-        let streamer = record
-            .get("streamer")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        let server = record.get("server").and_then(|v| v.as_str()).unwrap_or(did);
-        let count: i32 = record
-            .get("count")
-            .and_then(serde_json::Value::as_i64)
-            .unwrap_or(0)
-            .try_into()
-            .unwrap_or(i32::MAX);
-        let updated_at = record
-            .get("updatedAt")
-            .and_then(|v| v.as_str())
-            .unwrap_or(indexed_at);
-
-        if streamer.is_empty() {
-            return Ok(());
-        }
-
-        client
-            .execute(
-                "INSERT INTO stream_viewer_count (streamer, server, count, \"updatedAt\")
-                 VALUES ($1, $2, $3, $4)
-                 ON CONFLICT (streamer, server) DO UPDATE SET
-                   count = EXCLUDED.count,
-                   \"updatedAt\" = EXCLUDED.\"updatedAt\"",
-                &[&streamer, &server, &count, &updated_at],
-            )
-            .await?;
-
         Ok(())
     }
 

--- a/rsky-wintermute/src/metrics.rs
+++ b/rsky-wintermute/src/metrics.rs
@@ -342,6 +342,30 @@ pub static INDEXER_PROFILE_EVENTS_TOTAL: LazyLock<IntCounter> = LazyLock::new(||
     .unwrap()
 });
 
+pub static INDEXER_STREAM_CHAT_EVENTS_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "indexer_stream_chat_events_total",
+        "Total number of stream chat message events indexed"
+    )
+    .unwrap()
+});
+
+pub static INDEXER_STREAM_LIVESTREAM_EVENTS_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "indexer_stream_livestream_events_total",
+        "Total number of stream livestream events indexed"
+    )
+    .unwrap()
+});
+
+pub static INDEXER_STREAM_VIEWER_COUNT_EVENTS_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "indexer_stream_viewer_count_events_total",
+        "Total number of stream viewer count events indexed"
+    )
+    .unwrap()
+});
+
 /// Overall indexer stats
 pub static INDEXER_RECORDS_PROCESSED_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
     register_int_counter!(

--- a/rsky-wintermute/src/metrics.rs
+++ b/rsky-wintermute/src/metrics.rs
@@ -358,14 +358,6 @@ pub static INDEXER_STREAM_LIVESTREAM_EVENTS_TOTAL: LazyLock<IntCounter> = LazyLo
     .unwrap()
 });
 
-pub static INDEXER_STREAM_VIEWER_COUNT_EVENTS_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
-    register_int_counter!(
-        "indexer_stream_viewer_count_events_total",
-        "Total number of stream viewer count events indexed"
-    )
-    .unwrap()
-});
-
 /// Overall indexer stats
 pub static INDEXER_RECORDS_PROCESSED_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
     register_int_counter!(


### PR DESCRIPTION
## Summary

- Refactor wintermute handle-resolution sweep to two index-friendly queries (priority-A NULL handles every iteration, priority-B stale non-NULL every 20th iteration) — eliminates the `OR` clause that defeated `actor_null_handle_idx`. Drops 980 ms × 20K calls/hour to <10 ms each.
- Replace rsky-graph's long-lived `DECLARE CURSOR` bulk loader (the previous failure mode that hurt prod) with two safer paths: file-based load via `\copy` CSV (zero PG transaction during load) and keyset-paginated short-transaction queries with throttling. New `--load-from-file` / `GRAPH_LOAD_FROM_FILE` flag.
- Wire follow deletes through the firehose by recording `(actor_uid, rkey) → subject_uid` on creates so deletes can resolve the subject.

## Context

HAR captures showed users hitting `502 UpstreamFailure` from the PDS pipethrough at ~10s — the AppView itself was processing 27% of requests in >5s due to a mutual-follow self-join (645 ms × 1.24 M calls/hour) and the wintermute handle-resolution sweep (980 ms × 20K calls/hour). Plan in `~/.claude/plans/recursive-honking-sprout.md`.

A separate atproto branch `fix/graph-service-fallback` adds the feature-flagged `BSKY_GRAPH_SERVICE_URL` path in `getFollowsFollowing`, default off, falls back to PG on any error.

The starter-pack count fix (partial index `idx_profile_joined_via_sp`) was already deployed to production PG separately — `CREATE INDEX CONCURRENTLY`, no code change needed. Query 565 ms → 6 ms confirmed.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` pass for rsky-graph and rsky-wintermute
- [ ] `sudo /opt/appview/deploy-wintermute.sh main` once merged — auto-rollback in script handles regressions
- [ ] rsky-graph rollout is a separate operational sequence (off-peak `\copy` of `bsky.follow`, systemd unit install, firehose-only validation, feature-flag ramp) — code lands here but stays dormant until that sequence runs