### PR TITLE
fix(wintermute): make ingester compatible with a clean dataplane schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/migrations/create_sub_state.sql
+++ b/rsky-wintermute/migrations/create_sub_state.sql
@@ -1,0 +1,6 @@
+-- Per-stream cursor/sequence state for the firehose + label subscriptions.
+-- wintermute-only: the appview/dataplane never reads this table. Nothing else creates it.
+CREATE TABLE IF NOT EXISTS bsky.sub_state (
+    service text PRIMARY KEY,
+    cursor bigint NOT NULL
+);

--- a/rsky-wintermute/src/indexer/bulk.rs
+++ b/rsky-wintermute/src/indexer/bulk.rs
@@ -12,6 +12,15 @@ use futures::SinkExt;
 use futures::pin_mut;
 use std::io::Write;
 
+// Escape a field for COPY text format (backslash first, then tab/newline/cr).
+fn escape_copy_field(s: impl AsRef<str>) -> String {
+    s.as_ref()
+        .replace('\\', "\\\\")
+        .replace('\t', "\\t")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}
+
 /// Bulk insert records using `COPY` protocol.
 /// Returns vector of booleans indicating which records were applied (not stale).
 pub async fn copy_insert_records(
@@ -74,11 +83,7 @@ pub async fn copy_insert_records(
         // - Tab (0x09 -> \t)
         // - Newline (0x0a -> \n)
         // - Carriage return (0x0d -> \r)
-        let escaped_json = json
-            .replace('\\', "\\\\")
-            .replace('\t', "\\t")
-            .replace('\n', "\\n")
-            .replace('\r', "\\r");
+        let escaped_json = escape_copy_field(json);
         writeln!(
             buffer,
             "{uri}\t{cid}\t{did}\t{escaped_json}\t{rev}\t{indexed_at}"
@@ -249,13 +254,7 @@ pub async fn copy_insert_posts(
 
     let mut buffer = Vec::with_capacity(data.len() * 300);
     for (uri, cid, creator, text, created_at, indexed_at) in data {
-        let escaped_text: String = text
-            .chars()
-            .map(|c| match c {
-                '\t' | '\n' | '\r' => ' ',
-                _ => c,
-            })
-            .collect();
+        let escaped_text = escape_copy_field(text);
         writeln!(
             buffer,
             "{uri}\t{cid}\t{creator}\t{escaped_text}\t{created_at}\t{indexed_at}"
@@ -798,14 +797,7 @@ pub async fn copy_insert_post_embed_images(
 
     let mut buffer = Vec::with_capacity(data.len() * 150);
     for (post_uri, position, image_cid, alt) in data {
-        // Escape alt text for tabs/newlines
-        let escaped_alt: String = alt
-            .chars()
-            .map(|c| match c {
-                '\t' | '\n' | '\r' => ' ',
-                _ => c,
-            })
-            .collect();
+        let escaped_alt = escape_copy_field(alt);
         writeln!(buffer, "{post_uri}\t{position}\t{image_cid}\t{escaped_alt}")
             .map_err(|e| WintermuteError::Other(format!("buffer write error: {e}")))?;
     }
@@ -885,17 +877,9 @@ pub async fn copy_insert_post_embed_videos(
 
     let mut buffer = Vec::with_capacity(data.len() * 150);
     for (post_uri, video_cid, alt) in data {
-        let escaped_alt = alt.as_ref().map_or_else(
-            || "\\N".to_owned(), // PostgreSQL NULL marker
-            |a| {
-                a.chars()
-                    .map(|c| match c {
-                        '\t' | '\n' | '\r' => ' ',
-                        _ => c,
-                    })
-                    .collect::<String>()
-            },
-        );
+        let escaped_alt = alt
+            .as_ref()
+            .map_or_else(|| "\\N".to_owned(), escape_copy_field);
         writeln!(buffer, "{post_uri}\t{video_cid}\t{escaped_alt}")
             .map_err(|e| WintermuteError::Other(format!("buffer write error: {e}")))?;
     }
@@ -935,10 +919,22 @@ pub async fn copy_insert_post_embed_videos(
 
 #[cfg(test)]
 mod tests {
+    use super::escape_copy_field;
+
     #[test]
-    fn test_escape_tsv() {
-        let text = "hello\tworld\nnewline";
-        let escaped = text.replace(['\t', '\n'], " ");
-        assert_eq!(escaped, "hello world newline");
+    fn escapes_backslash_and_whitespace_for_copy() {
+        // Backslash is doubled first (it is the COPY escape char), then tab/newline/cr.
+        assert_eq!(escape_copy_field("a\\b"), "a\\\\b");
+        assert_eq!(
+            escape_copy_field("hello\tworld\nline\r"),
+            "hello\\tworld\\nline\\r"
+        );
+        assert_eq!(escape_copy_field("plain text"), "plain text");
+    }
+
+    #[test]
+    fn escapes_trailing_backslash_so_row_is_not_corrupted() {
+        // A trailing backslash previously escaped the tab delimiter and shifted columns.
+        assert_eq!(escape_copy_field("path\\"), "path\\\\");
     }
 }

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -3253,19 +3253,13 @@ impl IndexerManager {
         if let (Some(embed_uri), Some(embed_cid)) = (embed_uri, embed_cid) {
             // Only process if it's a post being quoted
             if embed_uri.contains("/app.bsky.feed.post/") {
-                // Calculate sortAt (earlier of indexed_at and created_at)
-                let sort_at_quote = if indexed_at < created_at {
-                    indexed_at
-                } else {
-                    created_at
-                };
-                // Insert into quote table
+                // sortAt is GENERATED ALWAYS; creator is unread by rsky/atproto appview (verified) so neither is written.
                 client
                     .execute(
-                        "INSERT INTO quote (uri, cid, creator, subject, \"subjectCid\", \"createdAt\", \"indexedAt\", \"sortAt\")
-                         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                        "INSERT INTO quote (uri, cid, subject, \"subjectCid\", \"createdAt\", \"indexedAt\")
+                         VALUES ($1, $2, $3, $4, $5, $6)
                          ON CONFLICT DO NOTHING",
-                        &[&post_uri, &post_cid, &creator, &embed_uri, &embed_cid, &created_at, &indexed_at, &sort_at_quote],
+                        &[&post_uri, &post_cid, &embed_uri, &embed_cid, &created_at, &indexed_at],
                     )
                     .await?;
 


### PR DESCRIPTION
Three fixes so wintermute indexes correctly against a freshly-migrated dataplane schema (bumps `rsky-wintermute` 0.2.0 → 0.2.1):

- **COPY backslash escaping** — post `text` and embed `alt` fields were not escaped for the backslash that PostgreSQL `COPY ... FORMAT text` treats as its escape char, so any value containing `\` corrupted the tab-delimited row (`missing data for column ...`). A shared `escape_copy_field` helper (matching the existing record-JSON path) now escapes `\`, tab, newline, cr.
- **quote insert** — dropped `creator` (not a column in the dataplane `quote` table, and unread by rsky or the appview) and `sortAt` (a `GENERATED ALWAYS` column). Matches the dataplane's own quote indexer.
- **sub_state migration** — adds the `bsky.sub_state` cursor table wintermute reads/writes; nothing created it before.

Test plan:
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets`
- [x] `cargo test` — `escape_copy_field` unit tests
- [x] `cargo build --release`