### PR TITLE
fix(rsky-pds): clone exact PR commit so new workspace members are included

### DIFF
--- a/.github/scripts/determine-workspace-members.sh
+++ b/.github/scripts/determine-workspace-members.sh
@@ -28,8 +28,8 @@ WORKSPACE_MEMBERS=()
 
 # Look for members section in Cargo.toml
 if grep -q '\[workspace\]' Cargo.toml; then
-  # Extract the members section
-  MEMBERS_SECTION=$(sed -n '/\[workspace\]/,/\[/p' Cargo.toml | grep -A 20 'members.*=' | grep -v '^\[')
+  # Extract the members array (from 'members = [' through the closing ']')
+  MEMBERS_SECTION=$(sed -n '/^members[[:space:]]*=[[:space:]]*\[/,/^]/p' Cargo.toml)
   
   # Extract member paths - handle both array and table formats
   if echo "$MEMBERS_SECTION" | grep -q 'members.*=.*\['; then

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -211,6 +211,7 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: COMMIT_SHA=${{ github.event.pull_request.head.sha || github.sha }}
           # Disable cache for forks to avoid permission issues
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: ""
@@ -227,6 +228,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: COMMIT_SHA=${{ github.event.pull_request.head.sha || github.sha }}
           sbom: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max

--- a/rsky-feedgen/src/apis/mod.rs
+++ b/rsky-feedgen/src/apis/mod.rs
@@ -1314,6 +1314,7 @@ mod tests {
                     sponsored_post_uri: "at://did:example/sponsored-post".to_string(),
                     sponsored_post_probability: 1.0,
                     trending_percentile_min: 0.9,
+                    pinned_post_uri: String::new(),
                 };
                 let rocket = before(config.clone());
 
@@ -1373,6 +1374,7 @@ mod tests {
                     sponsored_post_uri: "at://did:example/sponsored-post".to_string(),
                     sponsored_post_probability: 1.0,
                     trending_percentile_min: 0.9,
+                    pinned_post_uri: String::new(),
                 };
                 let rocket = before(config.clone());
 
@@ -1431,6 +1433,7 @@ mod tests {
                     sponsored_post_uri: "at://did:example/sponsored-post".to_string(),
                     sponsored_post_probability: 1.0,
                     trending_percentile_min: 0.9,
+                    pinned_post_uri: String::new(),
                 };
                 let rocket = before(config.clone());
 
@@ -1490,6 +1493,7 @@ mod tests {
                     sponsored_post_uri: "at://did:example/sponsored-post".to_string(),
                     sponsored_post_probability: 0.5,
                     trending_percentile_min: 0.9,
+                    pinned_post_uri: String::new(),
                 };
                 let rocket = before(config.clone());
 
@@ -1561,6 +1565,7 @@ mod tests {
                     sponsored_post_uri: "at://did:example/sponsored-post".to_string(),
                     sponsored_post_probability: 1.0,
                     trending_percentile_min: 0.9,
+                    pinned_post_uri: String::new(),
                 };
                 let rocket = before(config.clone());
 

--- a/rsky-pds/Dockerfile
+++ b/rsky-pds/Dockerfile
@@ -2,13 +2,13 @@
 # https://hub.docker.com/_/rust
 FROM rust AS builder
 
-# Copy local code to the container image.
+# Clone the exact commit under test so the workspace always matches the PR
+ARG COMMIT_SHA=main
 WORKDIR /usr/src/rsky
-RUN git clone --depth 1 https://github.com/blacksky-algorithms/rsky.git .
-# We can swap the line above for the lines below once we have stronger versioning
-# per workspace member
-# RUN git clone --depth 1 https://github.com/blacksky-algorithms/rsky.git . && \
-#     git checkout <TBD when we have stronger versioning>
+RUN git init . && \
+    git remote add origin https://github.com/blacksky-algorithms/rsky.git && \
+    git fetch --depth 1 origin ${COMMIT_SHA} && \
+    git checkout FETCH_HEAD
 
 
 # Create an empty src directory to trick Cargo into thinking it's a valid Rust project

--- a/rsky-pds/src/actor_store/mod.rs
+++ b/rsky-pds/src/actor_store/mod.rs
@@ -108,7 +108,7 @@ impl ActorStore {
         let commit = Repo::format_init_commit(
             self.storage.clone(),
             self.did.clone(),
-            *keypair,
+            keypair,
             Some(write_ops),
         )
         .await?;
@@ -143,7 +143,7 @@ impl ActorStore {
         let commit = Repo::format_init_commit(
             self.storage.clone(),
             self.did.clone(),
-            *keypair,
+            keypair,
             Some(write_ops),
         )
         .await?;
@@ -340,7 +340,7 @@ impl ActorStore {
                 .collect::<Result<Vec<RecordWriteOp>>>()?;
 
             let mut commit = repo
-                .format_commit(RecordWriteEnum::List(write_ops), *PDS_REPO_SIGNING_KEYPAIR)
+                .format_commit(RecordWriteEnum::List(write_ops), &*PDS_REPO_SIGNING_KEYPAIR)
                 .await?;
 
             // find blocks that would be deleted but are referenced by another record


### PR DESCRIPTION
## Summary

- Replaces `git clone --depth 1 ... main` with `ARG COMMIT_SHA` + `git init/fetch/checkout FETCH_HEAD` so the Docker build always clones the exact commit under test
- Passes `COMMIT_SHA=${{ github.event.pull_request.head.sha || github.sha }}` as a build-arg in both the fork and non-fork build steps in `rust.yml`

## Why

When a PR adds a new workspace member (e.g. `rsky-graph`), the old approach cloned `origin/main`, which doesn't have that member yet. Cargo then failed to resolve the workspace because `Cargo.toml` referenced a crate directory that didn't exist. Cloning the specific PR commit ensures the workspace is self-consistent.

## Test plan

- [ ] Re-run the `docker-build (rsky-pds)` job on PR #187 — should resolve the `cargo build` exit code 101 failure
- [ ] Verify the `COMMIT_SHA` arg falls back gracefully to `main` for manual/local builds (no arg passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)