### PR TITLE
fix(docker): clone exact PR commit in firehose and jetstream-subscriber Dockerfiles

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -211,6 +211,7 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: COMMIT_SHA=${{ github.event.pull_request.head.sha || github.sha }}
           # Disable cache for forks to avoid permission issues
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: ""
@@ -227,6 +228,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: COMMIT_SHA=${{ github.event.pull_request.head.sha || github.sha }}
           sbom: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max

--- a/rsky-firehose/Dockerfile
+++ b/rsky-firehose/Dockerfile
@@ -2,13 +2,13 @@
 # https://hub.docker.com/_/rust
 FROM rust AS builder
 
-# Copy local code to the container image.
+# Clone the exact commit under test so the workspace always matches the PR
+ARG COMMIT_SHA=main
 WORKDIR /usr/src/rsky
-RUN git clone --depth 1 https://github.com/blacksky-algorithms/rsky.git .
-# We can swap the line above for the lines below once we have stronger versioning
-# per workspace member
-# RUN git clone --depth 1 https://github.com/blacksky-algorithms/rsky.git . && \
-#     git checkout <TBD when we have stronger versioning>
+RUN git init . && \
+    git remote add origin https://github.com/blacksky-algorithms/rsky.git && \
+    git fetch --depth 1 origin ${COMMIT_SHA} && \
+    git checkout FETCH_HEAD
 
 # Create an empty src directory to trick Cargo into thinking it's a valid Rust project
 RUN mkdir -p rsky-firehose/src && echo "fn main() {}" > rsky-firehose/src/main.rs

--- a/rsky-jetstream-subscriber/Dockerfile
+++ b/rsky-jetstream-subscriber/Dockerfile
@@ -2,13 +2,13 @@
 # https://hub.docker.com/_/rust
 FROM rust AS builder
 
-# Copy local code to the container image.
+# Clone the exact commit under test so the workspace always matches the PR
+ARG COMMIT_SHA=main
 WORKDIR /usr/src/rsky
-RUN git clone --depth 1 https://github.com/blacksky-algorithms/rsky.git .
-# We can swap the line above for the lines below once we have stronger versioning
-# per workspace member
-# RUN git clone --depth 1 https://github.com/blacksky-algorithms/rsky.git . && \
-#     git checkout <TBD when we have stronger versioning>
+RUN git init . && \
+    git remote add origin https://github.com/blacksky-algorithms/rsky.git && \
+    git fetch --depth 1 origin ${COMMIT_SHA} && \
+    git checkout FETCH_HEAD
 
 # Create an empty src directory to trick Cargo into thinking it's a valid Rust project
 RUN mkdir -p rsky-jetstream-subscriber/src && echo "fn main() {}" > rsky-jetstream-subscriber/src/main.rs


### PR DESCRIPTION
## Summary

- Applies the same `ARG COMMIT_SHA` fix from #189 to `rsky-firehose/Dockerfile` and `rsky-jetstream-subscriber/Dockerfile`
- Both previously cloned `origin/main`, which would fail if a PR added a new workspace member not yet on main
- Also adds `build-args: COMMIT_SHA=...` to both build steps in `rust.yml` (the workflow change from #189 only lands on the feature branch; this brings it to main)

## Why

These three Dockerfiles share the same git-clone pattern. Any PR that adds a new `Cargo.toml` workspace member would cause all of them to fail at `cargo build` because the cloned workspace wouldn't include the new member directory.

## Test plan

- [ ] Confirm `docker-build (rsky-firehose)` and `docker-build (rsky-jetstream-subscriber)` pass on this PR
- [ ] After merge, confirm a subsequent PR that adds a workspace member no longer breaks these builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)