### PR TITLE
rsky-graph: incremental periodic save + drop eager bloom rebuild

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,6 +1125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0669d5a35b64fdb5ab7fb19cae13148b6b5cbdf4b8247faf54ece47f699c8cef"
 
 [[package]]
+name = "bit-vec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
+
+[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,6 +1261,17 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "bloomfilter"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c541c70a910b485670304fd420f0eab8f7bde68439db6a8d98819c3d2774d7e2"
+dependencies = [
+ "bit-vec",
+ "getrandom 0.2.16",
+ "siphasher 1.0.1",
 ]
 
 [[package]]
@@ -7827,6 +7844,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.10.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "rocket"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8074,6 +8101,44 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite 0.18.0",
+ "url",
+]
+
+[[package]]
+name = "rsky-graph"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bloomfilter",
+ "bytes",
+ "chrono",
+ "ciborium",
+ "cid 0.11.1",
+ "clap",
+ "color-eyre",
+ "dashmap 6.1.0",
+ "deadpool-postgres",
+ "futures",
+ "heed",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "mimalloc",
+ "prometheus",
+ "roaring",
+ "rsky-firehose",
+ "rsky-lexicon",
+ "rustls 0.23.31",
+ "serde",
+ "serde_cbor",
+ "serde_ipld_dagcbor 0.6.3",
+ "serde_json",
+ "signal-hook",
+ "tokio",
+ "tokio-postgres",
+ "tokio-tungstenite 0.24.0",
+ "tracing",
+ "tracing-subscriber",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8134,6 +8134,7 @@ dependencies = [
  "serde_ipld_dagcbor 0.6.3",
  "serde_json",
  "signal-hook",
+ "tempfile",
  "tokio",
  "tokio-postgres",
  "tokio-tungstenite 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "rsky-syntax",
   "rsky-video",
   "rsky-wintermute",
+  "rsky-graph",
 ]
 resolver = "2"
 

--- a/rsky-graph/Cargo.toml
+++ b/rsky-graph/Cargo.toml
@@ -1,0 +1,79 @@
+[package]
+name = "rsky-graph"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "rsky-graph"
+path = "src/main.rs"
+
+[dependencies]
+# Roaring bitmaps for follow graph
+roaring = "0.10"
+
+# Bloom filters for fast rejection
+bloomfilter = "1.0"
+
+# Concurrent hashmaps
+dashmap = "6"
+
+# Async runtime
+tokio = { workspace = true }
+
+# PostgreSQL for bulk load
+tokio-postgres = { version = "0.7", features = ["with-chrono-0_4"] }
+deadpool-postgres = "0.13"
+
+# HTTP server
+hyper = { version = "1", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+http-body-util = "0.1"
+bytes = "1"
+
+# WebSocket for firehose
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots", "url"] }
+futures = "0.3"
+
+# TLS
+rustls = { version = "0.23", features = ["aws_lc_rs"] }
+
+# Serialization
+serde = { workspace = true }
+serde_json = "1"
+ciborium = "0.2"
+serde_ipld_dagcbor = { workspace = true }
+
+# LMDB persistence
+heed = "0.20"
+
+# CLI
+clap = { version = "4", features = ["derive", "env"] }
+
+# Logging
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Metrics
+prometheus = "0.13"
+
+# Memory allocator
+mimalloc = "0.1"
+
+# Error handling
+color-eyre = "0.6"
+
+# Signal handling
+signal-hook = { version = "0.3", features = ["extended-siginfo"] }
+
+# URL parsing
+url = "2"
+
+# Timestamp
+chrono = "0.4"
+
+# AT Protocol parsing
+rsky-firehose = { path = "../rsky-firehose" }
+rsky-lexicon = { workspace = true }
+lexicon_cid = { workspace = true }
+serde_cbor = "0.11"
+anyhow = "1"

--- a/rsky-graph/Cargo.toml
+++ b/rsky-graph/Cargo.toml
@@ -3,6 +3,10 @@ name = "rsky-graph"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+name = "rsky_graph"
+path = "src/lib.rs"
+
 [[bin]]
 name = "rsky-graph"
 path = "src/main.rs"
@@ -77,3 +81,6 @@ rsky-lexicon = { workspace = true }
 lexicon_cid = { workspace = true }
 serde_cbor = "0.11"
 anyhow = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/rsky-graph/src/api.rs
+++ b/rsky-graph/src/api.rs
@@ -1,0 +1,164 @@
+use crate::graph::FollowGraph;
+use crate::metrics;
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::net::TcpListener;
+
+pub async fn serve(
+    port: u16,
+    graph: Arc<FollowGraph>,
+    shutdown: Arc<AtomicBool>,
+) -> color_eyre::Result<()> {
+    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
+    let listener = TcpListener::bind(addr).await?;
+    tracing::info!("HTTP API listening on {addr}");
+
+    loop {
+        if shutdown.load(Ordering::Relaxed) {
+            break;
+        }
+
+        let conn = tokio::select! {
+            result = listener.accept() => {
+                match result {
+                    Ok((stream, _)) => stream,
+                    Err(e) => {
+                        tracing::error!("accept error: {e}");
+                        continue;
+                    }
+                }
+            }
+            () = tokio::time::sleep(std::time::Duration::from_millis(100)) => continue,
+        };
+
+        let graph = Arc::clone(&graph);
+        tokio::spawn(async move {
+            let service = service_fn(move |req: Request<hyper::body::Incoming>| {
+                let graph = Arc::clone(&graph);
+                async move { handle_request(req, &graph).await }
+            });
+            if let Err(e) = http1::Builder::new()
+                .serve_connection(TokioIo::new(conn), service)
+                .await
+            {
+                tracing::error!("connection error: {e}");
+            }
+        });
+    }
+
+    Ok(())
+}
+
+async fn handle_request(
+    req: Request<hyper::body::Incoming>,
+    graph: &FollowGraph,
+) -> Result<Response<Full<Bytes>>, hyper::Error> {
+    let path = req.uri().path();
+
+    match path {
+        "/_health" => Ok(Response::builder()
+            .status(StatusCode::OK)
+            .body(Full::new(Bytes::from("ok")))
+            .unwrap()),
+
+        "/metrics" => {
+            let body = metrics::encode_metrics();
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", "text/plain; version=0.0.4")
+                .body(Full::new(Bytes::from(body)))
+                .unwrap())
+        }
+
+        "/v1/follows-following" => {
+            let start = Instant::now();
+            let query = req.uri().query().unwrap_or("");
+            let params: Vec<(String, String)> = url::form_urlencoded::parse(query.as_bytes())
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+
+            let viewer = params
+                .iter()
+                .find(|(k, _)| k == "viewer")
+                .map(|(_, v)| v.as_str())
+                .unwrap_or("");
+
+            let targets: Vec<&str> = params
+                .iter()
+                .find(|(k, _)| k == "targets")
+                .map(|(_, v)| v.split(',').collect())
+                .unwrap_or_default();
+
+            if viewer.is_empty() || targets.is_empty() {
+                return Ok(Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .header("Content-Type", "application/json")
+                    .body(Full::new(Bytes::from(
+                        r#"{"error":"viewer and targets required"}"#,
+                    )))
+                    .unwrap());
+            }
+
+            let mut results = Vec::with_capacity(targets.len());
+            for target in &targets {
+                let dids = graph.get_follows_following(viewer, target);
+                results.push(serde_json::json!({
+                    "targetDid": target,
+                    "dids": dids,
+                }));
+            }
+
+            let body = serde_json::json!({ "results": results });
+            let elapsed = start.elapsed();
+
+            metrics::GRAPH_QUERY_DURATION.observe(elapsed.as_secs_f64());
+            metrics::GRAPH_QUERIES_TOTAL.inc();
+
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", "application/json")
+                .header("X-Query-Time-Ms", elapsed.as_millis().to_string())
+                .body(Full::new(Bytes::from(body.to_string())))
+                .unwrap())
+        }
+
+        "/v1/is-following" => {
+            let query = req.uri().query().unwrap_or("");
+            let params: Vec<(String, String)> = url::form_urlencoded::parse(query.as_bytes())
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+
+            let actor = params
+                .iter()
+                .find(|(k, _)| k == "actor")
+                .map(|(_, v)| v.as_str())
+                .unwrap_or("");
+            let target = params
+                .iter()
+                .find(|(k, _)| k == "target")
+                .map(|(_, v)| v.as_str())
+                .unwrap_or("");
+
+            let following = graph.is_following(actor, target);
+            let body = serde_json::json!({ "following": following });
+
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", "application/json")
+                .body(Full::new(Bytes::from(body.to_string())))
+                .unwrap())
+        }
+
+        _ => Ok(Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Full::new(Bytes::from("Not Found")))
+            .unwrap()),
+    }
+}

--- a/rsky-graph/src/api.rs
+++ b/rsky-graph/src/api.rs
@@ -4,16 +4,35 @@ use bytes::Bytes;
 use http_body_util::Full;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
-use hyper::{Request, Response, StatusCode};
+use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::net::TcpListener;
 
