### PR TITLE
rsky-wintermute: configurable record collection allowlist

### DIFF
--- a/rsky-wintermute/src/backfiller/mod.rs
+++ b/rsky-wintermute/src/backfiller/mod.rs
@@ -340,7 +340,7 @@ impl BackfillerManager {
                 continue;
             };
 
-            if !collection.starts_with("app.bsky.") && !collection.starts_with("chat.bsky.") {
+            if !crate::config::ingest_collection_allowed(collection) {
                 metrics::BACKFILLER_RECORDS_FILTERED_TOTAL.inc();
                 continue;
             }

--- a/rsky-wintermute/src/bin/direct_index.rs
+++ b/rsky-wintermute/src/bin/direct_index.rs
@@ -193,8 +193,7 @@ async fn process_did(
         let collection = uri.get_collection();
         let rkey = uri.get_rkey();
 
-        // Filter to bsky/chat records
-        if !collection.starts_with("app.bsky.") && !collection.starts_with("chat.bsky.") {
+        if !rsky_wintermute::config::ingest_collection_allowed(&collection) {
             skipped_count += 1;
             continue;
         }

--- a/rsky-wintermute/src/config.rs
+++ b/rsky-wintermute/src/config.rs
@@ -166,3 +166,95 @@ pub static BACKFILLER_DB_POOL_SIZE: LazyLock<usize> = LazyLock::new(|| {
         .and_then(|s| s.parse().ok())
         .unwrap_or(32) // Default: 32 connections for backfiller (matches worker count)
 });
+
+// Comma-separated NSID prefixes (e.g. "app.bsky.,chat.bsky.,site.standard.") allowed in the record store. Empty = unset.
+pub static RECORD_COLLECTION_ALLOWLIST: LazyLock<Vec<String>> = LazyLock::new(|| {
+    std::env::var("RECORD_COLLECTION_ALLOWLIST")
+        .ok()
+        .map(|s| {
+            s.split(',')
+                .map(|p| p.trim().to_owned())
+                .filter(|p| !p.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+});
+
+const LEGACY_INGEST_PREFIXES: [&str; 2] = ["app.bsky.", "chat.bsky."];
+
+fn record_allowed(allow: &[String], collection: &str) -> bool {
+    allow.is_empty() || allow.iter().any(|p| collection.starts_with(p.as_str()))
+}
+
+fn ingest_allowed(allow: &[String], collection: &str) -> bool {
+    if allow.is_empty() {
+        LEGACY_INGEST_PREFIXES
+            .iter()
+            .any(|p| collection.starts_with(p))
+    } else {
+        allow.iter().any(|p| collection.starts_with(p.as_str()))
+    }
+}
+
+// Live indexer: unset allowlist allows all collections.
+#[must_use]
+pub fn record_collection_allowed(collection: &str) -> bool {
+    record_allowed(&RECORD_COLLECTION_ALLOWLIST, collection)
+}
+
+// Backfiller/direct-index: unset allowlist falls back to the legacy bsky/chat filter.
+#[must_use]
+pub fn ingest_collection_allowed(collection: &str) -> bool {
+    ingest_allowed(&RECORD_COLLECTION_ALLOWLIST, collection)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn prefixes(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    #[test]
+    fn record_allowed_empty_allows_everything() {
+        let allow: Vec<String> = Vec::new();
+        assert!(record_allowed(&allow, "app.bsky.feed.post"));
+        assert!(record_allowed(&allow, "com.whtwnd.blog.entry"));
+    }
+
+    #[test]
+    fn record_allowed_filters_by_prefix() {
+        let allow = prefixes(&["app.bsky.", "chat.bsky.", "site.standard."]);
+        assert!(record_allowed(&allow, "app.bsky.feed.post"));
+        assert!(record_allowed(&allow, "chat.bsky.actor.declaration"));
+        assert!(record_allowed(&allow, "site.standard.profile"));
+        assert!(!record_allowed(&allow, "com.whtwnd.blog.entry"));
+        assert!(!record_allowed(&allow, "app.popsky.feed.post"));
+    }
+
+    #[test]
+    fn ingest_allowed_empty_uses_legacy_bsky_chat() {
+        let allow: Vec<String> = Vec::new();
+        assert!(ingest_allowed(&allow, "app.bsky.feed.post"));
+        assert!(ingest_allowed(&allow, "chat.bsky.actor.declaration"));
+        assert!(!ingest_allowed(&allow, "site.standard.profile"));
+        assert!(!ingest_allowed(&allow, "com.whtwnd.blog.entry"));
+    }
+
+    #[test]
+    fn ingest_allowed_uses_configured_allowlist_when_set() {
+        let allow = prefixes(&["app.bsky.", "chat.bsky.", "site.standard."]);
+        assert!(ingest_allowed(&allow, "site.standard.profile"));
+        assert!(ingest_allowed(&allow, "app.bsky.feed.post"));
+        assert!(!ingest_allowed(&allow, "com.whtwnd.blog.entry"));
+    }
+
+    #[test]
+    fn public_wrappers_use_env_allowlist() {
+        // Unset in the test process: live allows all, ingest uses legacy filter.
+        assert!(record_collection_allowed("com.whtwnd.blog.entry"));
+        assert!(ingest_collection_allowed("app.bsky.feed.post"));
+        assert!(!ingest_collection_allowed("com.whtwnd.blog.entry"));
+    }
+}

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -1108,6 +1108,12 @@ impl IndexerManager {
 
         tracing::debug!("parsed uri: did={did}, collection={collection}, rkey={rkey}");
 
+        if !crate::config::record_collection_allowed(&collection) {
+            metrics::INDEXER_RECORDS_FILTERED_TOTAL.inc();
+            tracing::debug!("skipping non-allowlisted collection: {collection}");
+            return Ok(());
+        }
+
         let client = pool.get().await?;
         tracing::debug!("got database client");
 
@@ -1536,6 +1542,16 @@ impl IndexerManager {
             }
         }
         let parse_ms = parse_start.elapsed().as_millis();
+
+        parsed_jobs.retain(|p| {
+            if crate::config::record_collection_allowed(&p.collection) {
+                true
+            } else {
+                metrics::INDEXER_RECORDS_FILTERED_TOTAL.inc();
+                results.push(((*p.key).clone(), Ok(())));
+                false
+            }
+        });
 
         if parsed_jobs.is_empty() {
             return results;

--- a/rsky-wintermute/src/metrics.rs
+++ b/rsky-wintermute/src/metrics.rs
@@ -367,6 +367,14 @@ pub static INDEXER_STALE_WRITES_SKIPPED_TOTAL: LazyLock<IntCounter> = LazyLock::
     .unwrap()
 });
 
+pub static INDEXER_RECORDS_FILTERED_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "indexer_records_filtered_total",
+        "Total number of records skipped (collection not in allowlist)"
+    )
+    .unwrap()
+});
+
 pub static INDEXER_QUEUE_LENGTH: LazyLock<IntGauge> = LazyLock::new(|| {
     register_int_gauge!(
         "indexer_queue_length",


### PR DESCRIPTION
Adds an optional `RECORD_COLLECTION_ALLOWLIST` (comma-separated NSID prefixes, e.g. `app.bsky.,chat.bsky.,site.standard.`) to bound which collections wintermute persists to the `record` store.

Unset preserves current behavior: the live indexer stores all collections, while the backfiller/direct-index keep the legacy `app.bsky.`/`chat.bsky.` filter. When set, every ingest path (live `process_job`, batch, backfiller, direct-index) persists only collections matching a prefix. The previously-hardcoded filters now read the shared config, and a new `indexer_records_filtered_total` metric counts skips.

Test plan:
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets`
- [x] `cargo test` — allowlist unit tests (5/5)
- [x] `cargo build --release`