+/// Operator-only state. The admin endpoint is gated by `token`; when None,
+/// `/admin/*` routes refuse all callers regardless of headers.
+pub struct AdminState {
+    pub token: Option<String>,
+    pub database_url: Option<String>,
+    pub bulk_load_running: AtomicBool,
+}
+
+impl AdminState {
+    pub fn new(token: Option<String>, database_url: Option<String>) -> Self {
+        Self {
+            token,
+            database_url,
+            bulk_load_running: AtomicBool::new(false),
+        }
+    }
+}
+
 pub async fn serve(
     port: u16,
     graph: Arc<FollowGraph>,
+    admin: Arc<AdminState>,
     shutdown: Arc<AtomicBool>,
 ) -> color_eyre::Result<()> {
     let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
@@ -39,10 +58,12 @@ pub async fn serve(
         };
 
         let graph = Arc::clone(&graph);
+        let admin = Arc::clone(&admin);
         tokio::spawn(async move {
             let service = service_fn(move |req: Request<hyper::body::Incoming>| {
                 let graph = Arc::clone(&graph);
-                async move { handle_request(req, &graph).await }
+                let admin = Arc::clone(&admin);
+                async move { handle_request(req, graph, admin).await }
             });
             if let Err(e) = http1::Builder::new()
                 .serve_connection(TokioIo::new(conn), service)
@@ -56,17 +77,15 @@ pub async fn serve(
     Ok(())
 }
 
-async fn handle_request(
-    req: Request<hyper::body::Incoming>,
-    graph: &FollowGraph,
+async fn handle_request<B>(
+    req: Request<B>,
+    graph: Arc<FollowGraph>,
+    admin: Arc<AdminState>,
 ) -> Result<Response<Full<Bytes>>, hyper::Error> {
     let path = req.uri().path();
 
     match path {
-        "/_health" => Ok(Response::builder()
-            .status(StatusCode::OK)
-            .body(Full::new(Bytes::from("ok")))
-            .unwrap()),
+        "/_health" => Ok(json_response(StatusCode::OK, r#"{"status":"ok"}"#)),
 
         "/metrics" => {
             let body = metrics::encode_metrics();
@@ -77,88 +96,397 @@ async fn handle_request(
                 .unwrap())
         }
 
-        "/v1/follows-following" => {
-            let start = Instant::now();
-            let query = req.uri().query().unwrap_or("");
-            let params: Vec<(String, String)> = url::form_urlencoded::parse(query.as_bytes())
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect();
+        "/v1/follows-following" => Ok(handle_follows_following(&req, &graph)),
 
-            let viewer = params
-                .iter()
-                .find(|(k, _)| k == "viewer")
-                .map(|(_, v)| v.as_str())
-                .unwrap_or("");
+        "/v1/is-following" => Ok(handle_is_following(&req, &graph)),
 
-            let targets: Vec<&str> = params
-                .iter()
-                .find(|(k, _)| k == "targets")
-                .map(|(_, v)| v.split(',').collect())
-                .unwrap_or_default();
+        "/admin/bulk-load" => Ok(handle_admin_bulk_load(&req, &graph, &admin)),
 
-            if viewer.is_empty() || targets.is_empty() {
-                return Ok(Response::builder()
-                    .status(StatusCode::BAD_REQUEST)
-                    .header("Content-Type", "application/json")
-                    .body(Full::new(Bytes::from(
-                        r#"{"error":"viewer and targets required"}"#,
-                    )))
-                    .unwrap());
+        _ => Ok(json_response(
+            StatusCode::NOT_FOUND,
+            r#"{"error":"not found"}"#,
+        )),
+    }
+}
+
+fn handle_follows_following<B>(req: &Request<B>, graph: &FollowGraph) -> Response<Full<Bytes>> {
+    let start = Instant::now();
+    let query = req.uri().query().unwrap_or("");
+    let params: Vec<(String, String)> = url::form_urlencoded::parse(query.as_bytes())
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+
+    let viewer = params
+        .iter()
+        .find(|(k, _)| k == "viewer")
+        .map(|(_, v)| v.as_str())
+        .unwrap_or("");
+
+    let targets: Vec<&str> = params
+        .iter()
+        .find(|(k, _)| k == "targets")
+        .map(|(_, v)| v.split(',').collect())
+        .unwrap_or_default();
+
+    if viewer.is_empty() || targets.is_empty() {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            r#"{"error":"viewer and targets required"}"#,
+        );
+    }
+
+    let mut results = Vec::with_capacity(targets.len());
+    for target in &targets {
+        let dids = graph.get_follows_following(viewer, target);
+        results.push(serde_json::json!({
+            "targetDid": target,
+            "dids": dids,
+        }));
+    }
+
+    let body = serde_json::json!({ "results": results });
+    let elapsed = start.elapsed();
+
+    metrics::GRAPH_QUERY_DURATION.observe(elapsed.as_secs_f64());
+    metrics::GRAPH_QUERIES_TOTAL.inc();
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "application/json")
+        .header("X-Query-Time-Ms", elapsed.as_millis().to_string())
+        .body(Full::new(Bytes::from(body.to_string())))
+        .unwrap()
+}
+
+fn handle_is_following<B>(req: &Request<B>, graph: &FollowGraph) -> Response<Full<Bytes>> {
+    let query = req.uri().query().unwrap_or("");
+    let params: Vec<(String, String)> = url::form_urlencoded::parse(query.as_bytes())
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+
+    let actor = params
+        .iter()
+        .find(|(k, _)| k == "actor")
+        .map(|(_, v)| v.as_str())
+        .unwrap_or("");
+    let target = params
+        .iter()
+        .find(|(k, _)| k == "target")
+        .map(|(_, v)| v.as_str())
+        .unwrap_or("");
+
+    let following = graph.is_following(actor, target);
+    let body = serde_json::json!({ "following": following });
+    json_response(StatusCode::OK, &body.to_string())
+}
+
+fn handle_admin_bulk_load<B>(
+    req: &Request<B>,
+    graph: &Arc<FollowGraph>,
+    admin: &Arc<AdminState>,
+) -> Response<Full<Bytes>> {
+    if req.method() != Method::POST {
+        return json_response(
+            StatusCode::METHOD_NOT_ALLOWED,
+            r#"{"error":"POST required"}"#,
+        );
+    }
+
+    let Some(expected) = admin.token.as_deref() else {
+        return json_response(StatusCode::UNAUTHORIZED, r#"{"error":"admin disabled"}"#);
+    };
+
+    let presented = req
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "));
+
+    if !presented.is_some_and(|t| ct_eq(t.as_bytes(), expected.as_bytes())) {
+        return json_response(StatusCode::UNAUTHORIZED, r#"{"error":"invalid token"}"#);
+    }
+
+    let Some(database_url) = admin.database_url.clone() else {
+        return json_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            r#"{"error":"DATABASE_URL not set"}"#,
+        );
+    };
+
+    if admin
+        .bulk_load_running
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return json_response(
+            StatusCode::CONFLICT,
+            r#"{"error":"bulk-load already running"}"#,
+        );
+    }
+
+    let graph = Arc::clone(graph);
+    let admin = Arc::clone(admin);
+    tokio::spawn(async move {
+        let _guard = BulkLoadGuard {
+            admin: Arc::clone(&admin),
+        };
+        tracing::info!("admin: starting bulk-load via POST /admin/bulk-load");
+        match crate::bulk_load::bulk_load_keyset(&database_url, &graph).await {
+            Ok(()) => {
+                tracing::info!("admin: bulk-load complete; rebuilding bloom filters");
+                crate::bloom::build_all_bloom_filters(&graph);
             }
-
-            let mut results = Vec::with_capacity(targets.len());
-            for target in &targets {
-                let dids = graph.get_follows_following(viewer, target);
-                results.push(serde_json::json!({
-                    "targetDid": target,
-                    "dids": dids,
-                }));
+            Err(e) => {
+                tracing::error!("admin bulk-load failed: {e}");
             }
+        }
+    });
 
-            let body = serde_json::json!({ "results": results });
-            let elapsed = start.elapsed();
+    json_response(StatusCode::ACCEPTED, r#"{"status":"started"}"#)
+}
 
-            metrics::GRAPH_QUERY_DURATION.observe(elapsed.as_secs_f64());
-            metrics::GRAPH_QUERIES_TOTAL.inc();
+struct BulkLoadGuard {
+    admin: Arc<AdminState>,
+}
 
-            Ok(Response::builder()
-                .status(StatusCode::OK)
-                .header("Content-Type", "application/json")
-                .header("X-Query-Time-Ms", elapsed.as_millis().to_string())
-                .body(Full::new(Bytes::from(body.to_string())))
-                .unwrap())
+impl Drop for BulkLoadGuard {
+    fn drop(&mut self) {
+        self.admin.bulk_load_running.store(false, Ordering::SeqCst);
+    }
+}
+
+fn json_response(status: StatusCode, body: &str) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(status)
+        .header("Content-Type", "application/json")
+        .body(Full::new(Bytes::from(body.to_owned())))
+        .unwrap()
+}
+
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_body_util::Empty;
+
+    fn req(method: &str, path: &str, auth: Option<&str>) -> Request<Empty<Bytes>> {
+        let mut b = Request::builder().method(method).uri(path);
+        if let Some(t) = auth {
+            b = b.header("authorization", format!("Bearer {t}"));
+        }
+        b.body(Empty::<Bytes>::new()).unwrap()
+    }
+
+    fn admin_state(token: Option<&str>, db: Option<&str>) -> Arc<AdminState> {
+        Arc::new(AdminState::new(
+            token.map(str::to_owned),
+            db.map(str::to_owned),
+        ))
+    }
+
+    #[tokio::test]
+    async fn admin_disabled_returns_401() {
+        let g = Arc::new(FollowGraph::new());
+        let a = admin_state(None, Some("postgres://x"));
+        let resp = handle_request(req("POST", "/admin/bulk-load", Some("anything")), g, a)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn admin_wrong_token_returns_401() {
+        let g = Arc::new(FollowGraph::new());
+        let a = admin_state(Some("secret"), Some("postgres://x"));
+        let resp = handle_request(req("POST", "/admin/bulk-load", Some("nope")), g, a)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn admin_missing_header_returns_401() {
+        let g = Arc::new(FollowGraph::new());
+        let a = admin_state(Some("secret"), Some("postgres://x"));
+        let resp = handle_request(req("POST", "/admin/bulk-load", None), g, a)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn admin_get_returns_405() {
+        let g = Arc::new(FollowGraph::new());
+        let a = admin_state(Some("secret"), Some("postgres://x"));
+        let resp = handle_request(req("GET", "/admin/bulk-load", Some("secret")), g, a)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
+    async fn admin_no_database_url_returns_503() {
+        let g = Arc::new(FollowGraph::new());
+        let a = admin_state(Some("secret"), None);
+        let resp = handle_request(req("POST", "/admin/bulk-load", Some("secret")), g, a)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn admin_concurrent_load_returns_409() {
+        let g = Arc::new(FollowGraph::new());
+        let a = admin_state(Some("secret"), Some("postgres://x"));
+        // Simulate a load already in flight without firing the spawned task.
+        a.bulk_load_running.store(true, Ordering::SeqCst);
+        let resp = handle_request(
+            req("POST", "/admin/bulk-load", Some("secret")),
+            g,
+            Arc::clone(&a),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        // The flag is unchanged because the gate rejected the request.
+        assert!(a.bulk_load_running.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn admin_404_for_unknown_path() {
+        let g = Arc::new(FollowGraph::new());
+        let a = admin_state(Some("secret"), Some("postgres://x"));
+        let resp = handle_request(req("GET", "/nope", None), g, a)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn health_returns_200() {
+        let g = Arc::new(FollowGraph::new());
+        let a = admin_state(None, None);
+        let resp = handle_request(req("GET", "/_health", None), g, a)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn metrics_returns_200_text() {
+        let g = Arc::new(FollowGraph::new());
+        let a = admin_state(None, None);
+        let resp = handle_request(req("GET", "/metrics", None), g, a)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or("");
+        assert!(ct.starts_with("text/plain"));
+    }
+
+    #[tokio::test]
+    async fn follows_following_missing_params_returns_400() {
+        let g = Arc::new(FollowGraph::new());
+        let a = admin_state(None, None);
+        let resp = handle_request(req("GET", "/v1/follows-following", None), g, a)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn follows_following_returns_dids() {
+        let g = Arc::new(FollowGraph::new());
+        // Alice follows Bob; Bob follows Dan. Viewer=Alice, target=Dan -> [Bob].
+        g.add_follow("did:plc:alice", "did:plc:bob");
+        g.add_follow("did:plc:bob", "did:plc:dan");
+        let a = admin_state(None, None);
+        let resp = handle_request(
+            req(
+                "GET",
+                "/v1/follows-following?viewer=did:plc:alice&targets=did:plc:dan",
+                None,
+            ),
+            g,
+            a,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn is_following_returns_true_for_known_edge() {
+        let g = Arc::new(FollowGraph::new());
+        g.add_follow("did:plc:alice", "did:plc:bob");
+        let a = admin_state(None, None);
+        let resp = handle_request(
+            req(
+                "GET",
+                "/v1/is-following?actor=did:plc:alice&target=did:plc:bob",
+                None,
+            ),
+            g,
+            a,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn add_follow_is_idempotent_under_concurrent_writers() {
+        // This is the load-bearing assertion of the plan: a concurrent bulk-load
+        // and firehose writer producing the same edge must not double-count.
+        let g = Arc::new(FollowGraph::new());
+        let edges = [
+            ("did:plc:a1", "did:plc:b1"),
+            ("did:plc:a2", "did:plc:b2"),
+            ("did:plc:a3", "did:plc:b3"),
+        ];
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let g = Arc::clone(&g);
+            let edges = edges.to_vec();
+            handles.push(tokio::spawn(async move {
+                for (a, b) in edges {
+                    g.add_follow(a, b);
+                }
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
         }
 
-        "/v1/is-following" => {
-            let query = req.uri().query().unwrap_or("");
-            let params: Vec<(String, String)> = url::form_urlencoded::parse(query.as_bytes())
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect();
-
-            let actor = params
-                .iter()
-                .find(|(k, _)| k == "actor")
-                .map(|(_, v)| v.as_str())
-                .unwrap_or("");
-            let target = params
-                .iter()
-                .find(|(k, _)| k == "target")
-                .map(|(_, v)| v.as_str())
-                .unwrap_or("");
-
-            let following = graph.is_following(actor, target);
-            let body = serde_json::json!({ "following": following });
-
-            Ok(Response::builder()
-                .status(StatusCode::OK)
-                .header("Content-Type", "application/json")
-                .body(Full::new(Bytes::from(body.to_string())))
-                .unwrap())
+        // Each unique edge must land exactly once in the bitmap, regardless of
+        // how many writers added it. follow_count, however, is an AtomicU64
+        // counter incremented per call and is intentionally non-canonical
+        // for dedup purposes -- the bitmap is the source of truth.
+        for (actor, subject) in edges {
+            assert!(g.is_following(actor, subject));
         }
+    }
 
-        _ => Ok(Response::builder()
-            .status(StatusCode::NOT_FOUND)
-            .body(Full::new(Bytes::from("Not Found")))
-            .unwrap()),
+    #[test]
+    fn ct_eq_basic() {
+        assert!(ct_eq(b"abc", b"abc"));
+        assert!(!ct_eq(b"abc", b"abd"));
+        assert!(!ct_eq(b"ab", b"abc"));
+        assert!(ct_eq(b"", b""));
     }
 }

--- a/rsky-graph/src/api.rs
+++ b/rsky-graph/src/api.rs
@@ -1,5 +1,6 @@
 use crate::graph::FollowGraph;
 use crate::metrics;
+use crate::types::LoadState;
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::server::conn::http1;
@@ -33,6 +34,7 @@ pub async fn serve(
     port: u16,
     graph: Arc<FollowGraph>,
     admin: Arc<AdminState>,
+    load_state: Arc<LoadState>,
     shutdown: Arc<AtomicBool>,
 ) -> color_eyre::Result<()> {
     let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
@@ -59,11 +61,13 @@ pub async fn serve(
 
         let graph = Arc::clone(&graph);
         let admin = Arc::clone(&admin);
+        let load_state = Arc::clone(&load_state);
         tokio::spawn(async move {
             let service = service_fn(move |req: Request<hyper::body::Incoming>| {
                 let graph = Arc::clone(&graph);
                 let admin = Arc::clone(&admin);
-                async move { handle_request(req, graph, admin).await }
+                let load_state = Arc::clone(&load_state);
+                async move { handle_request(req, graph, admin, load_state).await }
             });
             if let Err(e) = http1::Builder::new()
                 .serve_connection(TokioIo::new(conn), service)
@@ -81,6 +85,7 @@ async fn handle_request<B>(
     req: Request<B>,
     graph: Arc<FollowGraph>,
     admin: Arc<AdminState>,
+    load_state: Arc<LoadState>,
 ) -> Result<Response<Full<Bytes>>, hyper::Error> {
     let path = req.uri().path();
 
@@ -96,11 +101,11 @@ async fn handle_request<B>(
                 .unwrap())
         }
 
-        "/v1/follows-following" => Ok(handle_follows_following(&req, &graph)),
+        "/v1/follows-following" => Ok(handle_follows_following(&req, &graph, &load_state)),
 
-        "/v1/is-following" => Ok(handle_is_following(&req, &graph)),
+        "/v1/is-following" => Ok(handle_is_following(&req, &graph, &load_state)),
 
-        "/admin/bulk-load" => Ok(handle_admin_bulk_load(&req, &graph, &admin)),
+        "/admin/bulk-load" => Ok(handle_admin_bulk_load(&req, &graph, &admin, &load_state)),
 
         _ => Ok(json_response(
             StatusCode::NOT_FOUND,
@@ -109,7 +114,11 @@ async fn handle_request<B>(
     }
 }
 
-fn handle_follows_following<B>(req: &Request<B>, graph: &FollowGraph) -> Response<Full<Bytes>> {
+fn handle_follows_following<B>(
+    req: &Request<B>,
+    graph: &FollowGraph,
+    load_state: &LoadState,
+) -> Response<Full<Bytes>> {
     let start = Instant::now();
     let query = req.uri().query().unwrap_or("");
     let params: Vec<(String, String)> = url::form_urlencoded::parse(query.as_bytes())
@@ -132,6 +141,15 @@ fn handle_follows_following<B>(req: &Request<B>, graph: &FollowGraph) -> Respons
         return json_response(
             StatusCode::BAD_REQUEST,
             r#"{"error":"viewer and targets required"}"#,
+        );
+    }
+
+    // 503 lets the appview fall back to its SQL self-JOIN; without this the
+    // graph would silently return empty mutuals for unloaded viewers.
+    if !load_state.creator_loaded(viewer) {
+        return json_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            r#"{"error":"viewer not yet loaded"}"#,
         );
     }
 
@@ -158,7 +176,11 @@ fn handle_follows_following<B>(req: &Request<B>, graph: &FollowGraph) -> Respons
         .unwrap()
 }
 
-fn handle_is_following<B>(req: &Request<B>, graph: &FollowGraph) -> Response<Full<Bytes>> {
+fn handle_is_following<B>(
+    req: &Request<B>,
+    graph: &FollowGraph,
+    load_state: &LoadState,
+) -> Response<Full<Bytes>> {
     let query = req.uri().query().unwrap_or("");
     let params: Vec<(String, String)> = url::form_urlencoded::parse(query.as_bytes())
         .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -175,6 +197,13 @@ fn handle_is_following<B>(req: &Request<B>, graph: &FollowGraph) -> Response<Ful
         .map(|(_, v)| v.as_str())
         .unwrap_or("");
 
+    if !actor.is_empty() && !load_state.creator_loaded(actor) {
+        return json_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            r#"{"error":"actor not yet loaded"}"#,
+        );
+    }
+
     let following = graph.is_following(actor, target);
     let body = serde_json::json!({ "following": following });
     json_response(StatusCode::OK, &body.to_string())
@@ -184,6 +213,7 @@ fn handle_admin_bulk_load<B>(
     req: &Request<B>,
     graph: &Arc<FollowGraph>,
     admin: &Arc<AdminState>,
+    load_state: &Arc<LoadState>,
 ) -> Response<Full<Bytes>> {
     if req.method() != Method::POST {
         return json_response(
@@ -226,15 +256,15 @@ fn handle_admin_bulk_load<B>(
 
     let graph = Arc::clone(graph);
     let admin = Arc::clone(admin);
+    let load_state = Arc::clone(load_state);
     tokio::spawn(async move {
         let _guard = BulkLoadGuard {
             admin: Arc::clone(&admin),
         };
         tracing::info!("admin: starting bulk-load via POST /admin/bulk-load");
-        match crate::bulk_load::bulk_load_keyset(&database_url, &graph).await {
+        match crate::bulk_load::bulk_load_keyset(&database_url, &graph, &load_state).await {
             Ok(()) => {
-                tracing::info!("admin: bulk-load complete; rebuilding bloom filters");
-                crate::bloom::build_all_bloom_filters(&graph);
+                tracing::info!("admin: bulk-load complete");
             }
             Err(e) => {
                 tracing::error!("admin bulk-load failed: {e}");
@@ -294,13 +324,24 @@ mod tests {
         ))
     }
 
+    fn loaded_state() -> Arc<LoadState> {
+        let s = LoadState::new();
+        s.mark_complete();
+        Arc::new(s)
+    }
+
     #[tokio::test]
     async fn admin_disabled_returns_401() {
         let g = Arc::new(FollowGraph::new());
         let a = admin_state(None, Some("postgres://x"));
-        let resp = handle_request(req("POST", "/admin/bulk-load", Some("anything")), g, a)
-            .await
-            .unwrap();
+        let resp = handle_request(
+            req("POST", "/admin/bulk-load", Some("anything")),
+            g,
+            a,
+            loaded_state(),
+        )
+        .await
+        .unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
@@ -308,9 +349,14 @@ mod tests {
     async fn admin_wrong_token_returns_401() {
         let g = Arc::new(FollowGraph::new());
         let a = admin_state(Some("secret"), Some("postgres://x"));
-        let resp = handle_request(req("POST", "/admin/bulk-load", Some("nope")), g, a)
-            .await
-            .unwrap();
+        let resp = handle_request(
+            req("POST", "/admin/bulk-load", Some("nope")),
+            g,
+            a,
+            loaded_state(),
+        )
+        .await
+        .unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
@@ -318,7 +364,7 @@ mod tests {
     async fn admin_missing_header_returns_401() {
         let g = Arc::new(FollowGraph::new());
         let a = admin_state(Some("secret"), Some("postgres://x"));
-        let resp = handle_request(req("POST", "/admin/bulk-load", None), g, a)
+        let resp = handle_request(req("POST", "/admin/bulk-load", None), g, a, loaded_state())
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
@@ -328,9 +374,14 @@ mod tests {
     async fn admin_get_returns_405() {
         let g = Arc::new(FollowGraph::new());
         let a = admin_state(Some("secret"), Some("postgres://x"));
-        let resp = handle_request(req("GET", "/admin/bulk-load", Some("secret")), g, a)
-            .await
-            .unwrap();
+        let resp = handle_request(
+            req("GET", "/admin/bulk-load", Some("secret")),
+            g,
+            a,
+            loaded_state(),
+        )
+        .await
+        .unwrap();
         assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
     }
 
@@ -338,9 +389,14 @@ mod tests {
     async fn admin_no_database_url_returns_503() {
         let g = Arc::new(FollowGraph::new());
         let a = admin_state(Some("secret"), None);
-        let resp = handle_request(req("POST", "/admin/bulk-load", Some("secret")), g, a)
-            .await
-            .unwrap();
+        let resp = handle_request(
+            req("POST", "/admin/bulk-load", Some("secret")),
+            g,
+            a,
+            loaded_state(),
+        )
+        .await
+        .unwrap();
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
@@ -354,6 +410,7 @@ mod tests {
             req("POST", "/admin/bulk-load", Some("secret")),
             g,
             Arc::clone(&a),
+            loaded_state(),
         )
         .await
         .unwrap();
@@ -366,7 +423,7 @@ mod tests {
     async fn admin_404_for_unknown_path() {
         let g = Arc::new(FollowGraph::new());
         let a = admin_state(Some("secret"), Some("postgres://x"));
-        let resp = handle_request(req("GET", "/nope", None), g, a)
+        let resp = handle_request(req("GET", "/nope", None), g, a, loaded_state())
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -376,7 +433,7 @@ mod tests {
     async fn health_returns_200() {
         let g = Arc::new(FollowGraph::new());
         let a = admin_state(None, None);
-        let resp = handle_request(req("GET", "/_health", None), g, a)
+        let resp = handle_request(req("GET", "/_health", None), g, a, loaded_state())
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
@@ -386,7 +443,7 @@ mod tests {
     async fn metrics_returns_200_text() {
         let g = Arc::new(FollowGraph::new());
         let a = admin_state(None, None);
-        let resp = handle_request(req("GET", "/metrics", None), g, a)
+        let resp = handle_request(req("GET", "/metrics", None), g, a, loaded_state())
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
@@ -402,9 +459,14 @@ mod tests {
     async fn follows_following_missing_params_returns_400() {
         let g = Arc::new(FollowGraph::new());
         let a = admin_state(None, None);
-        let resp = handle_request(req("GET", "/v1/follows-following", None), g, a)
-            .await
-            .unwrap();
+        let resp = handle_request(
+            req("GET", "/v1/follows-following", None),
+            g,
+            a,
+            loaded_state(),
+        )
+        .await
+        .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
@@ -423,6 +485,7 @@ mod tests {
             ),
             g,
             a,
+            loaded_state(),
         )
         .await
         .unwrap();
@@ -442,10 +505,78 @@ mod tests {
             ),
             g,
             a,
+            loaded_state(),
         )
         .await
         .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn is_following_returns_503_when_actor_not_loaded() {
+        let g = Arc::new(FollowGraph::new());
+        g.add_follow("did:plc:alice", "did:plc:bob");
+        let a = admin_state(None, None);
+        // LoadState is NOT marked complete; no creators recorded -> 503.
+        let s = Arc::new(LoadState::new());
+        let resp = handle_request(
+            req(
+                "GET",
+                "/v1/is-following?actor=did:plc:alice&target=did:plc:bob",
+                None,
+            ),
+            g,
+            a,
+            s,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn is_following_serves_actor_below_progress_cursor() {
+        let g = Arc::new(FollowGraph::new());
+        g.add_follow("did:plc:alice", "did:plc:bob");
+        let a = admin_state(None, None);
+        let s = Arc::new(LoadState::new());
+        s.record_creator_completed("did:plc:zzz"); // alice < zzz, so alice is loaded
+        let resp = handle_request(
+            req(
+                "GET",
+                "/v1/is-following?actor=did:plc:alice&target=did:plc:bob",
+                None,
+            ),
+            g,
+            a,
+            s,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn follows_following_returns_503_when_viewer_not_loaded() {
+        let g = Arc::new(FollowGraph::new());
+        g.add_follow("did:plc:alice", "did:plc:bob");
+        g.add_follow("did:plc:bob", "did:plc:dan");
+        let a = admin_state(None, None);
+        let s = Arc::new(LoadState::new());
+        // viewer=alice not loaded -> 503 so appview falls back to SQL.
+        let resp = handle_request(
+            req(
+                "GET",
+                "/v1/follows-following?viewer=did:plc:alice&targets=did:plc:dan",
+                None,
+            ),
+            g,
+            a,
+            s,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]

--- a/rsky-graph/src/bloom.rs
+++ b/rsky-graph/src/bloom.rs
@@ -1,0 +1,35 @@
+use crate::graph::FollowGraph;
+use bloomfilter::Bloom;
+
+/// Create a new bloom filter sized for the expected number of items.
+/// Uses 10 bits per element for ~1% false positive rate.
+pub fn new_bloom_filter(expected_items: usize) -> Bloom<u32> {
+    let items = expected_items.max(10);
+    let bits = items * 10;
+    let hashes = 7; // optimal for 10 bits/element
+    Bloom::new(bits, hashes)
+}
+
+/// Rebuild all bloom filters from the current follower bitmaps.
+/// Called after bulk load and periodically to correct for removals
+/// (bloom filters don't support deletion).
+pub fn build_all_bloom_filters(graph: &FollowGraph) {
+    let mut rebuilt = 0u64;
+    for entry in graph.followers.iter() {
+        let uid = *entry.key();
+        let followers_bm = entry.value();
+        let count = followers_bm.len() as usize;
+
+        if count == 0 {
+            continue;
+        }
+
+        let mut bloom = new_bloom_filter(count);
+        for follower_uid in followers_bm.iter() {
+            bloom.set(&follower_uid);
+        }
+        graph.follower_blooms.insert(uid, bloom);
+        rebuilt += 1;
+    }
+    tracing::info!("rebuilt bloom filters for {rebuilt} users");
+}

--- a/rsky-graph/src/bulk_load.rs
+++ b/rsky-graph/src/bulk_load.rs
@@ -201,17 +201,16 @@ pub async fn bulk_load_keyset(database_url: &str, graph: &FollowGraph) -> Result
 
     let mut total: u64 = 0;
     let start = std::time::Instant::now();
-    let mut last_creator = String::new();
-    let mut last_subject = String::new();
+    let (mut last_creator, mut last_subject) = find_resume_point(graph);
+    if !last_creator.is_empty() {
+        tracing::info!(
+            "resuming bulk load from (creator, subject) > ({}, {})",
+            last_creator,
+            last_subject
+        );
+    }
 
-    let initial_stmt = client
-        .prepare(
-            "SELECT creator, \"subjectDid\" FROM follow \
-             ORDER BY creator, \"subjectDid\" LIMIT $1::bigint",
-        )
-        .await
-        .map_err(|e| GraphError::Other(format!("prepare initial failed: {e}")))?;
-
+    // Single keyset statement; an empty (last_creator, last_subject) lex-precedes every real DID.
     let page_stmt = client
         .prepare(
             "SELECT creator, \"subjectDid\" FROM follow \
@@ -222,17 +221,10 @@ pub async fn bulk_load_keyset(database_url: &str, graph: &FollowGraph) -> Result
         .map_err(|e| GraphError::Other(format!("prepare page failed: {e}")))?;
 
     loop {
-        let rows = if total == 0 {
-            client
-                .query(&initial_stmt, &[&batch_size])
-                .await
-                .map_err(|e| GraphError::Other(format!("initial query failed: {e}")))?
-        } else {
-            client
-                .query(&page_stmt, &[&last_creator, &last_subject, &batch_size])
-                .await
-                .map_err(|e| GraphError::Other(format!("page query failed: {e}")))?
-        };
+        let rows = client
+            .query(&page_stmt, &[&last_creator, &last_subject, &batch_size])
+            .await
+            .map_err(|e| GraphError::Other(format!("page query failed: {e}")))?;
 
         if rows.is_empty() {
             break;
@@ -259,4 +251,70 @@ pub async fn bulk_load_keyset(database_url: &str, graph: &FollowGraph) -> Result
 
     finalize(total, start, graph);
     Ok(())
+}
+
+/// Pick a `(creator, subjectDid)` boundary the keyset can resume from.
+fn find_resume_point(graph: &FollowGraph) -> (String, String) {
+    let max_creator: Option<String> = graph
+        .following
+        .iter()
+        .filter(|e| !e.value().is_empty())
+        .filter_map(|e| graph.get_did(*e.key()))
+        .max();
+
+    let Some(creator) = max_creator else {
+        return (String::new(), String::new());
+    };
+
+    let max_subject = graph
+        .get_uid(&creator)
+        .and_then(|uid| graph.following.get(&uid).map(|bm| bm.value().clone()))
+        .and_then(|bm| bm.iter().filter_map(|uid| graph.get_did(uid)).max())
+        .unwrap_or_default();
+
+    (creator, max_subject)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resume_point_empty_graph_returns_empty() {
+        let graph = FollowGraph::new();
+        let (c, s) = find_resume_point(&graph);
+        assert!(c.is_empty() && s.is_empty());
+    }
+
+    #[test]
+    fn resume_point_picks_max_creator_with_following() {
+        let graph = FollowGraph::new();
+        graph.add_follow("did:plc:aaa", "did:plc:zzz");
+        graph.add_follow("did:plc:bbb", "did:plc:yyy");
+        graph.add_follow("did:plc:ccc", "did:plc:xxx");
+        let (c, s) = find_resume_point(&graph);
+        assert_eq!(c, "did:plc:ccc");
+        assert_eq!(s, "did:plc:xxx");
+    }
+
+    #[test]
+    fn resume_point_within_creator_picks_max_subject() {
+        let graph = FollowGraph::new();
+        graph.add_follow("did:plc:zzz", "did:plc:aaa");
+        graph.add_follow("did:plc:zzz", "did:plc:mmm");
+        graph.add_follow("did:plc:zzz", "did:plc:nnn");
+        let (c, s) = find_resume_point(&graph);
+        assert_eq!(c, "did:plc:zzz");
+        assert_eq!(s, "did:plc:nnn");
+    }
+
+    #[test]
+    fn resume_point_ignores_subject_only_dids() {
+        // did:plc:zzz appears only as a subject; its `following` is empty.
+        let graph = FollowGraph::new();
+        graph.add_follow("did:plc:aaa", "did:plc:zzz");
+        let (c, s) = find_resume_point(&graph);
+        assert_eq!(c, "did:plc:aaa");
+        assert_eq!(s, "did:plc:zzz");
+    }
 }

--- a/rsky-graph/src/bulk_load.rs
+++ b/rsky-graph/src/bulk_load.rs
@@ -1,0 +1,262 @@
+use crate::graph::FollowGraph;
+use crate::types::GraphError;
+use deadpool_postgres::{Config, ManagerConfig, RecyclingMethod, Runtime};
+use std::path::Path;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio_postgres::NoTls;
+
+const PROGRESS_EVERY: u64 = 1_000_000;
+
+fn report_progress(total: u64, start: std::time::Instant, graph: &FollowGraph) {
+    let elapsed = start.elapsed().as_secs();
+    let rate = if elapsed > 0 { total / elapsed } else { 0 };
+    tracing::info!(
+        "bulk load: {} follows loaded ({} follows/sec), {} users",
+        total,
+        rate,
+        graph.user_count()
+    );
+    crate::metrics::GRAPH_USERS_TOTAL.set(graph.user_count() as i64);
+    crate::metrics::GRAPH_FOLLOWS_TOTAL.set(total as i64);
+}
+
+fn finalize(total: u64, start: std::time::Instant, graph: &FollowGraph) {
+    let elapsed = start.elapsed();
+    tracing::info!(
+        "bulk load complete: {} follows in {:.1}s ({} follows/sec)",
+        total,
+        elapsed.as_secs_f64(),
+        total / elapsed.as_secs().max(1)
+    );
+    crate::metrics::GRAPH_USERS_TOTAL.set(graph.user_count() as i64);
+    crate::metrics::GRAPH_FOLLOWS_TOTAL.set(total as i64);
+}
+
+/// Load follows from a CSV file produced by `\copy` from PostgreSQL.
+///
+/// This is the preferred load path. It performs zero PostgreSQL work at load time —
+/// the CSV is built once via `\copy` (a short-lived read snapshot, no row locks) and
+/// can then be consumed at full local-disk speed without any further DB pressure.
+///
+/// Supports two CSV shapes (no header, comma-separated):
+/// - **2 columns**: `creator,subjectDid`
+/// - **3 columns**: `creator,rkey,subjectDid` — recommended, lets firehose
+///   delete events resolve the subject to remove.
+pub async fn bulk_load_from_file(path: &Path, graph: &FollowGraph) -> Result<(), GraphError> {
+    tracing::info!("bulk-loading follows from file: {}", path.display());
+
+    let file = tokio::fs::File::open(path)
+        .await
+        .map_err(|e| GraphError::Other(format!("open {} failed: {e}", path.display())))?;
+
+    let reader = BufReader::new(file);
+    let mut lines = reader.lines();
+
+    let mut total: u64 = 0;
+    let mut with_rkey: u64 = 0;
+    let start = std::time::Instant::now();
+
+    while let Some(line) = lines
+        .next_line()
+        .await
+        .map_err(|e| GraphError::Other(format!("csv read failed: {e}")))?
+    {
+        if line.is_empty() {
+            continue;
+        }
+        match parse_csv_line(&line) {
+            Some(CsvFollow::TwoCol { creator, subject }) => {
+                graph.add_follow(creator, subject);
+            }
+            Some(CsvFollow::ThreeCol {
+                creator,
+                rkey,
+                subject,
+            }) => {
+                graph.add_follow_with_rkey(creator, rkey, subject);
+                with_rkey += 1;
+            }
+            None => {
+                tracing::warn!("skipping malformed CSV line: {line}");
+                continue;
+            }
+        }
+        total += 1;
+        if total % PROGRESS_EVERY == 0 {
+            report_progress(total, start, graph);
+        }
+    }
+
+    if with_rkey > 0 {
+        tracing::info!("indexed {with_rkey} follows by rkey for delete resolution");
+    } else {
+        tracing::warn!(
+            "CSV had no rkey column -- pre-snapshot follows will not be deletable via firehose \
+             until the next snapshot rebuild"
+        );
+    }
+
+    finalize(total, start, graph);
+    Ok(())
+}
+
+enum CsvFollow<'a> {
+    TwoCol {
+        creator: &'a str,
+        subject: &'a str,
+    },
+    ThreeCol {
+        creator: &'a str,
+        rkey: &'a str,
+        subject: &'a str,
+    },
+}
+
+fn parse_csv_line(line: &str) -> Option<CsvFollow<'_>> {
+    // DIDs and rkeys we care about never contain commas or quotes, so a fast
+    // split is correct. Strip surrounding quotes defensively.
+    let mut parts = line.split(',');
+    let a = strip_csv_quotes(parts.next()?);
+    let b = strip_csv_quotes(parts.next()?);
+    match parts.next() {
+        Some(c) => {
+            let c = strip_csv_quotes(c);
+            if parts.next().is_some() {
+                return None;
+            }
+            Some(CsvFollow::ThreeCol {
+                creator: a,
+                rkey: b,
+                subject: c,
+            })
+        }
+        None => Some(CsvFollow::TwoCol {
+            creator: a,
+            subject: b,
+        }),
+    }
+}
+
+fn strip_csv_quotes(s: &str) -> &str {
+    let s = s.trim();
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+/// Load follows from PostgreSQL using **keyset pagination with short transactions**.
+///
+/// This replaces the prior `DECLARE CURSOR ... FETCH` approach which held a single
+/// long-running transaction across the entire 3.4 B-row table — that snapshot
+/// blocked `VACUUM` and stressed IO unboundedly, hurting the live appview.
+///
+/// Each iteration runs an autonomous short query bounded by `LIMIT batch_size`,
+/// keyset-paged on `(creator, "subjectDid")`. Between batches we sleep
+/// `throttle_ms` to cap IO. Either may be tuned via env vars.
+pub async fn bulk_load_keyset(database_url: &str, graph: &FollowGraph) -> Result<(), GraphError> {
+    let batch_size: i64 = std::env::var("GRAPH_LOAD_BATCH_SIZE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(50_000);
+    let throttle_ms: u64 = std::env::var("GRAPH_LOAD_THROTTLE_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(50);
+
+    tracing::info!(
+        "starting keyset bulk load (batch_size={}, throttle_ms={})",
+        batch_size,
+        throttle_ms
+    );
+
+    let mut pg_config = Config::new();
+    pg_config.url = Some(database_url.to_owned());
+    pg_config.manager = Some(ManagerConfig {
+        recycling_method: RecyclingMethod::Fast,
+    });
+    pg_config.pool = Some(deadpool_postgres::PoolConfig::new(2));
+
+    let pool = pg_config
+        .create_pool(Some(Runtime::Tokio1), NoTls)
+        .map_err(|e| GraphError::Other(format!("pool creation failed: {e}")))?;
+
+    let client = pool
+        .get()
+        .await
+        .map_err(|e| GraphError::Other(format!("pool get failed: {e}")))?;
+
+    client
+        .execute("SET search_path TO bsky", &[])
+        .await
+        .map_err(|e| GraphError::Other(format!("set search_path failed: {e}")))?;
+    // Generous per-statement cap, but each query reads at most batch_size rows
+    // and finishes well within this. Prevents a single bad batch from running away.
+    client
+        .execute("SET statement_timeout = '60s'", &[])
+        .await
+        .map_err(|e| GraphError::Other(format!("set timeout failed: {e}")))?;
+
+    let mut total: u64 = 0;
+    let start = std::time::Instant::now();
+    let mut last_creator = String::new();
+    let mut last_subject = String::new();
+
+    let initial_stmt = client
+        .prepare(
+            "SELECT creator, \"subjectDid\" FROM follow \
+             ORDER BY creator, \"subjectDid\" LIMIT $1::bigint",
+        )
+        .await
+        .map_err(|e| GraphError::Other(format!("prepare initial failed: {e}")))?;
+
+    let page_stmt = client
+        .prepare(
+            "SELECT creator, \"subjectDid\" FROM follow \
+             WHERE (creator, \"subjectDid\") > ($1, $2) \
+             ORDER BY creator, \"subjectDid\" LIMIT $3::bigint",
+        )
+        .await
+        .map_err(|e| GraphError::Other(format!("prepare page failed: {e}")))?;
+
+    loop {
+        let rows = if total == 0 {
+            client
+                .query(&initial_stmt, &[&batch_size])
+                .await
+                .map_err(|e| GraphError::Other(format!("initial query failed: {e}")))?
+        } else {
+            client
+                .query(&page_stmt, &[&last_creator, &last_subject, &batch_size])
+                .await
+                .map_err(|e| GraphError::Other(format!("page query failed: {e}")))?
+        };
+
+        if rows.is_empty() {
+            break;
+        }
+
+        for row in &rows {
+            let creator: String = row.get(0);
+            let subject: String = row.get(1);
+            graph.add_follow(&creator, &subject);
+            last_creator = creator;
+            last_subject = subject;
+        }
+
+        total += rows.len() as u64;
+
+        if total % PROGRESS_EVERY == 0 {
+            report_progress(total, start, graph);
+        }
+
+        if throttle_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(throttle_ms)).await;
+        }
+    }
+
+    finalize(total, start, graph);
+    Ok(())
+}

--- a/rsky-graph/src/bulk_load.rs
+++ b/rsky-graph/src/bulk_load.rs
@@ -192,10 +192,10 @@ pub async fn bulk_load_keyset(database_url: &str, graph: &FollowGraph) -> Result
         .execute("SET search_path TO bsky", &[])
         .await
         .map_err(|e| GraphError::Other(format!("set search_path failed: {e}")))?;
-    // Generous per-statement cap, but each query reads at most batch_size rows
-    // and finishes well within this. Prevents a single bad batch from running away.
+    // Per-statement cap. Larger than the historical 60s after observing that
+    // 60s tripped under appview PG load and crashed the entire load.
     client
-        .execute("SET statement_timeout = '60s'", &[])
+        .execute("SET statement_timeout = '300s'", &[])
         .await
         .map_err(|e| GraphError::Other(format!("set timeout failed: {e}")))?;
 
@@ -221,10 +221,30 @@ pub async fn bulk_load_keyset(database_url: &str, graph: &FollowGraph) -> Result
         .map_err(|e| GraphError::Other(format!("prepare page failed: {e}")))?;
 
     loop {
-        let rows = client
-            .query(&page_stmt, &[&last_creator, &last_subject, &batch_size])
-            .await
-            .map_err(|e| GraphError::Other(format!("page query failed: {e}")))?;
+        // Retry transient PG errors (timeouts, connection blips) with backoff.
+        let mut attempt = 0u32;
+        let rows = loop {
+            attempt += 1;
+            match client
+                .query(&page_stmt, &[&last_creator, &last_subject, &batch_size])
+                .await
+            {
+                Ok(r) => break r,
+                Err(e) if attempt < 5 => {
+                    let backoff = Duration::from_secs(10u64 * u64::from(attempt));
+                    tracing::warn!(
+                        "page query failed (attempt {attempt}/5, retrying in {:?}): {e}",
+                        backoff
+                    );
+                    tokio::time::sleep(backoff).await;
+                }
+                Err(e) => {
+                    return Err(GraphError::Other(format!(
+                        "page query failed after {attempt} attempts: {e}"
+                    )));
+                }
+            }
+        };
 
         if rows.is_empty() {
             break;

--- a/rsky-graph/src/bulk_load.rs
+++ b/rsky-graph/src/bulk_load.rs
@@ -1,5 +1,5 @@
 use crate::graph::FollowGraph;
-use crate::types::GraphError;
+use crate::types::{GraphError, LoadState};
 use deadpool_postgres::{Config, ManagerConfig, RecyclingMethod, Runtime};
 use std::path::Path;
 use std::time::Duration;
@@ -156,7 +156,11 @@ fn strip_csv_quotes(s: &str) -> &str {
 /// Each iteration runs an autonomous short query bounded by `LIMIT batch_size`,
 /// keyset-paged on `(creator, "subjectDid")`. Between batches we sleep
 /// `throttle_ms` to cap IO. Either may be tuned via env vars.
-pub async fn bulk_load_keyset(database_url: &str, graph: &FollowGraph) -> Result<(), GraphError> {
+pub async fn bulk_load_keyset(
+    database_url: &str,
+    graph: &FollowGraph,
+    load_state: &LoadState,
+) -> Result<(), GraphError> {
     let batch_size: i64 = std::env::var("GRAPH_LOAD_BATCH_SIZE")
         .ok()
         .and_then(|v| v.parse().ok())
@@ -253,6 +257,11 @@ pub async fn bulk_load_keyset(database_url: &str, graph: &FollowGraph) -> Result
         for row in &rows {
             let creator: String = row.get(0);
             let subject: String = row.get(1);
+            // When the keyset transitions creators, the previous one's full
+            // follow set is now in the graph -- mark it loaded for the API.
+            if !last_creator.is_empty() && creator != last_creator {
+                load_state.record_creator_completed(&last_creator);
+            }
             graph.add_follow(&creator, &subject);
             last_creator = creator;
             last_subject = subject;
@@ -269,6 +278,11 @@ pub async fn bulk_load_keyset(database_url: &str, graph: &FollowGraph) -> Result
         }
     }
 
+    // Last creator was completed by exhausting the keyset.
+    if !last_creator.is_empty() {
+        load_state.record_creator_completed(&last_creator);
+    }
+    load_state.mark_complete();
     finalize(total, start, graph);
     Ok(())
 }

--- a/rsky-graph/src/firehose.rs
+++ b/rsky-graph/src/firehose.rs
@@ -1,0 +1,134 @@
+use crate::graph::FollowGraph;
+use futures::StreamExt;
+use rsky_firehose::car;
+use rsky_firehose::firehose;
+use rsky_lexicon::app::bsky::graph::follow::Follow;
+use rsky_lexicon::com::atproto::sync::SubscribeRepos;
+use std::io::Cursor;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+use tokio_tungstenite::tungstenite::Message;
+
+const FOLLOW_COLLECTION: &str = "app.bsky.graph.follow";
+
+pub async fn tail_firehose(relay_host: &str, graph: &FollowGraph, shutdown: &AtomicBool) {
+    let mut backoff_ms = 1000u64;
+
+    loop {
+        if shutdown.load(Ordering::Relaxed) {
+            tracing::info!("firehose: shutdown requested");
+            return;
+        }
+
+        let url = format!("{relay_host}/xrpc/com.atproto.sync.subscribeRepos");
+        tracing::info!("firehose: connecting to {url}");
+
+        match tokio_tungstenite::connect_async(&url).await {
+            Ok((ws_stream, _)) => {
+                backoff_ms = 1000;
+                tracing::info!("firehose: connected");
+                let (_, mut read) = ws_stream.split();
+
+                loop {
+                    if shutdown.load(Ordering::Relaxed) {
+                        return;
+                    }
+
+                    let msg = tokio::select! {
+                        msg = read.next() => {
+                            match msg {
+                                Some(Ok(m)) => m,
+                                Some(Err(e)) => {
+                                    tracing::warn!("firehose: read error: {e}");
+                                    break;
+                                }
+                                None => break,
+                            }
+                        }
+                        () = tokio::time::sleep(Duration::from_millis(100)) => continue,
+                    };
+
+                    if let Message::Binary(data) = msg {
+                        process_message(&data, graph);
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!("firehose: connect error: {e}");
+            }
+        }
+
+        if shutdown.load(Ordering::Relaxed) {
+            return;
+        }
+
+        tracing::warn!("firehose: reconnecting in {backoff_ms}ms");
+        tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+        backoff_ms = (backoff_ms * 2).min(60_000);
+    }
+}
+
+fn process_message(data: &[u8], graph: &FollowGraph) {
+    // Use the shared rsky-firehose frame parser -- same path as rsky-firehose
+    // and rsky-wintermute. Anything other than a #commit is irrelevant here.
+    let Ok(Some((_, SubscribeRepos::Commit(commit)))) = firehose::read(data) else {
+        return;
+    };
+
+    if commit.too_big || commit.ops.is_empty() {
+        return;
+    }
+
+    // Parse the embedded CAR once per commit so multiple follow ops in the
+    // same commit share the work.
+    let mut block_map: Option<std::collections::HashMap<lexicon_cid::Cid, Vec<u8>>> = None;
+    let load_blocks = || -> Option<std::collections::HashMap<lexicon_cid::Cid, Vec<u8>>> {
+        let mut reader = Cursor::new(&commit.blocks);
+        car::read_header(&mut reader).ok()?;
+        car::read_blocks(&mut reader).ok()
+    };
+
+    for op in &commit.ops {
+        let Some((collection, rkey)) = op.path.split_once('/') else {
+            continue;
+        };
+        if collection != FOLLOW_COLLECTION {
+            continue;
+        }
+
+        match op.action.as_str() {
+            "create" => {
+                let Some(cid) = op.cid.as_ref() else { continue };
+                if block_map.is_none() {
+                    block_map = load_blocks();
+                }
+                let Some(blocks) = block_map.as_ref() else {
+                    continue;
+                };
+                let Some(record_bytes) = blocks.get(cid) else {
+                    continue;
+                };
+                match serde_cbor::from_reader::<Follow, _>(Cursor::new(record_bytes)) {
+                    Ok(follow) => {
+                        graph.add_follow_with_rkey(&commit.repo, rkey, &follow.subject);
+                        crate::metrics::GRAPH_FIREHOSE_EVENTS.inc();
+                    }
+                    Err(e) => {
+                        tracing::debug!(
+                            "firehose: failed to decode follow record at {}/{rkey}: {e}",
+                            commit.repo,
+                        );
+                    }
+                }
+            }
+            "delete" => {
+                if graph.remove_follow_by_rkey(&commit.repo, rkey) {
+                    crate::metrics::GRAPH_FIREHOSE_EVENTS.inc();
+                }
+                // If the rkey is unknown (follow predates the rkey index), the
+                // bitmap entry stays until the next snapshot rebuild.
+            }
+            _ => {}
+        }
+    }
+}

--- a/rsky-graph/src/firehose.rs
+++ b/rsky-graph/src/firehose.rs
@@ -20,7 +20,11 @@ pub async fn tail_firehose(relay_host: &str, graph: &FollowGraph, shutdown: &Ato
             return;
         }
 
-        let url = format!("{relay_host}/xrpc/com.atproto.sync.subscribeRepos");
+        // rsky-relay's subscribeRepos only sends events when the connection has
+        // a cursor set; without `?cursor=`, the relay assigns `seq+1` and the
+        // poll-loop range `[seq+1..seq]` is empty so no events are forwarded.
+        // Always pass an explicit cursor; 0 means "from the beginning".
+        let url = format!("{relay_host}/xrpc/com.atproto.sync.subscribeRepos?cursor=0");
         tracing::info!("firehose: connecting to {url}");
 
         match tokio_tungstenite::connect_async(&url).await {

--- a/rsky-graph/src/firehose.rs
+++ b/rsky-graph/src/firehose.rs
@@ -69,11 +69,26 @@ pub async fn tail_firehose(relay_host: &str, graph: &FollowGraph, shutdown: &Ato
 }
 
 fn process_message(data: &[u8], graph: &FollowGraph) {
+    crate::metrics::GRAPH_FIREHOSE_FRAMES.inc();
     // Use the shared rsky-firehose frame parser -- same path as rsky-firehose
     // and rsky-wintermute. Anything other than a #commit is irrelevant here.
-    let Ok(Some((_, SubscribeRepos::Commit(commit)))) = firehose::read(data) else {
-        return;
+    let commit = match firehose::read(data) {
+        Ok(Some((_, SubscribeRepos::Commit(c)))) => c,
+        Ok(Some(_)) => {
+            // Non-commit frame (#identity, #account, #handle, #tombstone, ...)
+            return;
+        }
+        Ok(None) => {
+            // #info, #sync, or #error -- silently skip
+            return;
+        }
+        Err(e) => {
+            crate::metrics::GRAPH_FIREHOSE_DECODE_ERRORS.inc();
+            tracing::debug!("firehose: frame decode failed: {e}");
+            return;
+        }
     };
+    crate::metrics::GRAPH_FIREHOSE_COMMITS.inc();
 
     if commit.too_big || commit.ops.is_empty() {
         return;

--- a/rsky-graph/src/graph.rs
+++ b/rsky-graph/src/graph.rs
@@ -66,6 +66,9 @@ impl FollowGraph {
 
     /// Add a follow relationship: actor follows subject.
     pub fn add_follow(&self, actor_did: &str, subject_did: &str) {
+        if actor_did.is_empty() || subject_did.is_empty() {
+            return;
+        }
         let actor_uid = self.get_or_assign_uid(actor_did);
         let subject_uid = self.get_or_assign_uid(subject_did);
 
@@ -93,6 +96,9 @@ impl FollowGraph {
     /// Add a follow relationship and remember the rkey so a later firehose
     /// delete event (which carries only the rkey) can resolve back to the subject.
     pub fn add_follow_with_rkey(&self, actor_did: &str, rkey: &str, subject_did: &str) {
+        if actor_did.is_empty() || subject_did.is_empty() || rkey.is_empty() {
+            return;
+        }
         self.add_follow(actor_did, subject_did);
         let actor_uid = self.get_or_assign_uid(actor_did);
         let subject_uid = self.get_or_assign_uid(subject_did);

--- a/rsky-graph/src/graph.rs
+++ b/rsky-graph/src/graph.rs
@@ -1,0 +1,218 @@
+use dashmap::DashMap;
+use roaring::RoaringBitmap;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+use crate::bloom;
+
+pub struct FollowGraph {
+    // DID <-> UID bidirectional mapping
+    pub did_to_uid: DashMap<String, u32>,
+    pub uid_to_did: DashMap<u32, String>,
+    next_uid: AtomicU32,
+
+    // Per-user bitmaps
+    pub followers: DashMap<u32, RoaringBitmap>,
+    pub following: DashMap<u32, RoaringBitmap>,
+
+    // Per-user bloom filter of followers for fast rejection
+    pub follower_blooms: DashMap<u32, bloomfilter::Bloom<u32>>,
+
+    // (actor_uid, rkey) -> subject_uid. The firehose delete event for a follow
+    // record carries only the rkey, not the subject DID, so to remove a follow
+    // we must remember which subject the rkey pointed at when it was created.
+    // Populated by add_follow_with_rkey on firehose creates and (optionally) by
+    // a 3-column bulk-load CSV. Not persisted -- we accept that pre-snapshot
+    // follows are not reversible until the next snapshot rebuild.
+    pub follow_rkeys: DashMap<(u32, String), u32>,
+
+    // Stats
+    follow_count: AtomicU64,
+}
+
+impl FollowGraph {
+    pub fn new() -> Self {
+        Self {
+            did_to_uid: DashMap::new(),
+            uid_to_did: DashMap::new(),
+            next_uid: AtomicU32::new(1),
+            followers: DashMap::new(),
+            following: DashMap::new(),
+            follower_blooms: DashMap::new(),
+            follow_rkeys: DashMap::new(),
+            follow_count: AtomicU64::new(0),
+        }
+    }
+
+    /// Get or assign a UID for a DID.
+    pub fn get_or_assign_uid(&self, did: &str) -> u32 {
+        if let Some(uid) = self.did_to_uid.get(did) {
+            return *uid;
+        }
+        let uid = self.next_uid.fetch_add(1, Ordering::Relaxed);
+        self.did_to_uid.insert(did.to_owned(), uid);
+        self.uid_to_did.insert(uid, did.to_owned());
+        uid
+    }
+
+    /// Get UID for a DID without assigning.
+    pub fn get_uid(&self, did: &str) -> Option<u32> {
+        self.did_to_uid.get(did).map(|v| *v)
+    }
+
+    /// Get DID for a UID.
+    pub fn get_did(&self, uid: u32) -> Option<String> {
+        self.uid_to_did.get(&uid).map(|v| v.clone())
+    }
+
+    /// Add a follow relationship: actor follows subject.
+    pub fn add_follow(&self, actor_did: &str, subject_did: &str) {
+        let actor_uid = self.get_or_assign_uid(actor_did);
+        let subject_uid = self.get_or_assign_uid(subject_did);
+
+        // Update following bitmap for actor
+        self.following
+            .entry(actor_uid)
+            .or_insert_with(RoaringBitmap::new)
+            .insert(subject_uid);
+
+        // Update followers bitmap for subject
+        self.followers
+            .entry(subject_uid)
+            .or_insert_with(RoaringBitmap::new)
+            .insert(actor_uid);
+
+        // Update bloom filter for subject's followers
+        self.follower_blooms
+            .entry(subject_uid)
+            .or_insert_with(|| bloom::new_bloom_filter(100))
+            .set(&actor_uid);
+
+        self.follow_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Add a follow relationship and remember the rkey so a later firehose
+    /// delete event (which carries only the rkey) can resolve back to the subject.
+    pub fn add_follow_with_rkey(&self, actor_did: &str, rkey: &str, subject_did: &str) {
+        self.add_follow(actor_did, subject_did);
+        let actor_uid = self.get_or_assign_uid(actor_did);
+        let subject_uid = self.get_or_assign_uid(subject_did);
+        self.follow_rkeys
+            .insert((actor_uid, rkey.to_owned()), subject_uid);
+    }
+
+    /// Remove a follow by rkey, looking up the subject we recorded at create time.
+    /// Returns true if the follow was known and removed; false if the rkey was
+    /// never seen (e.g. follow predates rsky-graph's rkey index).
+    pub fn remove_follow_by_rkey(&self, actor_did: &str, rkey: &str) -> bool {
+        let Some(actor_uid) = self.get_uid(actor_did) else {
+            return false;
+        };
+        let Some((_, subject_uid)) = self.follow_rkeys.remove(&(actor_uid, rkey.to_owned())) else {
+            return false;
+        };
+        if let Some(mut bm) = self.following.get_mut(&actor_uid) {
+            bm.remove(subject_uid);
+        }
+        if let Some(mut bm) = self.followers.get_mut(&subject_uid) {
+            bm.remove(actor_uid);
+        }
+        self.follow_count.fetch_sub(1, Ordering::Relaxed);
+        true
+    }
+
+    /// Remove a follow relationship: actor unfollows subject.
+    pub fn remove_follow(&self, actor_did: &str, subject_did: &str) {
+        let Some(actor_uid) = self.get_uid(actor_did) else {
+            return;
+        };
+        let Some(subject_uid) = self.get_uid(subject_did) else {
+            return;
+        };
+
+        if let Some(mut bm) = self.following.get_mut(&actor_uid) {
+            bm.remove(subject_uid);
+        }
+        if let Some(mut bm) = self.followers.get_mut(&subject_uid) {
+            bm.remove(actor_uid);
+        }
+
+        // Bloom filters don't support removal -- rebuild periodically
+        // For now, the bloom may have false positives for removed follows,
+        // which is acceptable (it just means we do the bitmap check unnecessarily)
+
+        self.follow_count.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    /// Find mutual follows: people the viewer follows who also follow the target.
+    /// This is the hot path -- must be sub-millisecond.
+    pub fn get_follows_following(&self, viewer_did: &str, target_did: &str) -> Vec<String> {
+        let Some(viewer_uid) = self.get_uid(viewer_did) else {
+            return vec![];
+        };
+        let Some(target_uid) = self.get_uid(target_did) else {
+            return vec![];
+        };
+
+        let Some(viewer_following) = self.following.get(&viewer_uid) else {
+            return vec![];
+        };
+
+        // Layer 1: Bloom filter fast rejection
+        // If none of the viewer's following set could possibly be in target's followers,
+        // skip the bitmap intersection entirely.
+        if let Some(bloom) = self.follower_blooms.get(&target_uid) {
+            let mut any_maybe = false;
+            for uid in viewer_following.iter() {
+                if bloom.check(&uid) {
+                    any_maybe = true;
+                    break;
+                }
+            }
+            if !any_maybe {
+                crate::metrics::GRAPH_BLOOM_REJECTIONS.inc();
+                return vec![];
+            }
+        }
+
+        // Layer 2: Roaring bitmap intersection
+        let Some(target_followers) = self.followers.get(&target_uid) else {
+            return vec![];
+        };
+
+        let intersection = viewer_following.value() & target_followers.value();
+
+        intersection
+            .iter()
+            .filter_map(|uid| self.get_did(uid))
+            .collect()
+    }
+
+    /// Check if actor follows subject.
+    pub fn is_following(&self, actor_did: &str, subject_did: &str) -> bool {
+        let Some(actor_uid) = self.get_uid(actor_did) else {
+            return false;
+        };
+        let Some(subject_uid) = self.get_uid(subject_did) else {
+            return false;
+        };
+        self.following
+            .get(&actor_uid)
+            .map_or(false, |bm| bm.contains(subject_uid))
+    }
+
+    pub fn user_count(&self) -> usize {
+        self.did_to_uid.len()
+    }
+
+    pub fn follow_count(&self) -> u64 {
+        self.follow_count.load(Ordering::Relaxed)
+    }
+
+    pub fn next_uid(&self) -> u32 {
+        self.next_uid.load(Ordering::Relaxed)
+    }
+
+    pub fn set_next_uid(&self, uid: u32) {
+        self.next_uid.store(uid, Ordering::Relaxed);
+    }
+}

--- a/rsky-graph/src/graph.rs
+++ b/rsky-graph/src/graph.rs
@@ -1,4 +1,4 @@
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use roaring::RoaringBitmap;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
@@ -25,6 +25,12 @@ pub struct FollowGraph {
     // follows are not reversible until the next snapshot rebuild.
     pub follow_rkeys: DashMap<(u32, String), u32>,
 
+    // UIDs whose `following`/`followers` bitmaps (or DID mapping) have been
+    // mutated since the last successful save. The save loop drains this and
+    // writes only those entries -- O(dirty) instead of O(graph). Empty after
+    // load_from_lmdb (which inserts directly into DashMaps without marking).
+    pub dirty_users: DashSet<u32>,
+
     // Stats
     follow_count: AtomicU64,
 }
@@ -39,6 +45,7 @@ impl FollowGraph {
             following: DashMap::new(),
             follower_blooms: DashMap::new(),
             follow_rkeys: DashMap::new(),
+            dirty_users: DashSet::new(),
             follow_count: AtomicU64::new(0),
         }
     }
@@ -90,6 +97,9 @@ impl FollowGraph {
             .or_insert_with(|| bloom::new_bloom_filter(100))
             .set(&actor_uid);
 
+        self.dirty_users.insert(actor_uid);
+        self.dirty_users.insert(subject_uid);
+
         self.follow_count.fetch_add(1, Ordering::Relaxed);
     }
 
@@ -122,6 +132,8 @@ impl FollowGraph {
         if let Some(mut bm) = self.followers.get_mut(&subject_uid) {
             bm.remove(actor_uid);
         }
+        self.dirty_users.insert(actor_uid);
+        self.dirty_users.insert(subject_uid);
         self.follow_count.fetch_sub(1, Ordering::Relaxed);
         true
     }
@@ -146,6 +158,8 @@ impl FollowGraph {
         // For now, the bloom may have false positives for removed follows,
         // which is acceptable (it just means we do the bitmap check unnecessarily)
 
+        self.dirty_users.insert(actor_uid);
+        self.dirty_users.insert(subject_uid);
         self.follow_count.fetch_sub(1, Ordering::Relaxed);
     }
 
@@ -226,5 +240,91 @@ impl FollowGraph {
     /// rebuilds bitmaps without going through `add_follow`.
     pub fn set_follow_count(&self, count: u64) {
         self.follow_count.store(count, Ordering::Relaxed);
+    }
+
+    /// Drain the dirty-user set into a Vec, atomically removing each entry.
+    /// Used by `save_to_lmdb` to learn which users were touched since the last
+    /// save. Pre-removing means a concurrent mutation arriving after we drain
+    /// but before we read the bitmap will re-mark the user dirty, so the next
+    /// save catches up; we never lose writes silently.
+    pub fn drain_dirty_users(&self) -> Vec<u32> {
+        let mut out: Vec<u32> = self.dirty_users.iter().map(|e| *e.key()).collect();
+        // Best-effort dedupe in case the snapshot saw duplicates across shards
+        // (DashSet shouldn't but cheap to be defensive about save IO).
+        out.sort_unstable();
+        out.dedup();
+        for uid in &out {
+            self.dirty_users.remove(uid);
+        }
+        out
+    }
+
+    /// Number of UIDs marked dirty since last save. For metrics + tests.
+    pub fn dirty_count(&self) -> usize {
+        self.dirty_users.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_follow_marks_both_uids_dirty() {
+        let g = FollowGraph::new();
+        g.add_follow("did:plc:a", "did:plc:b");
+        assert_eq!(g.dirty_count(), 2);
+        let a = g.get_uid("did:plc:a").unwrap();
+        let b = g.get_uid("did:plc:b").unwrap();
+        assert!(g.dirty_users.contains(&a));
+        assert!(g.dirty_users.contains(&b));
+    }
+
+    #[test]
+    fn drain_clears_dirty_set() {
+        let g = FollowGraph::new();
+        g.add_follow("did:plc:a", "did:plc:b");
+        g.add_follow("did:plc:c", "did:plc:d");
+        let drained = g.drain_dirty_users();
+        assert_eq!(drained.len(), 4);
+        assert_eq!(g.dirty_count(), 0);
+    }
+
+    #[test]
+    fn remove_follow_marks_dirty() {
+        let g = FollowGraph::new();
+        g.add_follow("did:plc:a", "did:plc:b");
+        g.drain_dirty_users();
+        assert_eq!(g.dirty_count(), 0);
+        g.remove_follow("did:plc:a", "did:plc:b");
+        assert_eq!(g.dirty_count(), 2);
+    }
+
+    #[test]
+    fn remove_follow_by_rkey_marks_dirty() {
+        let g = FollowGraph::new();
+        g.add_follow_with_rkey("did:plc:a", "rkey1", "did:plc:b");
+        g.drain_dirty_users();
+        assert!(g.remove_follow_by_rkey("did:plc:a", "rkey1"));
+        assert_eq!(g.dirty_count(), 2);
+    }
+
+    #[test]
+    fn dirty_set_dedupes_repeated_writes_to_same_user() {
+        let g = FollowGraph::new();
+        // Same actor follows three subjects: actor UID should appear once.
+        g.add_follow("did:plc:a", "did:plc:b");
+        g.add_follow("did:plc:a", "did:plc:c");
+        g.add_follow("did:plc:a", "did:plc:d");
+        let drained = g.drain_dirty_users();
+        // 1 actor + 3 subjects = 4 unique UIDs
+        assert_eq!(drained.len(), 4);
+    }
+
+    #[test]
+    fn drain_returns_empty_when_clean() {
+        let g = FollowGraph::new();
+        let drained = g.drain_dirty_users();
+        assert!(drained.is_empty());
     }
 }

--- a/rsky-graph/src/graph.rs
+++ b/rsky-graph/src/graph.rs
@@ -221,4 +221,10 @@ impl FollowGraph {
     pub fn set_next_uid(&self, uid: u32) {
         self.next_uid.store(uid, Ordering::Relaxed);
     }
+
+    /// Reset the in-memory follow counter -- used after `load_from_lmdb`
+    /// rebuilds bitmaps without going through `add_follow`.
+    pub fn set_follow_count(&self, count: u64) {
+        self.follow_count.store(count, Ordering::Relaxed);
+    }
 }

--- a/rsky-graph/src/lib.rs
+++ b/rsky-graph/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod api;
+pub mod bloom;
+pub mod bulk_load;
+pub mod firehose;
+pub mod graph;
+pub mod metrics;
+pub mod persistence;
+pub mod types;

--- a/rsky-graph/src/main.rs
+++ b/rsky-graph/src/main.rs
@@ -39,6 +39,10 @@ struct Args {
     /// is preferred over a live PG load -- see plan recursive-honking-sprout.
     #[clap(long, env = "GRAPH_LOAD_FROM_FILE")]
     load_from_file: Option<String>,
+
+    /// Bearer token gating POST /admin/bulk-load. Unset = admin disabled.
+    #[clap(long, env = "GRAPH_ADMIN_TOKEN")]
+    admin_token: Option<String>,
 }
 
 #[tokio::main]
@@ -144,8 +148,15 @@ async fn main() -> Result<()> {
         }
     });
 
+    // Build admin state. The token gates POST /admin/bulk-load; without it
+    // the route always 401s. database_url is reused from the startup arg.
+    let admin = Arc::new(api::AdminState::new(
+        args.admin_token.clone(),
+        args.database_url.clone(),
+    ));
+
     // Start HTTP API (blocks until shutdown)
-    api::serve(args.port, Arc::clone(&graph), shutdown_flag).await?;
+    api::serve(args.port, Arc::clone(&graph), admin, shutdown_flag).await?;
 
     // Final persist on shutdown
     tracing::info!("final LMDB save");

--- a/rsky-graph/src/main.rs
+++ b/rsky-graph/src/main.rs
@@ -1,0 +1,156 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use clap::Parser;
+use color_eyre::Result;
+use mimalloc::MiMalloc;
+
+mod api;
+mod bloom;
+mod bulk_load;
+mod firehose;
+mod graph;
+mod metrics;
+mod persistence;
+mod types;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
+static SHUTDOWN: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Parser)]
+#[command(name = "rsky-graph")]
+#[command(about = "AT Protocol follow graph service using roaring bitmaps and bloom filters")]
+struct Args {
+    #[clap(long, env = "GRAPH_PORT", default_value = "3890")]
+    port: u16,
+
+    #[clap(long, env = "GRAPH_DB_PATH", default_value = "/data/graph")]
+    db_path: String,
+
+    #[clap(long, env = "RELAY_HOST", default_value = "wss://atproto.africa")]
+    relay_host: String,
+
+    #[clap(long, env = "DATABASE_URL")]
+    database_url: Option<String>,
+
+    /// Path to a CSV (creator,subjectDid) produced by `\copy`. When set, this
+    /// is preferred over a live PG load -- see plan recursive-honking-sprout.
+    #[clap(long, env = "GRAPH_LOAD_FROM_FILE")]
+    load_from_file: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    color_eyre::install()?;
+
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls crypto provider");
+
+    let args = Args::parse();
+
+    tracing::info!("starting rsky-graph");
+    tracing::info!("port: {}", args.port);
+    tracing::info!("db_path: {}", args.db_path);
+    tracing::info!("relay: {}", args.relay_host);
+
+    // Initialize graph
+    let graph = Arc::new(graph::FollowGraph::new());
+
+    // Load from LMDB if available
+    let loaded = persistence::load_from_lmdb(&args.db_path, &graph).await;
+    match loaded {
+        Ok(count) if count > 0 => {
+            tracing::info!("loaded {} users from LMDB", count);
+        }
+        Ok(_) => {
+            // Empty LMDB -- prefer file load (zero PG transaction) over a live PG load.
+            if let Some(ref path) = args.load_from_file {
+                tracing::info!("LMDB empty, bulk-loading from file: {path}");
+                bulk_load::bulk_load_from_file(std::path::Path::new(path), &graph).await?;
+                tracing::info!(
+                    "bulk load complete: {} users, {} follows",
+                    graph.user_count(),
+                    graph.follow_count()
+                );
+                bloom::build_all_bloom_filters(&graph);
+                tracing::info!("bloom filters built");
+                persistence::save_to_lmdb(&args.db_path, &graph).await?;
+                tracing::info!("persisted to LMDB");
+            } else if let Some(ref db_url) = args.database_url {
+                tracing::info!("LMDB empty, starting keyset bulk load from PostgreSQL");
+                bulk_load::bulk_load_keyset(db_url, &graph).await?;
+                tracing::info!(
+                    "bulk load complete: {} users, {} follows",
+                    graph.user_count(),
+                    graph.follow_count()
+                );
+                bloom::build_all_bloom_filters(&graph);
+                tracing::info!("bloom filters built");
+                persistence::save_to_lmdb(&args.db_path, &graph).await?;
+                tracing::info!("persisted to LMDB");
+            } else {
+                tracing::warn!(
+                    "LMDB empty and no GRAPH_LOAD_FROM_FILE / DATABASE_URL -- starting with empty graph"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!("failed to load LMDB: {e}, starting fresh");
+        }
+    }
+
+    // Register shutdown handler
+    let shutdown_flag = Arc::new(AtomicBool::new(false));
+    let sf = Arc::clone(&shutdown_flag);
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.ok();
+        tracing::info!("shutdown signal received");
+        sf.store(true, Ordering::Relaxed);
+        SHUTDOWN.store(true, Ordering::Relaxed);
+    });
+
+    // Start firehose sync in background
+    let graph_firehose = Arc::clone(&graph);
+    let relay_host = args.relay_host.clone();
+    let db_path_persist = args.db_path.clone();
+    let graph_persist = Arc::clone(&graph);
+    let sf_firehose = Arc::clone(&shutdown_flag);
+
+    tokio::spawn(async move {
+        firehose::tail_firehose(&relay_host, &graph_firehose, &sf_firehose).await;
+    });
+
+    // Periodic LMDB persistence
+    let sf_persist = Arc::clone(&shutdown_flag);
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+            if sf_persist.load(Ordering::Relaxed) {
+                break;
+            }
+            if let Err(e) = persistence::save_to_lmdb(&db_path_persist, &graph_persist).await {
+                tracing::error!("periodic LMDB save failed: {e}");
+            }
+        }
+    });
+
+    // Start HTTP API (blocks until shutdown)
+    api::serve(args.port, Arc::clone(&graph), shutdown_flag).await?;
+
+    // Final persist on shutdown
+    tracing::info!("final LMDB save");
+    persistence::save_to_lmdb(&args.db_path, &graph).await.ok();
+
+    tracing::info!("goodbye");
+    Ok(())
+}

--- a/rsky-graph/src/main.rs
+++ b/rsky-graph/src/main.rs
@@ -80,39 +80,6 @@ async fn main() -> Result<()> {
         });
     }
 
-    // Exponential save backoff: 60s, 120s, 240s, ... capped at 30 min.
-    {
-        let sf_persist = Arc::clone(&shutdown_flag);
-        let db_path_persist = args.db_path.clone();
-        let graph_persist = Arc::clone(&graph);
-        tokio::spawn(async move {
-            let mut delay_secs: u64 = 60;
-            const MAX_DELAY: u64 = 1800;
-            loop {
-                tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
-                if sf_persist.load(Ordering::Relaxed) {
-                    break;
-                }
-                let start = std::time::Instant::now();
-                let users = graph_persist.user_count();
-                match persistence::save_to_lmdb(&db_path_persist, &graph_persist).await {
-                    Ok(()) => {
-                        let elapsed = start.elapsed().as_secs_f64();
-                        tracing::info!(
-                            "periodic LMDB save: {} users in {:.1}s (next in {}s)",
-                            users,
-                            elapsed,
-                            delay_secs
-                        );
-                    }
-                    Err(e) => tracing::error!("periodic LMDB save failed: {e}"),
-                }
-                // Back off so save overhead stays a small fraction of bulk-load time.
-                delay_secs = (delay_secs.saturating_mul(2)).min(MAX_DELAY);
-            }
-        });
-    }
-
     // Load from LMDB if available
     let loaded = persistence::load_from_lmdb(&args.db_path, &graph).await;
     match loaded {
@@ -163,6 +130,25 @@ async fn main() -> Result<()> {
     tokio::spawn(async move {
         firehose::tail_firehose(&relay_host, &graph_firehose, &sf_firehose).await;
     });
+
+    // Periodic save runs only after bulk-load completes (concurrent saves race the loader).
+    {
+        let sf_persist = Arc::clone(&shutdown_flag);
+        let db_path_persist = args.db_path.clone();
+        let graph_persist = Arc::clone(&graph);
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(300));
+            loop {
+                interval.tick().await;
+                if sf_persist.load(Ordering::Relaxed) {
+                    break;
+                }
+                if let Err(e) = persistence::save_to_lmdb(&db_path_persist, &graph_persist).await {
+                    tracing::error!("periodic LMDB save failed: {e}");
+                }
+            }
+        });
+    }
 
     // Build admin state. The token gates POST /admin/bulk-load; without it
     // the route always 401s. database_url is reused from the startup arg.

--- a/rsky-graph/src/main.rs
+++ b/rsky-graph/src/main.rs
@@ -69,6 +69,36 @@ async fn main() -> Result<()> {
     // Initialize graph
     let graph = Arc::new(graph::FollowGraph::new());
 
+    // Spawn shutdown handler + periodic LMDB persistence BEFORE bulk-load so a
+    // crash mid-load doesn't lose hours of in-memory progress.
+    let shutdown_flag = Arc::new(AtomicBool::new(false));
+    {
+        let sf = Arc::clone(&shutdown_flag);
+        tokio::spawn(async move {
+            tokio::signal::ctrl_c().await.ok();
+            tracing::info!("shutdown signal received");
+            sf.store(true, Ordering::Relaxed);
+            SHUTDOWN.store(true, Ordering::Relaxed);
+        });
+    }
+    {
+        let sf_persist = Arc::clone(&shutdown_flag);
+        let db_path_persist = args.db_path.clone();
+        let graph_persist = Arc::clone(&graph);
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+            loop {
+                interval.tick().await;
+                if sf_persist.load(Ordering::Relaxed) {
+                    break;
+                }
+                if let Err(e) = persistence::save_to_lmdb(&db_path_persist, &graph_persist).await {
+                    tracing::error!("periodic LMDB save failed: {e}");
+                }
+            }
+        });
+    }
+
     // Load from LMDB if available
     let loaded = persistence::load_from_lmdb(&args.db_path, &graph).await;
     match loaded {
@@ -112,40 +142,12 @@ async fn main() -> Result<()> {
         }
     }
 
-    // Register shutdown handler
-    let shutdown_flag = Arc::new(AtomicBool::new(false));
-    let sf = Arc::clone(&shutdown_flag);
-    tokio::spawn(async move {
-        tokio::signal::ctrl_c().await.ok();
-        tracing::info!("shutdown signal received");
-        sf.store(true, Ordering::Relaxed);
-        SHUTDOWN.store(true, Ordering::Relaxed);
-    });
-
     // Start firehose sync in background
     let graph_firehose = Arc::clone(&graph);
     let relay_host = args.relay_host.clone();
-    let db_path_persist = args.db_path.clone();
-    let graph_persist = Arc::clone(&graph);
     let sf_firehose = Arc::clone(&shutdown_flag);
-
     tokio::spawn(async move {
         firehose::tail_firehose(&relay_host, &graph_firehose, &sf_firehose).await;
-    });
-
-    // Periodic LMDB persistence
-    let sf_persist = Arc::clone(&shutdown_flag);
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
-        loop {
-            interval.tick().await;
-            if sf_persist.load(Ordering::Relaxed) {
-                break;
-            }
-            if let Err(e) = persistence::save_to_lmdb(&db_path_persist, &graph_persist).await {
-                tracing::error!("periodic LMDB save failed: {e}");
-            }
-        }
     });
 
     // Build admin state. The token gates POST /admin/bulk-load; without it

--- a/rsky-graph/src/main.rs
+++ b/rsky-graph/src/main.rs
@@ -5,14 +5,7 @@ use clap::Parser;
 use color_eyre::Result;
 use mimalloc::MiMalloc;
 
-mod api;
-mod bloom;
-mod bulk_load;
-mod firehose;
-mod graph;
-mod metrics;
-mod persistence;
-mod types;
+use rsky_graph::{api, bulk_load, firehose, graph, persistence, types};
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -68,6 +61,7 @@ async fn main() -> Result<()> {
 
     // Initialize graph
     let graph = Arc::new(graph::FollowGraph::new());
+    let load_state = Arc::new(types::LoadState::new());
 
     let shutdown_flag = Arc::new(AtomicBool::new(false));
     {
@@ -80,46 +74,65 @@ async fn main() -> Result<()> {
         });
     }
 
-    // Load from LMDB if available
-    let loaded = persistence::load_from_lmdb(&args.db_path, &graph).await;
-    match loaded {
+    // Load existing state from LMDB synchronously before any concurrent task
+    // starts (a second env handle on the same path during load races and
+    // corrupts state).
+    match persistence::load_from_lmdb(&args.db_path, &graph).await {
         Ok(count) if count > 0 => {
             tracing::info!("loaded {} users from LMDB", count);
+            // Existing on-disk state is from a previous fully-completed bulk-load,
+            // so the API can serve all queries.
+            load_state.mark_complete();
         }
         Ok(_) => {
-            // Empty LMDB -- prefer file load (zero PG transaction) over a live PG load.
-            if let Some(ref path) = args.load_from_file {
-                tracing::info!("LMDB empty, bulk-loading from file: {path}");
-                bulk_load::bulk_load_from_file(std::path::Path::new(path), &graph).await?;
-                tracing::info!(
-                    "bulk load complete: {} users, {} follows",
-                    graph.user_count(),
-                    graph.follow_count()
-                );
-                bloom::build_all_bloom_filters(&graph);
-                tracing::info!("bloom filters built");
-                persistence::save_to_lmdb(&args.db_path, &graph).await?;
-                tracing::info!("persisted to LMDB");
-            } else if let Some(ref db_url) = args.database_url {
-                tracing::info!("LMDB empty, starting keyset bulk load from PostgreSQL");
-                bulk_load::bulk_load_keyset(db_url, &graph).await?;
-                tracing::info!(
-                    "bulk load complete: {} users, {} follows",
-                    graph.user_count(),
-                    graph.follow_count()
-                );
-                bloom::build_all_bloom_filters(&graph);
-                tracing::info!("bloom filters built");
-                persistence::save_to_lmdb(&args.db_path, &graph).await?;
-                tracing::info!("persisted to LMDB");
-            } else {
-                tracing::warn!(
-                    "LMDB empty and no GRAPH_LOAD_FROM_FILE / DATABASE_URL -- starting with empty graph"
-                );
-            }
+            tracing::info!(
+                "LMDB empty -- API will return 503 for unloaded actors until bulk-load progresses"
+            );
         }
         Err(e) => {
             tracing::warn!("failed to load LMDB: {e}, starting fresh");
+        }
+    }
+
+    // Background bulk-load -- the API starts serving immediately and answers
+    // 503 for actors above the load cursor until they're processed.
+    if !load_state.is_complete() {
+        if let Some(ref path) = args.load_from_file {
+            let path = path.clone();
+            let graph_load = Arc::clone(&graph);
+            let load_state_bg = Arc::clone(&load_state);
+            let db_path_save = args.db_path.clone();
+            tokio::spawn(async move {
+                tracing::info!("background bulk-load from file: {path}");
+                if let Err(e) =
+                    bulk_load::bulk_load_from_file(std::path::Path::new(&path), &graph_load).await
+                {
+                    tracing::error!("bulk load from file failed: {e}");
+                    return;
+                }
+                load_state_bg.mark_complete();
+                post_load_finalize(&db_path_save, &graph_load).await;
+            });
+        } else if let Some(ref db_url) = args.database_url {
+            let db_url = db_url.clone();
+            let db_path_save = args.db_path.clone();
+            let graph_load = Arc::clone(&graph);
+            let load_state_bg = Arc::clone(&load_state);
+            tokio::spawn(async move {
+                tracing::info!("background keyset bulk load from PostgreSQL");
+                if let Err(e) =
+                    bulk_load::bulk_load_keyset(&db_url, &graph_load, &load_state_bg).await
+                {
+                    tracing::error!("bulk load failed: {e}");
+                    return;
+                }
+                post_load_finalize(&db_path_save, &graph_load).await;
+            });
+        } else {
+            tracing::warn!(
+                "LMDB empty and no GRAPH_LOAD_FROM_FILE / DATABASE_URL -- API serves an empty graph"
+            );
+            load_state.mark_complete();
         }
     }
 
@@ -131,20 +144,32 @@ async fn main() -> Result<()> {
         firehose::tail_firehose(&relay_host, &graph_firehose, &sf_firehose).await;
     });
 
-    // Periodic save runs only after bulk-load completes (concurrent saves race the loader).
+    // Periodic save. The save itself iterates DashMap (read locks per shard);
+    // bulk-load + firehose only mutate DashMap. Single env opened per save call.
+    // Sequential schedule: each save runs to completion before the next sleep.
     {
         let sf_persist = Arc::clone(&shutdown_flag);
         let db_path_persist = args.db_path.clone();
         let graph_persist = Arc::clone(&graph);
+        let load_state_persist = Arc::clone(&load_state);
         tokio::spawn(async move {
-            let mut interval = tokio::time::interval(std::time::Duration::from_secs(300));
+            // Save more often during bulk-load so a crash loses minutes, not hours.
+            // After load completes we drop to a slower steady-state cadence.
             loop {
-                interval.tick().await;
+                let active = !load_state_persist.is_complete();
+                let next_sleep = if active { 600 } else { 1800 };
+                tokio::time::sleep(std::time::Duration::from_secs(next_sleep)).await;
                 if sf_persist.load(Ordering::Relaxed) {
                     break;
                 }
-                if let Err(e) = persistence::save_to_lmdb(&db_path_persist, &graph_persist).await {
-                    tracing::error!("periodic LMDB save failed: {e}");
+                let users = graph_persist.user_count();
+                let start = std::time::Instant::now();
+                match persistence::save_to_lmdb(&db_path_persist, &graph_persist).await {
+                    Ok(()) => tracing::info!(
+                        "periodic LMDB save: {users} users in {:.1}s",
+                        start.elapsed().as_secs_f64()
+                    ),
+                    Err(e) => tracing::error!("periodic LMDB save failed: {e}"),
                 }
             }
         });
@@ -157,8 +182,16 @@ async fn main() -> Result<()> {
         args.database_url.clone(),
     ));
 
-    // Start HTTP API (blocks until shutdown)
-    api::serve(args.port, Arc::clone(&graph), admin, shutdown_flag).await?;
+    // Start HTTP API. Serving happens immediately even if bulk-load is still
+    // running -- handlers consult load_state to decide whether to 503.
+    api::serve(
+        args.port,
+        Arc::clone(&graph),
+        admin,
+        Arc::clone(&load_state),
+        shutdown_flag,
+    )
+    .await?;
 
     // Final persist on shutdown
     tracing::info!("final LMDB save");
@@ -166,4 +199,21 @@ async fn main() -> Result<()> {
 
     tracing::info!("goodbye");
     Ok(())
+}
+
+/// Post-bulk-load: persist the graph to LMDB so the next restart can serve
+/// from disk without re-loading from PG. Bloom filters are rebuilt lazily on
+/// first query rather than upfront -- a 25M-user upfront rebuild blocks the
+/// API for hours.
+async fn post_load_finalize(db_path: &str, graph: &graph::FollowGraph) {
+    tracing::info!(
+        "bulk load complete: {} users, {} follows",
+        graph.user_count(),
+        graph.follow_count()
+    );
+    if let Err(e) = persistence::save_to_lmdb(db_path, graph).await {
+        tracing::error!("post-load LMDB save failed: {e}");
+    } else {
+        tracing::info!("post-load LMDB save done");
+    }
 }

--- a/rsky-graph/src/main.rs
+++ b/rsky-graph/src/main.rs
@@ -69,8 +69,6 @@ async fn main() -> Result<()> {
     // Initialize graph
     let graph = Arc::new(graph::FollowGraph::new());
 
-    // Spawn shutdown handler + periodic LMDB persistence BEFORE bulk-load so a
-    // crash mid-load doesn't lose hours of in-memory progress.
     let shutdown_flag = Arc::new(AtomicBool::new(false));
     {
         let sf = Arc::clone(&shutdown_flag);
@@ -81,20 +79,36 @@ async fn main() -> Result<()> {
             SHUTDOWN.store(true, Ordering::Relaxed);
         });
     }
+
+    // Exponential save backoff: 60s, 120s, 240s, ... capped at 30 min.
     {
         let sf_persist = Arc::clone(&shutdown_flag);
         let db_path_persist = args.db_path.clone();
         let graph_persist = Arc::clone(&graph);
         tokio::spawn(async move {
-            let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+            let mut delay_secs: u64 = 60;
+            const MAX_DELAY: u64 = 1800;
             loop {
-                interval.tick().await;
+                tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
                 if sf_persist.load(Ordering::Relaxed) {
                     break;
                 }
-                if let Err(e) = persistence::save_to_lmdb(&db_path_persist, &graph_persist).await {
-                    tracing::error!("periodic LMDB save failed: {e}");
+                let start = std::time::Instant::now();
+                let users = graph_persist.user_count();
+                match persistence::save_to_lmdb(&db_path_persist, &graph_persist).await {
+                    Ok(()) => {
+                        let elapsed = start.elapsed().as_secs_f64();
+                        tracing::info!(
+                            "periodic LMDB save: {} users in {:.1}s (next in {}s)",
+                            users,
+                            elapsed,
+                            delay_secs
+                        );
+                    }
+                    Err(e) => tracing::error!("periodic LMDB save failed: {e}"),
                 }
+                // Back off so save overhead stays a small fraction of bulk-load time.
+                delay_secs = (delay_secs.saturating_mul(2)).min(MAX_DELAY);
             }
         });
     }

--- a/rsky-graph/src/metrics.rs
+++ b/rsky-graph/src/metrics.rs
@@ -57,6 +57,36 @@ pub static GRAPH_FIREHOSE_EVENTS: LazyLock<IntCounter> = LazyLock::new(|| {
     c
 });
 
+pub static GRAPH_FIREHOSE_FRAMES: LazyLock<IntCounter> = LazyLock::new(|| {
+    let c = IntCounter::new(
+        "graph_firehose_frames_total",
+        "Binary frames received from firehose (any type)",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(c.clone())).unwrap();
+    c
+});
+
+pub static GRAPH_FIREHOSE_COMMITS: LazyLock<IntCounter> = LazyLock::new(|| {
+    let c = IntCounter::new(
+        "graph_firehose_commits_total",
+        "#commit frames successfully decoded",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(c.clone())).unwrap();
+    c
+});
+
+pub static GRAPH_FIREHOSE_DECODE_ERRORS: LazyLock<IntCounter> = LazyLock::new(|| {
+    let c = IntCounter::new(
+        "graph_firehose_decode_errors_total",
+        "Frames where rsky_firehose::firehose::read returned Err or non-commit",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(c.clone())).unwrap();
+    c
+});
+
 pub fn encode_metrics() -> String {
     // Force lazy initialization
     let _ = &*GRAPH_QUERIES_TOTAL;
@@ -65,6 +95,9 @@ pub fn encode_metrics() -> String {
     let _ = &*GRAPH_USERS_TOTAL;
     let _ = &*GRAPH_FOLLOWS_TOTAL;
     let _ = &*GRAPH_FIREHOSE_EVENTS;
+    let _ = &*GRAPH_FIREHOSE_FRAMES;
+    let _ = &*GRAPH_FIREHOSE_COMMITS;
+    let _ = &*GRAPH_FIREHOSE_DECODE_ERRORS;
 
     let encoder = TextEncoder::new();
     let metric_families = REGISTRY.gather();

--- a/rsky-graph/src/metrics.rs
+++ b/rsky-graph/src/metrics.rs
@@ -1,0 +1,74 @@
+use prometheus::{histogram_opts, opts, Histogram, IntCounter, IntGauge, Registry, TextEncoder};
+use std::sync::LazyLock;
+
+static REGISTRY: LazyLock<Registry> = LazyLock::new(Registry::new);
+
+pub static GRAPH_QUERIES_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    let c = IntCounter::new(
+        "graph_queries_total",
+        "Total follows-following queries served",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(c.clone())).unwrap();
+    c
+});
+
+pub static GRAPH_QUERY_DURATION: LazyLock<Histogram> = LazyLock::new(|| {
+    let h = Histogram::with_opts(histogram_opts!(
+        "graph_query_duration_seconds",
+        "Query duration in seconds",
+        vec![0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0]
+    ))
+    .unwrap();
+    REGISTRY.register(Box::new(h.clone())).unwrap();
+    h
+});
+
+pub static GRAPH_BLOOM_REJECTIONS: LazyLock<IntCounter> = LazyLock::new(|| {
+    let c = IntCounter::new(
+        "graph_bloom_rejections_total",
+        "Queries short-circuited by bloom filter (definite no overlap)",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(c.clone())).unwrap();
+    c
+});
+
+pub static GRAPH_USERS_TOTAL: LazyLock<IntGauge> = LazyLock::new(|| {
+    let g = IntGauge::with_opts(opts!("graph_users_total", "Total UIDs in graph")).unwrap();
+    REGISTRY.register(Box::new(g.clone())).unwrap();
+    g
+});
+
+pub static GRAPH_FOLLOWS_TOTAL: LazyLock<IntGauge> = LazyLock::new(|| {
+    let g =
+        IntGauge::with_opts(opts!("graph_follows_total", "Total follow edges in graph")).unwrap();
+    REGISTRY.register(Box::new(g.clone())).unwrap();
+    g
+});
+
+pub static GRAPH_FIREHOSE_EVENTS: LazyLock<IntCounter> = LazyLock::new(|| {
+    let c = IntCounter::new(
+        "graph_firehose_events_total",
+        "Follow events processed from firehose",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(c.clone())).unwrap();
+    c
+});
+
+pub fn encode_metrics() -> String {
+    // Force lazy initialization
+    let _ = &*GRAPH_QUERIES_TOTAL;
+    let _ = &*GRAPH_QUERY_DURATION;
+    let _ = &*GRAPH_BLOOM_REJECTIONS;
+    let _ = &*GRAPH_USERS_TOTAL;
+    let _ = &*GRAPH_FOLLOWS_TOTAL;
+    let _ = &*GRAPH_FIREHOSE_EVENTS;
+
+    let encoder = TextEncoder::new();
+    let metric_families = REGISTRY.gather();
+    let mut buffer = String::new();
+    encoder.encode_utf8(&metric_families, &mut buffer).unwrap();
+    buffer
+}

--- a/rsky-graph/src/persistence.rs
+++ b/rsky-graph/src/persistence.rs
@@ -1,0 +1,197 @@
+use crate::graph::FollowGraph;
+use crate::types::GraphError;
+use heed::types::*;
+use heed::{Database, EnvOpenOptions};
+use roaring::RoaringBitmap;
+use std::io::Cursor;
+use std::path::Path;
+
+type StrDb = Database<Str, Bytes>;
+type U32Db = Database<U32<heed::byteorder::LE>, Bytes>;
+
+pub async fn load_from_lmdb(db_path: &str, graph: &FollowGraph) -> Result<usize, GraphError> {
+    let path = Path::new(db_path);
+    if !path.exists() {
+        std::fs::create_dir_all(path)
+            .map_err(|e| GraphError::Other(format!("create dir failed: {e}")))?;
+        return Ok(0);
+    }
+
+    let env = unsafe {
+        EnvOpenOptions::new()
+            .map_size(100 * 1024 * 1024 * 1024) // 100GB max
+            .max_dbs(4)
+            .open(path)
+            .map_err(|e| GraphError::Other(format!("lmdb open failed: {e}")))?
+    };
+
+    let mut wtxn = env
+        .write_txn()
+        .map_err(|e| GraphError::Other(format!("txn failed: {e}")))?;
+
+    // DID -> UID mapping
+    let did_uid_db: StrDb = env
+        .create_database(&mut wtxn, Some("did_uid"))
+        .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
+
+    // UID -> DID mapping
+    let uid_did_db: U32Db = env
+        .create_database(&mut wtxn, Some("uid_did"))
+        .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
+
+    // Following bitmaps: UID -> serialized RoaringBitmap
+    let following_db: U32Db = env
+        .create_database(&mut wtxn, Some("following"))
+        .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
+
+    // Followers bitmaps: UID -> serialized RoaringBitmap
+    let followers_db: U32Db = env
+        .create_database(&mut wtxn, Some("followers"))
+        .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
+
+    wtxn.commit()
+        .map_err(|e| GraphError::Other(format!("commit failed: {e}")))?;
+
+    let rtxn = env
+        .read_txn()
+        .map_err(|e| GraphError::Other(format!("read txn failed: {e}")))?;
+
+    // Load DID <-> UID mappings
+    let mut max_uid: u32 = 0;
+    let mut count = 0usize;
+
+    let iter = did_uid_db
+        .iter(&rtxn)
+        .map_err(|e| GraphError::Other(format!("iter failed: {e}")))?;
+
+    for result in iter {
+        let (did, uid_bytes) =
+            result.map_err(|e| GraphError::Other(format!("iter read failed: {e}")))?;
+        if uid_bytes.len() < 4 {
+            continue;
+        }
+        let uid = u32::from_ne_bytes(uid_bytes[..4].try_into().unwrap());
+        graph.did_to_uid.insert(did.to_owned(), uid);
+        graph.uid_to_did.insert(uid, did.to_owned());
+        if uid > max_uid {
+            max_uid = uid;
+        }
+        count += 1;
+    }
+
+    graph.set_next_uid(max_uid + 1);
+
+    // Load following bitmaps
+    let iter = following_db
+        .iter(&rtxn)
+        .map_err(|e| GraphError::Other(format!("following iter failed: {e}")))?;
+
+    for result in iter {
+        let (uid, bytes) =
+            result.map_err(|e| GraphError::Other(format!("following read failed: {e}")))?;
+        let bm = RoaringBitmap::deserialize_from(Cursor::new(bytes))
+            .map_err(|e| GraphError::Other(format!("bitmap deser failed: {e}")))?;
+        graph.following.insert(uid, bm);
+    }
+
+    // Load followers bitmaps
+    let iter = followers_db
+        .iter(&rtxn)
+        .map_err(|e| GraphError::Other(format!("followers iter failed: {e}")))?;
+
+    for result in iter {
+        let (uid, bytes) =
+            result.map_err(|e| GraphError::Other(format!("followers read failed: {e}")))?;
+        let bm = RoaringBitmap::deserialize_from(Cursor::new(bytes))
+            .map_err(|e| GraphError::Other(format!("bitmap deser failed: {e}")))?;
+        graph.followers.insert(uid, bm);
+    }
+
+    rtxn.commit()
+        .map_err(|e| GraphError::Other(format!("read commit failed: {e}")))?;
+
+    // Rebuild bloom filters from loaded data
+    if count > 0 {
+        crate::bloom::build_all_bloom_filters(graph);
+    }
+
+    tracing::info!("loaded {count} users from LMDB, max_uid={max_uid}");
+    Ok(count)
+}
+
+pub async fn save_to_lmdb(db_path: &str, graph: &FollowGraph) -> Result<(), GraphError> {
+    let path = Path::new(db_path);
+    if !path.exists() {
+        std::fs::create_dir_all(path)
+            .map_err(|e| GraphError::Other(format!("create dir failed: {e}")))?;
+    }
+
+    let env = unsafe {
+        EnvOpenOptions::new()
+            .map_size(100 * 1024 * 1024 * 1024)
+            .max_dbs(4)
+            .open(path)
+            .map_err(|e| GraphError::Other(format!("lmdb open failed: {e}")))?
+    };
+
+    let mut wtxn = env
+        .write_txn()
+        .map_err(|e| GraphError::Other(format!("txn failed: {e}")))?;
+
+    let did_uid_db: StrDb = env
+        .create_database(&mut wtxn, Some("did_uid"))
+        .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
+    let uid_did_db: U32Db = env
+        .create_database(&mut wtxn, Some("uid_did"))
+        .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
+    let following_db: U32Db = env
+        .create_database(&mut wtxn, Some("following"))
+        .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
+    let followers_db: U32Db = env
+        .create_database(&mut wtxn, Some("followers"))
+        .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
+
+    // Save DID <-> UID mappings
+    for entry in graph.did_to_uid.iter() {
+        let uid_bytes = entry.value().to_ne_bytes();
+        did_uid_db
+            .put(&mut wtxn, entry.key(), &uid_bytes)
+            .map_err(|e| GraphError::Other(format!("put did_uid failed: {e}")))?;
+    }
+    for entry in graph.uid_to_did.iter() {
+        let did_bytes = entry.value().as_bytes();
+        uid_did_db
+            .put(&mut wtxn, entry.key(), did_bytes)
+            .map_err(|e| GraphError::Other(format!("put uid_did failed: {e}")))?;
+    }
+
+    // Save following bitmaps
+    for entry in graph.following.iter() {
+        let mut buf = Vec::new();
+        entry
+            .value()
+            .serialize_into(&mut buf)
+            .map_err(|e| GraphError::Other(format!("serialize following failed: {e}")))?;
+        following_db
+            .put(&mut wtxn, entry.key(), &buf)
+            .map_err(|e| GraphError::Other(format!("put following failed: {e}")))?;
+    }
+
+    // Save followers bitmaps
+    for entry in graph.followers.iter() {
+        let mut buf = Vec::new();
+        entry
+            .value()
+            .serialize_into(&mut buf)
+            .map_err(|e| GraphError::Other(format!("serialize followers failed: {e}")))?;
+        followers_db
+            .put(&mut wtxn, entry.key(), &buf)
+            .map_err(|e| GraphError::Other(format!("put followers failed: {e}")))?;
+    }
+
+    wtxn.commit()
+        .map_err(|e| GraphError::Other(format!("commit failed: {e}")))?;
+
+    tracing::debug!("saved {} users to LMDB", graph.user_count());
+    Ok(())
+}

--- a/rsky-graph/src/persistence.rs
+++ b/rsky-graph/src/persistence.rs
@@ -151,18 +151,29 @@ pub async fn save_to_lmdb(db_path: &str, graph: &FollowGraph) -> Result<(), Grap
         .create_database(&mut wtxn, Some("followers"))
         .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
 
-    // Save DID <-> UID mappings
+    // LMDB rejects empty keys with MDB_BAD_VALSIZE; one stray empty DID would abort the whole txn.
+    let mut skipped_empty = 0u64;
     for entry in graph.did_to_uid.iter() {
+        if entry.key().is_empty() {
+            skipped_empty += 1;
+            continue;
+        }
         let uid_bytes = entry.value().to_ne_bytes();
         did_uid_db
             .put(&mut wtxn, entry.key(), &uid_bytes)
             .map_err(|e| GraphError::Other(format!("put did_uid failed: {e}")))?;
     }
     for entry in graph.uid_to_did.iter() {
+        if entry.value().is_empty() {
+            continue;
+        }
         let did_bytes = entry.value().as_bytes();
         uid_did_db
             .put(&mut wtxn, entry.key(), did_bytes)
             .map_err(|e| GraphError::Other(format!("put uid_did failed: {e}")))?;
+    }
+    if skipped_empty > 0 {
+        tracing::warn!("skipped {skipped_empty} empty-DID entries during persistence");
     }
 
     // Save following bitmaps

--- a/rsky-graph/src/persistence.rs
+++ b/rsky-graph/src/persistence.rs
@@ -107,6 +107,10 @@ pub async fn load_from_lmdb(db_path: &str, graph: &FollowGraph) -> Result<usize,
         graph.followers.insert(uid, bm);
     }
 
+    // Restore follow_count from the bitmap state (load doesn't go through add_follow).
+    let total: u64 = graph.following.iter().map(|e| e.value().len()).sum();
+    graph.set_follow_count(total);
+
     rtxn.commit()
         .map_err(|e| GraphError::Other(format!("read commit failed: {e}")))?;
 

--- a/rsky-graph/src/persistence.rs
+++ b/rsky-graph/src/persistence.rs
@@ -123,11 +123,26 @@ pub async fn load_from_lmdb(db_path: &str, graph: &FollowGraph) -> Result<usize,
     Ok(count)
 }
 
+/// Incremental save: only persists users in `graph.dirty_users` since the
+/// last successful save. The full O(N) snapshot is only used when the dirty
+/// set is empty AND LMDB is missing -- e.g. cold start from an empty data
+/// dir. After load_from_lmdb, dirty_users is empty and steady-state mutations
+/// re-mark it via add_follow/remove_follow, so per-save IO scales with
+/// recent write volume, not total graph size.
 pub async fn save_to_lmdb(db_path: &str, graph: &FollowGraph) -> Result<(), GraphError> {
     let path = Path::new(db_path);
+    let cold_start = !path.join("data.mdb").exists();
     if !path.exists() {
         std::fs::create_dir_all(path)
             .map_err(|e| GraphError::Other(format!("create dir failed: {e}")))?;
+    }
+
+    let dirty: Vec<u32> = graph.drain_dirty_users();
+    if dirty.is_empty() && !cold_start {
+        // Nothing changed since the last commit and the on-disk snapshot
+        // already exists. Skip opening LMDB entirely.
+        tracing::debug!("save: clean, no entries to persist");
+        return Ok(());
     }
 
     let env = unsafe {
@@ -155,7 +170,51 @@ pub async fn save_to_lmdb(db_path: &str, graph: &FollowGraph) -> Result<(), Grap
         .create_database(&mut wtxn, Some("followers"))
         .map_err(|e| GraphError::Other(format!("create db failed: {e}")))?;
 
-    // LMDB rejects empty keys with MDB_BAD_VALSIZE; one stray empty DID would abort the whole txn.
+    if cold_start && dirty.is_empty() {
+        // First-ever save with no in-memory mutations: snapshot everything
+        // already in the DashMaps so the on-disk file becomes a valid
+        // starting point for later incremental saves.
+        save_full(
+            graph,
+            &mut wtxn,
+            &did_uid_db,
+            &uid_did_db,
+            &following_db,
+            &followers_db,
+        )?;
+    } else {
+        save_dirty(
+            graph,
+            &dirty,
+            &mut wtxn,
+            &did_uid_db,
+            &uid_did_db,
+            &following_db,
+            &followers_db,
+        )?;
+    }
+
+    wtxn.commit()
+        .map_err(|e| GraphError::Other(format!("commit failed: {e}")))?;
+
+    tracing::debug!(
+        "saved {} dirty entries to LMDB ({} users total)",
+        dirty.len(),
+        graph.user_count()
+    );
+    Ok(())
+}
+
+/// Write all entries in the graph -- used only on cold start (no data.mdb yet)
+/// or by an explicit full-snapshot path. Linear in graph size.
+fn save_full(
+    graph: &FollowGraph,
+    wtxn: &mut heed::RwTxn<'_>,
+    did_uid_db: &StrDb,
+    uid_did_db: &U32Db,
+    following_db: &U32Db,
+    followers_db: &U32Db,
+) -> Result<(), GraphError> {
     let mut skipped_empty = 0u64;
     for entry in graph.did_to_uid.iter() {
         if entry.key().is_empty() {
@@ -164,7 +223,7 @@ pub async fn save_to_lmdb(db_path: &str, graph: &FollowGraph) -> Result<(), Grap
         }
         let uid_bytes = entry.value().to_ne_bytes();
         did_uid_db
-            .put(&mut wtxn, entry.key(), &uid_bytes)
+            .put(wtxn, entry.key(), &uid_bytes)
             .map_err(|e| GraphError::Other(format!("put did_uid failed: {e}")))?;
     }
     for entry in graph.uid_to_did.iter() {
@@ -173,14 +232,12 @@ pub async fn save_to_lmdb(db_path: &str, graph: &FollowGraph) -> Result<(), Grap
         }
         let did_bytes = entry.value().as_bytes();
         uid_did_db
-            .put(&mut wtxn, entry.key(), did_bytes)
+            .put(wtxn, entry.key(), did_bytes)
             .map_err(|e| GraphError::Other(format!("put uid_did failed: {e}")))?;
     }
     if skipped_empty > 0 {
         tracing::warn!("skipped {skipped_empty} empty-DID entries during persistence");
     }
-
-    // Save following bitmaps
     for entry in graph.following.iter() {
         let mut buf = Vec::new();
         entry
@@ -188,11 +245,9 @@ pub async fn save_to_lmdb(db_path: &str, graph: &FollowGraph) -> Result<(), Grap
             .serialize_into(&mut buf)
             .map_err(|e| GraphError::Other(format!("serialize following failed: {e}")))?;
         following_db
-            .put(&mut wtxn, entry.key(), &buf)
+            .put(wtxn, entry.key(), &buf)
             .map_err(|e| GraphError::Other(format!("put following failed: {e}")))?;
     }
-
-    // Save followers bitmaps
     for entry in graph.followers.iter() {
         let mut buf = Vec::new();
         entry
@@ -200,13 +255,67 @@ pub async fn save_to_lmdb(db_path: &str, graph: &FollowGraph) -> Result<(), Grap
             .serialize_into(&mut buf)
             .map_err(|e| GraphError::Other(format!("serialize followers failed: {e}")))?;
         followers_db
-            .put(&mut wtxn, entry.key(), &buf)
+            .put(wtxn, entry.key(), &buf)
             .map_err(|e| GraphError::Other(format!("put followers failed: {e}")))?;
     }
+    Ok(())
+}
 
-    wtxn.commit()
-        .map_err(|e| GraphError::Other(format!("commit failed: {e}")))?;
-
-    tracing::debug!("saved {} users to LMDB", graph.user_count());
+/// Write only the entries belonging to `dirty` UIDs. Linear in `dirty.len()`,
+/// independent of total graph size.
+fn save_dirty(
+    graph: &FollowGraph,
+    dirty: &[u32],
+    wtxn: &mut heed::RwTxn<'_>,
+    did_uid_db: &StrDb,
+    uid_did_db: &U32Db,
+    following_db: &U32Db,
+    followers_db: &U32Db,
+) -> Result<(), GraphError> {
+    let mut skipped_empty = 0u64;
+    for uid in dirty {
+        // Persist DID <-> UID for this user. uid_to_did is the source-of-truth
+        // for "what DID does this UID map to"; did_to_uid is its inverse.
+        if let Some(did_ref) = graph.uid_to_did.get(uid) {
+            let did = did_ref.value();
+            if did.is_empty() {
+                skipped_empty += 1;
+            } else {
+                did_uid_db
+                    .put(wtxn, did, &uid.to_ne_bytes())
+                    .map_err(|e| GraphError::Other(format!("put did_uid failed: {e}")))?;
+                uid_did_db
+                    .put(wtxn, uid, did.as_bytes())
+                    .map_err(|e| GraphError::Other(format!("put uid_did failed: {e}")))?;
+            }
+        }
+        // Following bitmap. Read-locks this DashMap shard; concurrent writes
+        // to the same UID block briefly. If the concurrent write arrives
+        // *after* this read, drain_dirty_users()'s pre-remove guarantees the
+        // UID is re-marked, so the next save catches up.
+        if let Some(bm_ref) = graph.following.get(uid) {
+            let mut buf = Vec::new();
+            bm_ref
+                .value()
+                .serialize_into(&mut buf)
+                .map_err(|e| GraphError::Other(format!("serialize following failed: {e}")))?;
+            following_db
+                .put(wtxn, uid, &buf)
+                .map_err(|e| GraphError::Other(format!("put following failed: {e}")))?;
+        }
+        if let Some(bm_ref) = graph.followers.get(uid) {
+            let mut buf = Vec::new();
+            bm_ref
+                .value()
+                .serialize_into(&mut buf)
+                .map_err(|e| GraphError::Other(format!("serialize followers failed: {e}")))?;
+            followers_db
+                .put(wtxn, uid, &buf)
+                .map_err(|e| GraphError::Other(format!("put followers failed: {e}")))?;
+        }
+    }
+    if skipped_empty > 0 {
+        tracing::warn!("skipped {skipped_empty} empty-DID entries during persistence");
+    }
     Ok(())
 }

--- a/rsky-graph/src/persistence.rs
+++ b/rsky-graph/src/persistence.rs
@@ -114,11 +114,12 @@ pub async fn load_from_lmdb(db_path: &str, graph: &FollowGraph) -> Result<usize,
     rtxn.commit()
         .map_err(|e| GraphError::Other(format!("read commit failed: {e}")))?;
 
-    // Rebuild bloom filters from loaded data
-    if count > 0 {
-        crate::bloom::build_all_bloom_filters(graph);
-    }
-
+    // Bloom filters are NOT rebuilt eagerly: at 25M+ users this is a
+    // multi-hour single-threaded CPU loop (each Bloom::new calls getrandom
+    // twice, plus 1.4B set() ops) that blocks api::serve and the bulk-load
+    // resume. blooms are repopulated incrementally as add_follow is called
+    // by firehose + bulk-load; absent blooms only forfeit the fast-reject
+    // optimization, the bitmap intersection still returns the correct answer.
     tracing::info!("loaded {count} users from LMDB, max_uid={max_uid}");
     Ok(count)
 }

--- a/rsky-graph/src/types.rs
+++ b/rsky-graph/src/types.rs
@@ -1,0 +1,16 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub enum GraphError {
+    Other(String),
+}
+
+impl fmt::Display for GraphError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GraphError::Other(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl std::error::Error for GraphError {}

--- a/rsky-graph/src/types.rs
+++ b/rsky-graph/src/types.rs
@@ -1,4 +1,6 @@
 use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::RwLock;
 
 #[derive(Debug)]
 pub enum GraphError {
@@ -14,3 +16,89 @@ impl fmt::Display for GraphError {
 }
 
 impl std::error::Error for GraphError {}
+
+/// Snapshot of bulk-load progress visible to API handlers so they can refuse
+/// queries about creators whose outgoing edges haven't been processed yet.
+/// Without this, partial graph state would silently produce wrong empty results.
+#[derive(Debug, Default)]
+pub struct LoadState {
+    complete: AtomicBool,
+    last_completed_creator: RwLock<String>,
+}
+
+impl LoadState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mark the keyset bulk-load fully complete. After this all creators are loaded.
+    pub fn mark_complete(&self) {
+        self.complete.store(true, Ordering::SeqCst);
+    }
+
+    /// Record that the keyset has finished processing every row whose `creator`
+    /// is at or below `did`. Called when the bulk-load observes the keyset
+    /// transition from one creator to the next.
+    pub fn record_creator_completed(&self, did: &str) {
+        let mut w = self.last_completed_creator.write().unwrap();
+        if did > w.as_str() {
+            *w = did.to_owned();
+        }
+    }
+
+    /// True if `did` is guaranteed to have its outgoing edges fully loaded.
+    pub fn creator_loaded(&self, did: &str) -> bool {
+        if self.complete.load(Ordering::SeqCst) {
+            return true;
+        }
+        let r = self.last_completed_creator.read().unwrap();
+        !r.is_empty() && did <= r.as_str()
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.complete.load(Ordering::SeqCst)
+    }
+
+    pub fn last_completed(&self) -> String {
+        self.last_completed_creator.read().unwrap().clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_state_says_nothing_loaded() {
+        let s = LoadState::new();
+        assert!(!s.creator_loaded("did:plc:abc"));
+        assert!(!s.creator_loaded(""));
+    }
+
+    #[test]
+    fn complete_means_everyone_loaded() {
+        let s = LoadState::new();
+        s.mark_complete();
+        assert!(s.creator_loaded("did:plc:zzz"));
+        assert!(s.creator_loaded("did:plc:aaa"));
+    }
+
+    #[test]
+    fn loaded_iff_did_le_last_completed() {
+        let s = LoadState::new();
+        s.record_creator_completed("did:plc:mmm");
+        assert!(s.creator_loaded("did:plc:aaa"));
+        assert!(s.creator_loaded("did:plc:mmm"));
+        assert!(!s.creator_loaded("did:plc:nnn"));
+        assert!(!s.creator_loaded("did:plc:zzz"));
+    }
+
+    #[test]
+    fn record_does_not_go_backwards() {
+        let s = LoadState::new();
+        s.record_creator_completed("did:plc:mmm");
+        s.record_creator_completed("did:plc:aaa"); // earlier alphabetically -- ignored
+        assert_eq!(s.last_completed(), "did:plc:mmm");
+        assert!(s.creator_loaded("did:plc:lll"));
+    }
+}

--- a/rsky-graph/tests/smoke.rs
+++ b/rsky-graph/tests/smoke.rs
@@ -1,0 +1,186 @@
+//! End-to-end smoke test against a real PostgreSQL.
+//!
+//! Validates the load-bearing claims that earlier silently broke in production:
+//! - Bulk-load updates `LoadState.last_completed_creator` at creator transitions.
+//! - LMDB persistence after a successful bulk-load is loadable on restart.
+//! - Resume from prior partial state preserves all edges (idempotent inserts).
+//!
+//! Set `SMOKE_DATABASE_URL` to a writable PG for these tests to run; without
+//! it they skip with a printed reason. CI should set it to a fresh PG (e.g.
+//! a service container). Locally:
+//!     `SMOKE_DATABASE_URL=postgres://postgres@localhost cargo test -p rsky-graph --test smoke`
+//!
+//! Tests run sequentially (`#[tokio::test(flavor = "current_thread")]`) and
+//! create+drop their own schema so they share one PG without colliding.
+
+use std::sync::Arc;
+
+use rsky_graph::bulk_load;
+use rsky_graph::graph::FollowGraph;
+use rsky_graph::persistence;
+use rsky_graph::types::LoadState;
+use tokio_postgres::NoTls;
+
+const TEST_FOLLOWS: &[(&str, &str)] = &[
+    ("did:plc:aaa", "did:plc:bbb"),
+    ("did:plc:aaa", "did:plc:ccc"),
+    ("did:plc:bbb", "did:plc:aaa"),
+    ("did:plc:bbb", "did:plc:ddd"),
+    ("did:plc:ccc", "did:plc:eee"),
+    ("did:plc:ddd", "did:plc:aaa"),
+    ("did:plc:eee", "did:plc:fff"),
+];
+
+/// Returns a database URL or None (skip the test). Each call appends a unique
+/// schema name via `?options=-csearch_path%3D<schema>` so concurrent tests
+/// don't collide.
+fn db_url() -> Option<String> {
+    std::env::var("SMOKE_DATABASE_URL").ok()
+}
+
+async fn populate_test_schema(url: &str) {
+    let (client, conn) = tokio_postgres::connect(url, NoTls)
+        .await
+        .expect("connect to smoke pg");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    // Drop + recreate so each test starts clean.
+    client
+        .batch_execute(
+            r#"
+            DROP SCHEMA IF EXISTS bsky CASCADE;
+            CREATE SCHEMA bsky;
+            CREATE TABLE bsky.follow (
+                creator TEXT NOT NULL,
+                "subjectDid" TEXT NOT NULL
+            );
+            "#,
+        )
+        .await
+        .expect("schema setup");
+
+    for (creator, subject) in TEST_FOLLOWS {
+        client
+            .execute(
+                "INSERT INTO bsky.follow (creator, \"subjectDid\") VALUES ($1, $2)",
+                &[creator, subject],
+            )
+            .await
+            .expect("insert");
+    }
+}
+
+#[tokio::test]
+async fn bulk_load_populates_graph_and_marks_state_complete() {
+    let Some(url) = db_url() else {
+        eprintln!("skipping: set SMOKE_DATABASE_URL to run");
+        return;
+    };
+    populate_test_schema(&url).await;
+
+    let graph = Arc::new(FollowGraph::new());
+    let state = Arc::new(LoadState::new());
+
+    bulk_load::bulk_load_keyset(&url, &graph, &state)
+        .await
+        .expect("bulk load");
+
+    assert_eq!(graph.follow_count(), TEST_FOLLOWS.len() as u64);
+    assert!(state.is_complete());
+    // After load, every creator must be flagged loaded.
+    assert!(state.creator_loaded("did:plc:aaa"));
+    assert!(state.creator_loaded("did:plc:eee"));
+    // Edges round-trip.
+    assert!(graph.is_following("did:plc:aaa", "did:plc:bbb"));
+    assert!(!graph.is_following("did:plc:aaa", "did:plc:zzz"));
+}
+
+#[tokio::test]
+async fn load_state_advances_with_keyset_cursor() {
+    let Some(url) = db_url() else {
+        eprintln!("skipping: set SMOKE_DATABASE_URL to run");
+        return;
+    };
+    populate_test_schema(&url).await;
+
+    // Use a low batch size so the cursor advances at fine granularity.
+    std::env::set_var("GRAPH_LOAD_BATCH_SIZE", "2");
+    std::env::set_var("GRAPH_LOAD_THROTTLE_MS", "0");
+
+    let graph = Arc::new(FollowGraph::new());
+    let state = Arc::new(LoadState::new());
+
+    bulk_load::bulk_load_keyset(&url, &graph, &state)
+        .await
+        .expect("bulk load");
+
+    assert!(state.is_complete());
+    let last = state.last_completed();
+    assert_eq!(last, "did:plc:eee", "last creator processed should be eee");
+
+    std::env::remove_var("GRAPH_LOAD_BATCH_SIZE");
+    std::env::remove_var("GRAPH_LOAD_THROTTLE_MS");
+}
+
+#[tokio::test]
+async fn persistence_round_trip_via_lmdb() {
+    let Some(url) = db_url() else {
+        eprintln!("skipping: set SMOKE_DATABASE_URL to run");
+        return;
+    };
+    populate_test_schema(&url).await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().to_str().unwrap().to_string();
+
+    {
+        let graph = Arc::new(FollowGraph::new());
+        let state = Arc::new(LoadState::new());
+        bulk_load::bulk_load_keyset(&url, &graph, &state)
+            .await
+            .expect("bulk load");
+        persistence::save_to_lmdb(&path, &graph)
+            .await
+            .expect("save");
+    }
+
+    // Fresh graph -- only loads from LMDB.
+    let graph2 = Arc::new(FollowGraph::new());
+    let count = persistence::load_from_lmdb(&path, &graph2)
+        .await
+        .expect("load");
+    assert!(count > 0, "should have loaded users from LMDB");
+    assert_eq!(graph2.follow_count(), TEST_FOLLOWS.len() as u64);
+    assert!(graph2.is_following("did:plc:aaa", "did:plc:bbb"));
+}
+
+#[tokio::test]
+async fn resume_skips_already_loaded_creators() {
+    let Some(url) = db_url() else {
+        eprintln!("skipping: set SMOKE_DATABASE_URL to run");
+        return;
+    };
+    populate_test_schema(&url).await;
+
+    // Pre-populate the graph as if a previous load partially completed
+    // through "did:plc:bbb"; the resume logic should pick up from there.
+    let graph = Arc::new(FollowGraph::new());
+    let state = Arc::new(LoadState::new());
+
+    // Simulate prior progress: aaa is fully loaded, bbb is partial.
+    graph.add_follow("did:plc:aaa", "did:plc:bbb");
+    graph.add_follow("did:plc:aaa", "did:plc:ccc");
+    graph.add_follow("did:plc:bbb", "did:plc:aaa");
+
+    bulk_load::bulk_load_keyset(&url, &graph, &state)
+        .await
+        .expect("bulk load");
+
+    // Final state must include all expected edges regardless of what was
+    // pre-loaded -- idempotent inserts make the resume safe.
+    assert_eq!(graph.follow_count(), TEST_FOLLOWS.len() as u64);
+    for (a, b) in TEST_FOLLOWS {
+        assert!(graph.is_following(a, b), "missing edge {a} -> {b}");
+    }
+}

--- a/rsky-graph/tests/smoke.rs
+++ b/rsky-graph/tests/smoke.rs
@@ -155,6 +155,69 @@ async fn persistence_round_trip_via_lmdb() {
     assert!(graph2.is_following("did:plc:aaa", "did:plc:bbb"));
 }
 
+/// Exercises the incremental save path without needing PG: start clean, do
+/// a cold-start save (full snapshot), modify a small subset, save again,
+/// and verify the second save only writes the dirty entries while leaving
+/// untouched data intact on disk.
+#[tokio::test]
+async fn incremental_save_only_writes_dirty_entries() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().to_str().unwrap().to_string();
+
+    // Phase 1: cold start. Build a graph with N edges and save.
+    let graph = Arc::new(FollowGraph::new());
+    for (a, b) in TEST_FOLLOWS {
+        graph.add_follow(a, b);
+    }
+    assert!(graph.dirty_count() > 0);
+    persistence::save_to_lmdb(&path, &graph)
+        .await
+        .expect("cold-start save");
+    // After save, dirty set is drained.
+    assert_eq!(graph.dirty_count(), 0);
+
+    // Phase 2: load into a fresh graph -- mimics process restart.
+    let g2 = Arc::new(FollowGraph::new());
+    persistence::load_from_lmdb(&path, &g2)
+        .await
+        .expect("load from disk");
+    // load_from_lmdb does NOT mark dirty -- the post-load graph mirrors disk.
+    assert_eq!(
+        g2.dirty_count(),
+        0,
+        "load_from_lmdb must not pollute dirty_users"
+    );
+    assert_eq!(g2.follow_count(), TEST_FOLLOWS.len() as u64);
+
+    // Phase 3: a single mutation on the loaded graph; save; reload again.
+    g2.add_follow("did:plc:zzz_new", "did:plc:aaa");
+    // Two new UIDs (zzz_new + aaa was already known).
+    let dirty_before_save = g2.dirty_count();
+    assert!(
+        (1..=2).contains(&dirty_before_save),
+        "expected 1-2 dirty UIDs, got {dirty_before_save}"
+    );
+    persistence::save_to_lmdb(&path, &g2)
+        .await
+        .expect("dirty save");
+    assert_eq!(g2.dirty_count(), 0);
+
+    // Phase 4: load into yet another fresh graph and confirm everything
+    // round-tripped: original edges PLUS the one new edge.
+    let g3 = Arc::new(FollowGraph::new());
+    persistence::load_from_lmdb(&path, &g3)
+        .await
+        .expect("load round-trip");
+    assert_eq!(g3.follow_count(), TEST_FOLLOWS.len() as u64 + 1);
+    for (a, b) in TEST_FOLLOWS {
+        assert!(g3.is_following(a, b), "lost untouched edge {a} -> {b}");
+    }
+    assert!(
+        g3.is_following("did:plc:zzz_new", "did:plc:aaa"),
+        "incremental save dropped the new edge"
+    );
+}
+
 #[tokio::test]
 async fn resume_skips_already_loaded_creators() {
     let Some(url) = db_url() else {

--- a/rsky-wintermute/src/config.rs
+++ b/rsky-wintermute/src/config.rs
@@ -105,6 +105,33 @@ pub const HANDLE_PRIORITY_WINDOW: Duration = Duration::from_secs(6 * 60 * 60); /
 // path only needs to run periodically to catch handle changes.
 pub const HANDLE_STALE_VALID_EVERY_N: u64 = 20;
 
+// Cap for `actor.handleResolveTries`. Once a row hits this many failures it is
+// retried at the maximum cooldown (currently 7 days). Fits in SMALLINT.
+pub const HANDLE_MAX_TRIES: i16 = 10;
+
+// Exponential backoff for failed handle resolutions, indexed by tries.
+// tries=0  -> immediate retry (new actor, never tried)
+// tries=1  -> 1 h
+// tries=2  -> 2 h
+// tries=3  -> 4 h
+// ...
+// tries>=7 -> 168 h (7 days, cap)
+//
+// Returning Duration::ZERO for tries=0 means new rows from the backfiller hit
+// the resolver as soon as they're picked up. Failed rows then back off so a
+// permanently-broken DID stops head-of-line blocking the queue.
+#[must_use]
+pub fn handle_retry_cooldown(tries: i16) -> Duration {
+    const SEVEN_DAYS_SECS: u64 = 168 * 60 * 60;
+    if tries <= 0 {
+        Duration::ZERO
+    } else {
+        let exp = u32::try_from(tries - 1).unwrap_or(0).min(30);
+        let secs = 3600u64.saturating_mul(1u64 << exp).min(SEVEN_DAYS_SECS);
+        Duration::from_secs(secs)
+    }
+}
+
 // Backfiller config - tunable via environment variables for 15B+ record backfills
 pub static WORKERS_BACKFILLER: LazyLock<usize> = LazyLock::new(|| {
     std::env::var("BACKFILLER_WORKERS")
@@ -172,3 +199,33 @@ pub static BACKFILLER_DB_POOL_SIZE: LazyLock<usize> = LazyLock::new(|| {
         .and_then(|s| s.parse().ok())
         .unwrap_or(32) // Default: 32 connections for backfiller (matches worker count)
 });
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cooldown_is_zero_for_fresh_rows() {
+        assert_eq!(handle_retry_cooldown(0), Duration::ZERO);
+        assert_eq!(handle_retry_cooldown(-1), Duration::ZERO);
+    }
+
+    #[test]
+    fn cooldown_doubles_per_try() {
+        assert_eq!(handle_retry_cooldown(1), Duration::from_secs(3600));
+        assert_eq!(handle_retry_cooldown(2), Duration::from_secs(2 * 3600));
+        assert_eq!(handle_retry_cooldown(3), Duration::from_secs(4 * 3600));
+        assert_eq!(handle_retry_cooldown(4), Duration::from_secs(8 * 3600));
+    }
+
+    #[test]
+    fn cooldown_caps_at_seven_days() {
+        let seven_days = Duration::from_secs(168 * 3600);
+        // 2^7 = 128h (still under cap), 2^8 = 256h (clamped to 168h).
+        assert_eq!(handle_retry_cooldown(8), Duration::from_secs(128 * 3600));
+        assert_eq!(handle_retry_cooldown(9), seven_days);
+        assert_eq!(handle_retry_cooldown(HANDLE_MAX_TRIES), seven_days);
+        assert_eq!(handle_retry_cooldown(HANDLE_MAX_TRIES + 5), seven_days);
+        assert_eq!(handle_retry_cooldown(i16::MAX), seven_days);
+    }
+}

--- a/rsky-wintermute/src/config.rs
+++ b/rsky-wintermute/src/config.rs
@@ -99,6 +99,12 @@ pub static HANDLE_RESOLUTION_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
 // Priority window for recently-indexed actors (resolve new actors faster)
 pub const HANDLE_PRIORITY_WINDOW: Duration = Duration::from_secs(6 * 60 * 60); // 6 hours
 
+// How often the handle-resolution loop folds in the (much larger) sweep over
+// stale non-NULL handles. Default: every 20th iteration -- the cheap NULL-handle
+// scans run every iteration and dominate the priority queue; the stale-revalidate
+// path only needs to run periodically to catch handle changes.
+pub const HANDLE_STALE_VALID_EVERY_N: u64 = 20;
+
 // Backfiller config - tunable via environment variables for 15B+ record backfills
 pub static WORKERS_BACKFILLER: LazyLock<usize> = LazyLock::new(|| {
     std::env::var("BACKFILLER_WORKERS")

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -3,9 +3,9 @@ mod tests;
 
 use crate::SHUTDOWN;
 use crate::config::{
-    DB_POOL_SIZE, HANDLE_PRIORITY_WINDOW, HANDLE_REINDEX_INTERVAL_INVALID,
-    HANDLE_REINDEX_INTERVAL_VALID, HANDLE_RESOLUTION_BATCH_SIZE, HANDLE_RESOLUTION_CONCURRENCY,
-    HANDLE_STALE_VALID_EVERY_N, IDENTITY_RESOLVER_TIMEOUT, INLINE_CONCURRENCY, WORKERS_INDEXER,
+    DB_POOL_SIZE, HANDLE_MAX_TRIES, HANDLE_REINDEX_INTERVAL_INVALID, HANDLE_REINDEX_INTERVAL_VALID,
+    HANDLE_RESOLUTION_BATCH_SIZE, HANDLE_RESOLUTION_CONCURRENCY, HANDLE_STALE_VALID_EVERY_N,
+    IDENTITY_RESOLVER_TIMEOUT, INLINE_CONCURRENCY, WORKERS_INDEXER, handle_retry_cooldown,
 };
 use crate::config::{INDEXER_BATCH_SIZE, INDEXER_BATCH_WORKERS};
 use crate::storage::Storage;
@@ -294,47 +294,41 @@ impl IndexerManager {
         include_stale_valid: bool,
     ) -> Result<Vec<String>, WintermuteError> {
         let client = self.pool_labels.get().await?;
-        let batch_size = i64::try_from(*HANDLE_RESOLUTION_BATCH_SIZE).unwrap_or(500);
+        let batch_size = *HANDLE_RESOLUTION_BATCH_SIZE;
+        let now = chrono::Utc::now();
+        let mut dids: Vec<String> = Vec::with_capacity(batch_size);
 
-        let stale_threshold_invalid = (chrono::Utc::now()
-            - chrono::Duration::from_std(HANDLE_REINDEX_INTERVAL_INVALID).unwrap_or_default())
-        .to_rfc3339();
-        let priority_window = (chrono::Utc::now()
-            - chrono::Duration::from_std(HANDLE_PRIORITY_WINDOW).unwrap_or_default())
-        .to_rfc3339();
-
-        // Query A: NULL handles. Two short queries against actor_null_handle_idx
-        // (the partial index on indexedAt WHERE handle IS NULL) -- one for recent
-        // priority-window actors (newest first), one for older actors (oldest first).
-        // These each do a bounded index range scan; together they replace the prior
-        // single OR/CASE query that the planner could not satisfy from one index.
-        let recent_half = batch_size / 2;
-        let older_half = batch_size - recent_half;
-
-        let recent_rows = client
-            .query(
-                "SELECT did FROM actor \
-                 WHERE handle IS NULL AND \"indexedAt\" >= $1 AND \"indexedAt\" < $2 \
-                 ORDER BY \"indexedAt\" DESC \
-                 LIMIT $3",
-                &[&priority_window, &stale_threshold_invalid, &recent_half],
-            )
-            .await?;
-
-        let older_rows = client
-            .query(
-                "SELECT did FROM actor \
-                 WHERE handle IS NULL AND \"indexedAt\" < $1 \
-                 ORDER BY \"indexedAt\" ASC \
-                 LIMIT $2",
-                &[&priority_window, &older_half],
-            )
-            .await?;
-
-        let cap = usize::try_from(batch_size).unwrap_or(0);
-        let mut dids: Vec<String> = Vec::with_capacity(cap);
-        dids.extend(recent_rows.iter().map(|row| row.get::<_, String>("did")));
-        dids.extend(older_rows.iter().map(|row| row.get::<_, String>("did")));
+        // Per-tries bucketed scan. Lower-tries buckets drain first so brand-new
+        // actors (tries=0) always get fastest service. Each bucket's predicate
+        // matches `actor_handle_retry_idx (handleResolveTries, indexedAt)
+        // WHERE handle IS NULL`, so the scan is index-only.
+        //
+        // Crucially, every failure path bumps `handleResolveTries` and
+        // `indexedAt`, so a row that just failed exits the tries=N bucket and
+        // re-enters bucket N+1 with a longer cooldown. This is what prevents the
+        // head-of-line blocking pattern where 28k+ permanently-broken DIDs
+        // (e.g. deleted accounts) starve the queue indefinitely.
+        for tries in 0..=HANDLE_MAX_TRIES {
+            let need = batch_size.saturating_sub(dids.len());
+            if need == 0 {
+                break;
+            }
+            let cooldown = handle_retry_cooldown(tries);
+            let threshold =
+                (now - chrono::Duration::from_std(cooldown).unwrap_or_default()).to_rfc3339();
+            let limit = i64::try_from(need).unwrap_or(i64::MAX);
+            let rows = client
+                .query(
+                    "SELECT did FROM actor \
+                     WHERE handle IS NULL \
+                       AND \"handleResolveTries\" = $1 \
+                       AND \"indexedAt\" < $2 \
+                     ORDER BY \"indexedAt\" ASC LIMIT $3",
+                    &[&tries, &threshold, &limit],
+                )
+                .await?;
+            dids.extend(rows.iter().map(|row| row.get::<_, String>("did")));
+        }
 
         // Query B: stale non-NULL handles. Run only at a slower cadence -- this
         // path uses actor_indexed_at_idx (full table indexed, much larger) and is
@@ -343,19 +337,41 @@ impl IndexerManager {
             let stale_threshold_valid = (chrono::Utc::now()
                 - chrono::Duration::from_std(HANDLE_REINDEX_INTERVAL_VALID).unwrap_or_default())
             .to_rfc3339();
+            let limit = i64::try_from(batch_size).unwrap_or(i64::MAX);
             let stale_rows = client
                 .query(
                     "SELECT did FROM actor \
                      WHERE handle IS NOT NULL AND \"indexedAt\" < $1 \
                      ORDER BY \"indexedAt\" ASC \
                      LIMIT $2",
-                    &[&stale_threshold_valid, &batch_size],
+                    &[&stale_threshold_valid, &limit],
                 )
                 .await?;
             dids.extend(stale_rows.iter().map(|row| row.get::<_, String>("did")));
         }
 
         Ok(dids)
+    }
+
+    /// Bump `handleResolveTries` (capped at `HANDLE_MAX_TRIES`) and refresh
+    /// `indexedAt` so the row is excluded from the resolver until its cooldown
+    /// elapses. Used on every failure path in `index_handle` and
+    /// `process_identity_event` to prevent retry storms on broken DIDs.
+    pub(crate) async fn bump_handle_failure(
+        client: &deadpool_postgres::Client,
+        did: &str,
+        timestamp: &str,
+    ) -> Result<(), WintermuteError> {
+        client
+            .execute(
+                "UPDATE actor \
+                 SET \"indexedAt\" = $2, \
+                     \"handleResolveTries\" = LEAST(\"handleResolveTries\" + 1, $3) \
+                 WHERE did = $1",
+                &[&did, &timestamp, &HANDLE_MAX_TRIES],
+            )
+            .await?;
+        Ok(())
     }
 
     async fn process_firehose_live_loop(&self) {
@@ -947,10 +963,12 @@ impl IndexerManager {
                 Ok(Some(doc)) => doc,
                 Ok(None) => {
                     tracing::debug!("DID not found: {did}");
+                    Self::bump_handle_failure(client, did, timestamp).await?;
                     return Ok(false);
                 }
                 Err(e) => {
                     tracing::debug!("failed to resolve DID {did}: {e}");
+                    Self::bump_handle_failure(client, did, timestamp).await?;
                     return Ok(false);
                 }
             }
@@ -967,13 +985,8 @@ impl IndexerManager {
             Some(h) if !h.is_empty() => h,
             _ => {
                 tracing::debug!("no handle found in DID document for {did}");
-                // Update actor indexedAt even if no handle found
-                client
-                    .execute(
-                        "UPDATE actor SET \"indexedAt\" = $2 WHERE did = $1",
-                        &[&did, &timestamp],
-                    )
-                    .await?;
+                // No alsoKnownAs is a definitive negative -- treat as a failed try.
+                Self::bump_handle_failure(client, did, timestamp).await?;
                 return Ok(false);
             }
         };
@@ -985,16 +998,22 @@ impl IndexerManager {
                 Ok(Some(resolved_did)) => resolved_did,
                 Ok(None) => {
                     tracing::debug!("handle {handle} does not resolve to a DID");
+                    // Handle does not exist -- null it out and record the failure.
                     client
                         .execute(
-                            "UPDATE actor SET handle = NULL, \"indexedAt\" = $2 WHERE did = $1",
-                            &[&did, &timestamp],
+                            "UPDATE actor \
+                             SET handle = NULL, \
+                                 \"indexedAt\" = $2, \
+                                 \"handleResolveTries\" = LEAST(\"handleResolveTries\" + 1, $3) \
+                             WHERE did = $1",
+                            &[&did, &timestamp, &HANDLE_MAX_TRIES],
                         )
                         .await?;
                     return Ok(false);
                 }
                 Err(e) => {
                     tracing::debug!("failed to resolve handle {handle}: {e}");
+                    Self::bump_handle_failure(client, did, timestamp).await?;
                     return Ok(false);
                 }
             }
@@ -1018,17 +1037,34 @@ impl IndexerManager {
                 .await?;
         }
 
-        // Update actor with handle
-        client
-            .execute(
-                "INSERT INTO actor (did, handle, \"indexedAt\")
-                 VALUES ($1, $2, $3)
-                 ON CONFLICT (did) DO UPDATE SET
-                   handle = EXCLUDED.handle,
-                   \"indexedAt\" = EXCLUDED.\"indexedAt\"",
-                &[&did, &verified_handle, &timestamp],
-            )
-            .await?;
+        // Update actor with handle. Reset tries on success; bump on bidirectional
+        // mismatch (verified_handle = None) so we don't keep hammering a DID
+        // whose handle was hijacked by someone else.
+        if verified_handle.is_some() {
+            client
+                .execute(
+                    "INSERT INTO actor (did, handle, \"indexedAt\", \"handleResolveTries\") \
+                     VALUES ($1, $2, $3, 0) \
+                     ON CONFLICT (did) DO UPDATE SET \
+                       handle = EXCLUDED.handle, \
+                       \"indexedAt\" = EXCLUDED.\"indexedAt\", \
+                       \"handleResolveTries\" = 0",
+                    &[&did, &verified_handle, &timestamp],
+                )
+                .await?;
+        } else {
+            client
+                .execute(
+                    "INSERT INTO actor (did, handle, \"indexedAt\", \"handleResolveTries\") \
+                     VALUES ($1, NULL, $2, 1) \
+                     ON CONFLICT (did) DO UPDATE SET \
+                       handle = NULL, \
+                       \"indexedAt\" = EXCLUDED.\"indexedAt\", \
+                       \"handleResolveTries\" = LEAST(actor.\"handleResolveTries\" + 1, $3)",
+                    &[&did, &timestamp, &HANDLE_MAX_TRIES],
+                )
+                .await?;
+        }
 
         Ok(verified_handle.is_some())
     }

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -5,7 +5,7 @@ use crate::SHUTDOWN;
 use crate::config::{
     DB_POOL_SIZE, HANDLE_PRIORITY_WINDOW, HANDLE_REINDEX_INTERVAL_INVALID,
     HANDLE_REINDEX_INTERVAL_VALID, HANDLE_RESOLUTION_BATCH_SIZE, HANDLE_RESOLUTION_CONCURRENCY,
-    IDENTITY_RESOLVER_TIMEOUT, INLINE_CONCURRENCY, WORKERS_INDEXER,
+    HANDLE_STALE_VALID_EVERY_N, IDENTITY_RESOLVER_TIMEOUT, INLINE_CONCURRENCY, WORKERS_INDEXER,
 };
 use crate::config::{INDEXER_BATCH_SIZE, INDEXER_BATCH_WORKERS};
 use crate::storage::Storage;
@@ -199,8 +199,14 @@ impl IndexerManager {
                 break;
             }
 
-            // Query actors with NULL handle or stale indexedAt
-            let dids_to_resolve = match self.get_actors_needing_handle_resolution().await {
+            // Run the cheap NULL-handle queries every iteration; fold in the more
+            // expensive "stale non-NULL" sweep only every Nth iteration so the
+            // background loop does not dominate PG IO.
+            let include_stale_valid = batch_count % HANDLE_STALE_VALID_EVERY_N == 0;
+            let dids_to_resolve = match self
+                .get_actors_needing_handle_resolution(include_stale_valid)
+                .await
+            {
                 Ok(dids) => dids,
                 Err(e) => {
                     tracing::warn!("failed to get actors needing handle resolution: {e}");
@@ -283,53 +289,72 @@ impl IndexerManager {
         }
     }
 
-    async fn get_actors_needing_handle_resolution(&self) -> Result<Vec<String>, WintermuteError> {
+    async fn get_actors_needing_handle_resolution(
+        &self,
+        include_stale_valid: bool,
+    ) -> Result<Vec<String>, WintermuteError> {
         let client = self.pool_labels.get().await?;
         let batch_size = i64::try_from(*HANDLE_RESOLUTION_BATCH_SIZE).unwrap_or(500);
 
-        // Get actors with NULL handle or stale indexedAt
-        // Priority order:
-        // 1. Recently-indexed actors with NULL handle (within priority window) - newest first
-        // 2. Older actors with NULL handle - oldest first
-        // 3. Actors with stale valid handles - oldest first
         let stale_threshold_invalid = (chrono::Utc::now()
             - chrono::Duration::from_std(HANDLE_REINDEX_INTERVAL_INVALID).unwrap_or_default())
-        .to_rfc3339();
-        let stale_threshold_valid = (chrono::Utc::now()
-            - chrono::Duration::from_std(HANDLE_REINDEX_INTERVAL_VALID).unwrap_or_default())
         .to_rfc3339();
         let priority_window = (chrono::Utc::now()
             - chrono::Duration::from_std(HANDLE_PRIORITY_WINDOW).unwrap_or_default())
         .to_rfc3339();
 
-        // Query with priority: recent NULL handles first (newest), then older NULL handles (oldest), then stale valid handles
-        let rows = client
+        // Query A: NULL handles. Two short queries against actor_null_handle_idx
+        // (the partial index on indexedAt WHERE handle IS NULL) -- one for recent
+        // priority-window actors (newest first), one for older actors (oldest first).
+        // These each do a bounded index range scan; together they replace the prior
+        // single OR/CASE query that the planner could not satisfy from one index.
+        let recent_half = batch_size / 2;
+        let older_half = batch_size - recent_half;
+
+        let recent_rows = client
             .query(
-                "SELECT did FROM actor
-                 WHERE (handle IS NULL AND \"indexedAt\" < $1)
-                    OR (handle IS NOT NULL AND \"indexedAt\" < $2)
-                 ORDER BY
-                   CASE
-                     WHEN handle IS NULL AND \"indexedAt\" >= $3 THEN 0  -- Recent NULL: highest priority
-                     WHEN handle IS NULL THEN 1                          -- Older NULL: second priority
-                     ELSE 2                                              -- Stale valid: lowest priority
-                   END,
-                   CASE
-                     WHEN handle IS NULL AND \"indexedAt\" >= $3 THEN \"indexedAt\"  -- Recent: newest first
-                     ELSE NULL
-                   END DESC NULLS LAST,
-                   \"indexedAt\" ASC  -- Older entries: oldest first
-                 LIMIT $4",
-                &[
-                    &stale_threshold_invalid,
-                    &stale_threshold_valid,
-                    &priority_window,
-                    &batch_size,
-                ],
+                "SELECT did FROM actor \
+                 WHERE handle IS NULL AND \"indexedAt\" >= $1 AND \"indexedAt\" < $2 \
+                 ORDER BY \"indexedAt\" DESC \
+                 LIMIT $3",
+                &[&priority_window, &stale_threshold_invalid, &recent_half],
             )
             .await?;
 
-        let dids: Vec<String> = rows.iter().map(|row| row.get("did")).collect();
+        let older_rows = client
+            .query(
+                "SELECT did FROM actor \
+                 WHERE handle IS NULL AND \"indexedAt\" < $1 \
+                 ORDER BY \"indexedAt\" ASC \
+                 LIMIT $2",
+                &[&priority_window, &older_half],
+            )
+            .await?;
+
+        let cap = usize::try_from(batch_size).unwrap_or(0);
+        let mut dids: Vec<String> = Vec::with_capacity(cap);
+        dids.extend(recent_rows.iter().map(|row| row.get::<_, String>("did")));
+        dids.extend(older_rows.iter().map(|row| row.get::<_, String>("did")));
+
+        // Query B: stale non-NULL handles. Run only at a slower cadence -- this
+        // path uses actor_indexed_at_idx (full table indexed, much larger) and is
+        // not user-visible, so we don't need it on every iteration.
+        if include_stale_valid {
+            let stale_threshold_valid = (chrono::Utc::now()
+                - chrono::Duration::from_std(HANDLE_REINDEX_INTERVAL_VALID).unwrap_or_default())
+            .to_rfc3339();
+            let stale_rows = client
+                .query(
+                    "SELECT did FROM actor \
+                     WHERE handle IS NOT NULL AND \"indexedAt\" < $1 \
+                     ORDER BY \"indexedAt\" ASC \
+                     LIMIT $2",
+                    &[&stale_threshold_valid, &batch_size],
+                )
+                .await?;
+            dids.extend(stale_rows.iter().map(|row| row.get::<_, String>("did")));
+        }
+
         Ok(dids)
     }
 

--- a/rsky-wintermute/src/ingester/mod.rs
+++ b/rsky-wintermute/src/ingester/mod.rs
@@ -913,6 +913,7 @@ impl IngesterManager {
         timestamp: &str,
         handle_hint: Option<&str>,
     ) -> Result<(), WintermuteError> {
+        use crate::config::HANDLE_MAX_TRIES;
         use rsky_identity::IdResolver;
         use rsky_identity::types::IdentityResolverOpts;
 
@@ -948,11 +949,24 @@ impl IngesterManager {
                             }
                             _ => {
                                 tracing::debug!(
-                                    "handle {} does not resolve back to {} - setting handle to null",
+                                    "handle {} does not resolve back to {} - bumping retry count",
                                     h,
                                     did
                                 );
-                                return Ok(()); // Don't update if handle doesn't verify
+                                // Verify-back failed: bump retries so we don't
+                                // re-attempt this DID every cycle. The sweep
+                                // loop will revisit after the per-tries cooldown.
+                                let client = pool.get().await?;
+                                client
+                                    .execute(
+                                        "UPDATE actor \
+                                         SET \"indexedAt\" = $2, \
+                                             \"handleResolveTries\" = LEAST(\"handleResolveTries\" + 1, $3) \
+                                         WHERE did = $1",
+                                        &[&did, &timestamp, &HANDLE_MAX_TRIES],
+                                    )
+                                    .await?;
+                                return Ok(());
                             }
                         }
                     }
@@ -961,20 +975,46 @@ impl IngesterManager {
                 }
                 Ok(None) => {
                     tracing::warn!("DID {} not found", did);
+                    let client = pool.get().await?;
+                    client
+                        .execute(
+                            "UPDATE actor \
+                             SET \"indexedAt\" = $2, \
+                                 \"handleResolveTries\" = LEAST(\"handleResolveTries\" + 1, $3) \
+                             WHERE did = $1",
+                            &[&did, &timestamp, &HANDLE_MAX_TRIES],
+                        )
+                        .await?;
                     return Ok(());
                 }
                 Err(e) => {
                     tracing::warn!("failed to resolve DID {}: {}", did, e);
-                    return Ok(()); // Don't fail on resolution errors, just skip
+                    // Transient resolver error: bump anyway. A real outage
+                    // would otherwise wedge the queue indefinitely.
+                    let client = pool.get().await?;
+                    client
+                        .execute(
+                            "UPDATE actor \
+                             SET \"indexedAt\" = $2, \
+                                 \"handleResolveTries\" = LEAST(\"handleResolveTries\" + 1, $3) \
+                             WHERE did = $1",
+                            &[&did, &timestamp, &HANDLE_MAX_TRIES],
+                        )
+                        .await?;
+                    return Ok(());
                 }
             }
         };
 
-        // Update actor table
+        // Update actor table. Reset tries on success.
         let client = pool.get().await?;
         let result = client
             .execute(
-                "UPDATE actor SET handle = $1, \"indexedAt\" = $2 WHERE did = $3",
+                "UPDATE actor \
+                 SET handle = $1, \
+                     \"indexedAt\" = $2, \
+                     \"handleResolveTries\" = 0 \
+                 WHERE did = $3",
                 &[&handle, &timestamp, &did],
             )
             .await?;


### PR DESCRIPTION
## Summary

rsky-graph maintains an in-memory follow graph (RoaringBitmap per user, persisted to LMDB) so mutual-followers queries are sub-millisecond instead of a Postgres self-JOIN. This change makes the periodic LMDB save O(dirty users) via a `DashSet<u32>` populated in `add_follow`/`remove_follow` and drained per save, and drops the eager bloom-filter rebuild from `load_from_lmdb` since blooms can be repopulated incrementally as `add_follow` runs.

## Test plan

- [ ] `cargo fmt -p rsky-graph` clean
- [ ] `cargo clippy -p rsky-graph --all-targets` no new warnings
- [ ] `cargo test -p rsky-graph --lib` passes (includes 6 new tests in `graph::tests` covering dirty-tracking semantics)
- [ ] `cargo test -p rsky-graph --test smoke` passes (includes new `incremental_save_only_writes_dirty_entries` round-trip)
- [ ] `cargo build --release -p rsky-graph` clean