### PR TITLE
feat(wintermute): add car_loader for bulk-loading CAR exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8335,7 +8335,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-relay"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -8525,6 +8525,7 @@ dependencies = [
  "iroh-car",
  "mimalloc",
  "mockito",
+ "num_cpus",
  "prometheus",
  "rand 0.8.5",
  "reqwest 0.12.23",
@@ -8535,6 +8536,7 @@ dependencies = [
  "rsky-repo",
  "rsky-syntax",
  "rtrb",
+ "rusqlite",
  "rustls 0.23.31",
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rand = "0.8.5"
 rand_core = "0.6.4"
 secp256k1 = { version = "0.28.2", features = ["global-context", "serde", "rand", "hashes","rand-std"] }
 serde_json = { version = "1.0.96",features = ["preserve_order"] }
+rusqlite = { version = "0.36", features = ["bundled"] }
 rsky-lexicon = {path = "rsky-lexicon", version = "0.2.8"}
 rsky-identity = {path = "rsky-identity", version = "0.1.0"}
 rsky-crypto = {path = "rsky-crypto", version = "0.1.1"}

--- a/rsky-relay/Cargo.toml
+++ b/rsky-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-relay"
-version = "0.1.0"
+version = "0.1.1"
 default-run = "rsky-relay"
 edition = "2024"
 
@@ -34,7 +34,7 @@ p256 = "0.13"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "gzip", "hickory-dns", "http2", "json", "rustls-tls-webpki-roots-no-provider"] }
 rs-car-sync = "0.5"
 rtrb = "0.3"
-rusqlite = { version = "0.36", features = ["bundled", "chrono"] }
+rusqlite = { workspace = true, features = ["chrono"] }
 rustls = "0.23"
 rustls-pemfile = "2"
 serde = { version = "1", features = ["derive"] }

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"
@@ -24,6 +24,10 @@ path = "src/bin/plc_import.rs"
 [[bin]]
 name = "label_sync"
 path = "src/bin/label_sync.rs"
+
+[[bin]]
+name = "car_loader"
+path = "src/bin/car_loader.rs"
 
 [dependencies]
 base64 = "0.22"
@@ -60,6 +64,9 @@ rand = "0.8"
 hyper = { version = "1", features = ["server", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1"
+
+rusqlite = { workspace = true }
+num_cpus = "1"
 
 rsky-common = { workspace = true }
 rsky-crypto = { workspace = true }

--- a/rsky-wintermute/src/bin/car_loader.rs
+++ b/rsky-wintermute/src/bin/car_loader.rs
@@ -1,0 +1,639 @@
+//! Bulk-load a CAR export into the bsky Postgres schema.
+//!
+//! Reads per-repo `.car` files listed in a SQLite manifest, parses them in parallel, and writes
+//! records in cross-repo COPY batches. Resumable via an on-disk SQLite state file. Aggregates are
+//! recomputed separately afterward, so writes run in bulk-load mode (no inline aggregates).
+
+use std::io::Cursor;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use clap::Parser;
+use color_eyre::Result;
+use deadpool_postgres::{Config, ManagerConfig, Pool, RecyclingMethod, Runtime};
+use iroh_car::CarReader;
+use rsky_repo::parse::get_and_parse_record;
+use rsky_repo::readable_repo::ReadableRepo;
+use rsky_repo::storage::memory_blockstore::MemoryBlockstore;
+use rsky_syntax::aturi::AtUri;
+use rusqlite::OpenFlags;
+use tokio_postgres::NoTls;
+
+use rsky_wintermute::backfiller::convert_record_to_ipld;
+use rsky_wintermute::config::ingest_collection_allowed;
+use rsky_wintermute::indexer::IndexerManager;
+use rsky_wintermute::types::{IndexJob, WriteAction};
+
+#[derive(Debug, Parser)]
+#[command(name = "car_loader")]
+#[command(about = "Bulk-load a CAR export into the bsky Postgres schema")]
+struct Args {
+    #[arg(long, env = "DATABASE_URL")]
+    database_url: String,
+
+    #[arg(long, env = "CAR_DUMP_DIR", default_value = "/data/car-dump")]
+    car_dump_dir: PathBuf,
+
+    /// SQLite manifest; defaults to {car_dump_dir}/car-dump.sqlite
+    #[arg(long, env = "CAR_DUMP_SQLITE")]
+    manifest: Option<PathBuf>,
+
+    /// On-disk loader state (resume + failures); kept beside the binary by default.
+    #[arg(
+        long,
+        env = "CAR_LOADER_STATE",
+        default_value = "./car_loader_state.sqlite"
+    )]
+    state_file: PathBuf,
+
+    #[arg(long, env = "CAR_LOADER_WORKERS", default_value_t = num_cpus::get())]
+    workers: usize,
+
+    #[arg(long, env = "CAR_LOADER_WRITERS", default_value_t = 24)]
+    writers: usize,
+
+    /// Records accumulated across repos before a COPY flush.
+    #[arg(long, env = "CAR_LOADER_BATCH", default_value_t = 20_000)]
+    batch_size: usize,
+
+    #[arg(long, env = "CAR_LOADER_SHARDS", default_value_t = 1)]
+    shards: i64,
+
+    #[arg(long, env = "CAR_LOADER_SHARD", default_value_t = 0)]
+    shard: i64,
+
+    #[arg(long, env = "DB_POOL_SIZE", default_value_t = 48)]
+    db_pool_size: usize,
+
+    /// Process a single repo with verbose logging (for verifying a failure case).
+    #[arg(long = "did")]
+    did: Option<String>,
+
+    /// Reprocess only the DIDs recorded in the state file's `failed` table.
+    #[arg(long, default_value_t = false)]
+    retry_failed: bool,
+
+    /// Print progress (percent complete, rates) from the state file and exit.
+    #[arg(long, default_value_t = false)]
+    status: bool,
+}
+
+impl Args {
+    fn manifest_path(&self) -> PathBuf {
+        self.manifest
+            .clone()
+            .unwrap_or_else(|| self.car_dump_dir.join("car-dump.sqlite"))
+    }
+}
+
+/// One repo to load, taken from the manifest.
+#[derive(Clone)]
+struct ManifestRow {
+    did: String,
+    path: String,
+}
+
+/// A parsed repo: index jobs to write plus any per-record extraction failures.
+struct ParsedRepo {
+    did: String,
+    jobs: Vec<IndexJob>,
+    record_failures: Vec<RecordFailure>,
+}
+
+struct RecordFailure {
+    uri: String,
+    collection: String,
+    error: String,
+}
+
+/// Messages to the single thread that owns the state SQLite.
+enum StateMsg {
+    ReposDone(Vec<String>),
+    RepoFailed {
+        did: String,
+        path: String,
+        error: String,
+    },
+    RecordsFailed(Vec<RecordFailure>),
+    Sample,
+}
+
+#[derive(Default)]
+struct Counters {
+    repos_done: AtomicU64,
+    repos_failed: AtomicU64,
+    records_written: AtomicU64,
+    records_failed: AtomicU64,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    color_eyre::install()?;
+    tracing_subscriber::fmt::init();
+    let args = Args::parse();
+
+    if args.status {
+        return report_status(&args);
+    }
+
+    let pool = build_pg_pool(&args)?;
+
+    if let Some(did) = args.did.clone() {
+        return load_single_repo(&args, &pool, &did).await;
+    }
+
+    run_full_load(args, pool).await
+}
+
+/// Build the Postgres connection pool.
+fn build_pg_pool(args: &Args) -> Result<Pool> {
+    let mut cfg = Config::new();
+    cfg.url = Some(args.database_url.clone());
+    cfg.pool = Some(deadpool_postgres::PoolConfig::new(args.db_pool_size));
+    cfg.manager = Some(ManagerConfig {
+        recycling_method: RecyclingMethod::Fast,
+    });
+    Ok(cfg.create_pool(Some(Runtime::Tokio1), NoTls)?)
+}
+
+/// Read a repo's CAR, walk its MST, and build index jobs for allowed collections.
+async fn parse_repo_to_jobs(
+    car_dump_dir: &std::path::Path,
+    row: &ManifestRow,
+) -> Result<ParsedRepo> {
+    let full_path = car_dump_dir.join(&row.path);
+    let bytes = tokio::task::spawn_blocking(move || std::fs::read(full_path)).await??;
+
+    let mut reader = CarReader::new(Cursor::new(bytes))
+        .await
+        .map_err(|e| color_eyre::eyre::eyre!("CAR parse: {e}"))?;
+    let root = *reader
+        .header()
+        .roots()
+        .first()
+        .ok_or_else(|| color_eyre::eyre::eyre!("no root CID"))?;
+    let mut blocks = rsky_repo::block_map::BlockMap::new();
+    while let Some((cid, data)) = reader
+        .next_block()
+        .await
+        .map_err(|e| color_eyre::eyre::eyre!("CAR block: {e}"))?
+    {
+        blocks.set(cid, data);
+    }
+
+    let blockstore = MemoryBlockstore::new(Some(blocks))
+        .await
+        .map_err(|e| color_eyre::eyre::eyre!("blockstore: {e}"))?;
+    let storage = Arc::new(tokio::sync::RwLock::new(blockstore));
+    let mut repo = ReadableRepo::load(storage, root)
+        .await
+        .map_err(|e| color_eyre::eyre::eyre!("repo load: {e}"))?;
+
+    if repo.did() != &row.did {
+        return Err(color_eyre::eyre::eyre!(
+            "DID mismatch: file {} vs commit {}",
+            row.did,
+            repo.did()
+        ));
+    }
+
+    let leaves = repo
+        .data
+        .list(None, None, None)
+        .await
+        .map_err(|e| color_eyre::eyre::eyre!("mst list: {e}"))?;
+    let block_data = {
+        let guard = repo.storage.read().await;
+        guard
+            .get_blocks(leaves.iter().map(|e| e.value).collect())
+            .await
+            .map_err(|e| color_eyre::eyre::eyre!("get_blocks: {e}"))?
+    };
+
+    let rev = repo.commit.rev.clone();
+    let now = chrono::Utc::now()
+        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+        .to_string();
+
+    let did = row.did.clone();
+    let mut jobs = Vec::with_capacity(leaves.len());
+    let mut record_failures = Vec::new();
+
+    for entry in &leaves {
+        let Ok(uri) = AtUri::new(format!("at://{did}/{}", entry.key), None) else {
+            continue;
+        };
+        let collection = uri.get_collection();
+        if !ingest_collection_allowed(&collection) {
+            continue;
+        }
+        // A malformed record is logged and skipped, never allowed to fail the whole repo.
+        match get_and_parse_record(&block_data.blocks, entry.value) {
+            Ok(parsed) => match serde_json::to_value(&parsed.record) {
+                Ok(raw) => jobs.push(IndexJob {
+                    uri: uri.to_string(),
+                    cid: entry.value.to_string(),
+                    action: WriteAction::Create,
+                    record: Some(convert_record_to_ipld(&raw)),
+                    indexed_at: now.clone(),
+                    rev: rev.clone(),
+                }),
+                Err(e) => record_failures.push(RecordFailure {
+                    uri: uri.to_string(),
+                    collection,
+                    error: format!("to_value: {e}"),
+                }),
+            },
+            Err(e) => record_failures.push(RecordFailure {
+                uri: uri.to_string(),
+                collection,
+                error: format!("parse: {e}"),
+            }),
+        }
+    }
+
+    Ok(ParsedRepo {
+        did,
+        jobs,
+        record_failures,
+    })
+}
+
+/// Run the full load: enqueue repos from the manifest, parse them in worker tasks, and write the
+/// resulting records to Postgres in cross-repo batches.
+async fn run_full_load(args: Args, pool: Pool) -> Result<()> {
+    let args = Arc::new(args);
+    let counters = Arc::new(Counters::default());
+
+    let (state_tx, state_rx) = std::sync::mpsc::channel::<StateMsg>();
+    let state_path = args.state_file.clone();
+    let state_counters = Arc::clone(&counters);
+    let state_thread =
+        std::thread::spawn(move || run_state_store(&state_path, &state_rx, &state_counters));
+
+    let (work_tx, work_rx) = tokio::sync::mpsc::channel::<ManifestRow>(args.workers * 4);
+    spawn_repo_enqueuer(&args, work_tx);
+
+    let (parsed_tx, parsed_rx) = tokio::sync::mpsc::channel::<ParsedRepo>(args.writers * 4);
+    let work_rx = Arc::new(tokio::sync::Mutex::new(work_rx));
+    let parsed_rx = Arc::new(tokio::sync::Mutex::new(parsed_rx));
+
+    let mut worker_handles = Vec::new();
+    for _ in 0..args.workers {
+        let work_rx = Arc::clone(&work_rx);
+        let parsed_tx = parsed_tx.clone();
+        let state_tx = state_tx.clone();
+        let args = Arc::clone(&args);
+        let counters = Arc::clone(&counters);
+        worker_handles.push(tokio::spawn(async move {
+            loop {
+                let row = {
+                    let mut rx = work_rx.lock().await;
+                    rx.recv().await
+                };
+                let Some(row) = row else { break };
+                match parse_repo_to_jobs(&args.car_dump_dir, &row).await {
+                    Ok(mut parsed) => {
+                        let failures = std::mem::take(&mut parsed.record_failures);
+                        if !failures.is_empty() {
+                            counters
+                                .records_failed
+                                .fetch_add(failures.len() as u64, Ordering::Relaxed);
+                            let _ = state_tx.send(StateMsg::RecordsFailed(failures));
+                        }
+                        let _ = parsed_tx.send(parsed).await;
+                    }
+                    Err(e) => {
+                        counters.repos_failed.fetch_add(1, Ordering::Relaxed);
+                        let _ = state_tx.send(StateMsg::RepoFailed {
+                            did: row.did.clone(),
+                            path: row.path.clone(),
+                            error: format!("{e:#}"),
+                        });
+                    }
+                }
+            }
+        }));
+    }
+    drop(parsed_tx);
+
+    let mut writer_handles = Vec::new();
+    for _ in 0..args.writers {
+        let parsed_rx = Arc::clone(&parsed_rx);
+        let pool = pool.clone();
+        let state_tx = state_tx.clone();
+        let counters = Arc::clone(&counters);
+        let batch_size = args.batch_size;
+        writer_handles.push(tokio::spawn(async move {
+            let mut batch_jobs: Vec<(Vec<u8>, IndexJob)> = Vec::new();
+            let mut batch_dids: Vec<String> = Vec::new();
+            loop {
+                let parsed = {
+                    let mut rx = parsed_rx.lock().await;
+                    rx.recv().await
+                };
+                let Some(parsed) = parsed else { break };
+                for job in parsed.jobs {
+                    batch_jobs.push((job.uri.clone().into_bytes(), job));
+                }
+                batch_dids.push(parsed.did);
+                if batch_jobs.len() >= batch_size {
+                    write_batch(
+                        &pool,
+                        &mut batch_jobs,
+                        &mut batch_dids,
+                        &state_tx,
+                        &counters,
+                    )
+                    .await;
+                }
+            }
+            write_batch(
+                &pool,
+                &mut batch_jobs,
+                &mut batch_dids,
+                &state_tx,
+                &counters,
+            )
+            .await;
+        }));
+    }
+    drop(state_tx);
+
+    let logger = spawn_progress_logger(Arc::clone(&counters));
+
+    for h in worker_handles {
+        let _ = h.await;
+    }
+    for h in writer_handles {
+        let _ = h.await;
+    }
+    logger.abort();
+    let _ = state_thread.join();
+
+    tracing::info!(
+        "done: repos done={}, failed={}, records={}, record failures={}",
+        counters.repos_done.load(Ordering::Relaxed),
+        counters.repos_failed.load(Ordering::Relaxed),
+        counters.records_written.load(Ordering::Relaxed),
+        counters.records_failed.load(Ordering::Relaxed),
+    );
+    Ok(())
+}
+
+/// Write one accumulated cross-repo batch to Postgres and mark its repos done.
+async fn write_batch(
+    pool: &Pool,
+    batch_jobs: &mut Vec<(Vec<u8>, IndexJob)>,
+    batch_dids: &mut Vec<String>,
+    state_tx: &std::sync::mpsc::Sender<StateMsg>,
+    counters: &Counters,
+) {
+    let repos = batch_dids.len() as u64;
+    if !batch_jobs.is_empty() {
+        let n = batch_jobs.len() as u64;
+        // bulk_load = true: skip inline aggregates + the like-insert semaphore.
+        let _ = IndexerManager::process_jobs_batch(pool, batch_jobs, true).await;
+        counters.records_written.fetch_add(n, Ordering::Relaxed);
+        batch_jobs.clear();
+    }
+    if repos > 0 {
+        counters.repos_done.fetch_add(repos, Ordering::Relaxed);
+        let _ = state_tx.send(StateMsg::ReposDone(std::mem::take(batch_dids)));
+        let _ = state_tx.send(StateMsg::Sample);
+    }
+}
+
+/// Log throughput (records/s, repos/s, percent via the state file) every 30s.
+fn spawn_progress_logger(counters: Arc<Counters>) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let start = Instant::now();
+        let mut last = (0u64, 0u64, Instant::now());
+        loop {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            let done = counters.repos_done.load(Ordering::Relaxed);
+            let failed = counters.repos_failed.load(Ordering::Relaxed);
+            let recs = counters.records_written.load(Ordering::Relaxed);
+            let dt = last.2.elapsed().as_secs_f64().max(1.0);
+            let rps = (recs.saturating_sub(last.0)) as f64 / dt;
+            let repos_ps = (done.saturating_sub(last.1)) as f64 / dt;
+            tracing::info!(
+                "progress: repos done={done} failed={failed}, records={recs}, {rps:.0} rec/s, {repos_ps:.0} repos/s, elapsed {}s",
+                start.elapsed().as_secs()
+            );
+            last = (recs, done, Instant::now());
+        }
+    })
+}
+
+/// Spawn the manifest reader on a blocking thread (rusqlite is synchronous).
+fn spawn_repo_enqueuer(args: &Arc<Args>, work_tx: tokio::sync::mpsc::Sender<ManifestRow>) {
+    let args = Arc::clone(args);
+    std::thread::spawn(move || {
+        if let Err(e) = enqueue_repos(&args, &work_tx) {
+            tracing::error!("manifest reader failed: {e:#}");
+        }
+    });
+}
+
+/// Stream manifest rows (skipping already-done DIDs) into the work channel; or the recorded
+/// failures when `--retry-failed`.
+fn enqueue_repos(args: &Args, work_tx: &tokio::sync::mpsc::Sender<ManifestRow>) -> Result<()> {
+    let manifest = rusqlite::Connection::open_with_flags(
+        args.manifest_path(),
+        OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )?;
+    // Read-write so a fresh run can create the table; reads the prior run's `done` for resume.
+    let state = rusqlite::Connection::open(&args.state_file)?;
+    state.execute_batch("CREATE TABLE IF NOT EXISTS done (did TEXT PRIMARY KEY)")?;
+    let mut is_done = state.prepare("SELECT 1 FROM done WHERE did = ?1")?;
+
+    if args.retry_failed {
+        let mut stmt = state.prepare("SELECT did, path FROM failed")?;
+        let rows = stmt.query_map([], manifest_row)?;
+        for row in rows {
+            if work_tx.blocking_send(row?).is_err() {
+                break;
+            }
+        }
+        return Ok(());
+    }
+
+    let mut stmt = manifest.prepare(
+        "SELECT did, path FROM repo_dumps \
+         WHERE (?1 = 1 OR rowid % ?1 = ?2) ORDER BY did",
+    )?;
+    let rows = stmt.query_map(rusqlite::params![args.shards, args.shard], manifest_row)?;
+    for row in rows {
+        let row = row?;
+        if is_done.exists([&row.did])? {
+            continue;
+        }
+        if work_tx.blocking_send(row).is_err() {
+            break;
+        }
+    }
+    Ok(())
+}
+
+fn manifest_row(r: &rusqlite::Row) -> rusqlite::Result<ManifestRow> {
+    Ok(ManifestRow {
+        did: r.get(0)?,
+        path: r.get(1)?,
+    })
+}
+
+/// Owns the state SQLite on a single thread: records done/failed repos, failed records, and
+/// periodic progress samples.
+fn run_state_store(
+    path: &std::path::Path,
+    rx: &std::sync::mpsc::Receiver<StateMsg>,
+    counters: &Counters,
+) {
+    let conn = match rusqlite::Connection::open(path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("state db open failed: {e}");
+            return;
+        }
+    };
+    let _ = conn.execute_batch(
+        "PRAGMA journal_mode=WAL;
+         CREATE TABLE IF NOT EXISTS done (did TEXT PRIMARY KEY);
+         CREATE TABLE IF NOT EXISTS failed (did TEXT PRIMARY KEY, path TEXT, error TEXT, attempted_at TEXT DEFAULT (datetime('now')));
+         CREATE TABLE IF NOT EXISTS failed_records (uri TEXT PRIMARY KEY, collection TEXT, error TEXT, attempted_at TEXT DEFAULT (datetime('now')));
+         CREATE TABLE IF NOT EXISTS progress (id INTEGER PRIMARY KEY CHECK (id=1), repos_done INTEGER, repos_failed INTEGER, records_written INTEGER, updated_at TEXT);
+         CREATE TABLE IF NOT EXISTS progress_samples (ts TEXT, records_written INTEGER, repos_done INTEGER);",
+    );
+
+    while let Ok(msg) = rx.recv() {
+        match msg {
+            StateMsg::ReposDone(dids) => {
+                if let Ok(tx) = conn.unchecked_transaction() {
+                    if let Ok(mut stmt) =
+                        tx.prepare_cached("INSERT OR IGNORE INTO done (did) VALUES (?1)")
+                    {
+                        for did in &dids {
+                            let _ = stmt.execute([did]);
+                        }
+                    }
+                    let _ = tx.commit();
+                }
+            }
+            StateMsg::RepoFailed { did, path, error } => {
+                let _ = conn.execute(
+                    "INSERT OR REPLACE INTO failed (did, path, error) VALUES (?1, ?2, ?3)",
+                    rusqlite::params![did, path, error],
+                );
+            }
+            StateMsg::RecordsFailed(failures) => {
+                if let Ok(tx) = conn.unchecked_transaction() {
+                    if let Ok(mut stmt) = tx.prepare_cached(
+                        "INSERT OR IGNORE INTO failed_records (uri, collection, error) VALUES (?1, ?2, ?3)",
+                    ) {
+                        for f in &failures {
+                            let _ = stmt.execute(rusqlite::params![f.uri, f.collection, f.error]);
+                        }
+                    }
+                    let _ = tx.commit();
+                }
+            }
+            StateMsg::Sample => {
+                let done = counters.repos_done.load(Ordering::Relaxed) as i64;
+                let failed = counters.repos_failed.load(Ordering::Relaxed) as i64;
+                let recs = counters.records_written.load(Ordering::Relaxed) as i64;
+                let _ = conn.execute(
+                    "INSERT INTO progress (id, repos_done, repos_failed, records_written, updated_at)
+                     VALUES (1, ?1, ?2, ?3, datetime('now'))
+                     ON CONFLICT (id) DO UPDATE SET repos_done=?1, repos_failed=?2, records_written=?3, updated_at=datetime('now')",
+                    rusqlite::params![done, failed, recs],
+                );
+                let _ = conn.execute(
+                    "INSERT INTO progress_samples (ts, records_written, repos_done) VALUES (datetime('now'), ?1, ?2)",
+                    rusqlite::params![recs, done],
+                );
+            }
+        }
+    }
+}
+
+/// Print percent-complete and recent rate from the state file (safe to run during a load).
+fn report_status(args: &Args) -> Result<()> {
+    let manifest = rusqlite::Connection::open_with_flags(
+        args.manifest_path(),
+        OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )?;
+    let total: i64 = manifest.query_row("SELECT count(*) FROM repo_dumps", [], |r| r.get(0))?;
+
+    let state =
+        rusqlite::Connection::open_with_flags(&args.state_file, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let done: i64 = state
+        .query_row("SELECT count(*) FROM done", [], |r| r.get(0))
+        .unwrap_or(0);
+    let failed: i64 = state
+        .query_row("SELECT count(*) FROM failed", [], |r| r.get(0))
+        .unwrap_or(0);
+    let recs: i64 = state
+        .query_row("SELECT records_written FROM progress WHERE id=1", [], |r| {
+            r.get(0)
+        })
+        .unwrap_or(0);
+
+    let mut rate = String::from("n/a");
+    let mut stmt =
+        state.prepare("SELECT records_written FROM progress_samples ORDER BY ts DESC LIMIT 2")?;
+    let samples: Vec<i64> = stmt
+        .query_map([], |r| r.get(0))?
+        .filter_map(|x| x.ok())
+        .collect();
+    if samples.len() == 2 {
+        rate = format!("~{} records / 30s window", samples[0] - samples[1]);
+    }
+
+    let pct = if total > 0 {
+        (done + failed) as f64 * 100.0 / total as f64
+    } else {
+        0.0
+    };
+    println!("CAR loader status:");
+    println!("  repos: {done} done + {failed} failed / {total} ({pct:.2}%)");
+    println!("  records written: {recs}");
+    println!("  rate: {rate}");
+    Ok(())
+}
+
+/// Parse and write a single repo with verbose logging (for verifying one DID).
+async fn load_single_repo(args: &Args, pool: &Pool, did: &str) -> Result<()> {
+    let manifest = rusqlite::Connection::open_with_flags(
+        args.manifest_path(),
+        OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )?;
+    let row = manifest.query_row(
+        "SELECT did, path FROM repo_dumps WHERE did = ?1",
+        [did],
+        manifest_row,
+    )?;
+    tracing::info!("processing {did} from {}", row.path);
+    let parsed = parse_repo_to_jobs(&args.car_dump_dir, &row).await?;
+    tracing::info!(
+        "parsed {} records, {} record failures",
+        parsed.jobs.len(),
+        parsed.record_failures.len()
+    );
+    for f in &parsed.record_failures {
+        tracing::warn!("record failure {}: {}", f.uri, f.error);
+    }
+    let mut jobs: Vec<(Vec<u8>, IndexJob)> = parsed
+        .jobs
+        .into_iter()
+        .map(|j| (j.uri.clone().into_bytes(), j))
+        .collect();
+    let results = IndexerManager::process_jobs_batch(pool, &jobs, true).await;
+    let errs = results.iter().filter(|(_, r)| r.is_err()).count();
+    jobs.clear();
+    tracing::info!("wrote {} records ({errs} write errors)", results.len());
+    Ok(())
+}

--- a/rsky-wintermute/src/indexer/bulk.rs
+++ b/rsky-wintermute/src/indexer/bulk.rs
@@ -215,6 +215,7 @@ pub async fn copy_ensure_actors(
 pub async fn copy_insert_posts(
     client: &deadpool_postgres::Client,
     data: &[(String, String, String, String, String, String)], // uri, cid, creator, text, created_at, indexed_at
+    compute_agg: bool, // false for the bulk CAR load (aggregates recomputed in one pass after)
 ) -> Result<(), WintermuteError> {
     use std::time::Instant;
 
@@ -279,18 +280,20 @@ pub async fn copy_insert_posts(
         .await?;
     let insert_ms = insert_start.elapsed().as_millis();
 
-    // Phase 4: Update profile_agg postsCount for affected creators
+    // Phase 4: Update profile_agg postsCount for affected creators (skipped during bulk load)
     let agg_start = Instant::now();
-    client
-        .execute(
-            "INSERT INTO profile_agg (did, \"postsCount\")
-             SELECT creator, COUNT(*) FROM post
-             WHERE creator IN (SELECT DISTINCT creator FROM _bulk_post)
-             GROUP BY creator
-             ON CONFLICT (did) DO UPDATE SET \"postsCount\" = EXCLUDED.\"postsCount\"",
-            &[],
-        )
-        .await?;
+    if compute_agg {
+        client
+            .execute(
+                "INSERT INTO profile_agg (did, \"postsCount\")
+                 SELECT creator, COUNT(*) FROM post
+                 WHERE creator IN (SELECT DISTINCT creator FROM _bulk_post)
+                 GROUP BY creator
+                 ON CONFLICT (did) DO UPDATE SET \"postsCount\" = EXCLUDED.\"postsCount\"",
+                &[],
+            )
+            .await?;
+    }
     let agg_ms = agg_start.elapsed().as_millis();
 
     // Log if total > 100ms (worth investigating)
@@ -481,6 +484,7 @@ pub async fn copy_insert_likes(
 pub async fn copy_insert_follows(
     client: &deadpool_postgres::Client,
     data: &[(String, String, String, String, String, String)], // uri, cid, creator, subject_did, created_at, indexed_at
+    compute_agg: bool, // false for the bulk CAR load (aggregates recomputed in one pass after)
 ) -> Result<(), WintermuteError> {
     use std::time::Instant;
 
@@ -544,30 +548,32 @@ pub async fn copy_insert_follows(
         .await?;
     let insert_ms = insert_start.elapsed().as_millis();
 
-    // Phase 4: Update profile_agg followsCount and followersCount
+    // Phase 4: Update profile_agg followsCount and followersCount (skipped during bulk load)
     let agg_start = Instant::now();
-    // Update followsCount for creators (those who are following)
-    client
-        .execute(
-            "INSERT INTO profile_agg (did, \"followsCount\")
-             SELECT creator, COUNT(*) FROM follow
-             WHERE creator IN (SELECT DISTINCT creator FROM _bulk_follow)
-             GROUP BY creator
-             ON CONFLICT (did) DO UPDATE SET \"followsCount\" = EXCLUDED.\"followsCount\"",
-            &[],
-        )
-        .await?;
-    // Update followersCount for subjects (those who are followed)
-    client
-        .execute(
-            "INSERT INTO profile_agg (did, \"followersCount\")
-             SELECT \"subjectDid\", COUNT(*) FROM follow
-             WHERE \"subjectDid\" IN (SELECT DISTINCT subject_did FROM _bulk_follow)
-             GROUP BY \"subjectDid\"
-             ON CONFLICT (did) DO UPDATE SET \"followersCount\" = EXCLUDED.\"followersCount\"",
-            &[],
-        )
-        .await?;
+    if compute_agg {
+        // Update followsCount for creators (those who are following)
+        client
+            .execute(
+                "INSERT INTO profile_agg (did, \"followsCount\")
+                 SELECT creator, COUNT(*) FROM follow
+                 WHERE creator IN (SELECT DISTINCT creator FROM _bulk_follow)
+                 GROUP BY creator
+                 ON CONFLICT (did) DO UPDATE SET \"followsCount\" = EXCLUDED.\"followsCount\"",
+                &[],
+            )
+            .await?;
+        // Update followersCount for subjects (those who are followed)
+        client
+            .execute(
+                "INSERT INTO profile_agg (did, \"followersCount\")
+                 SELECT \"subjectDid\", COUNT(*) FROM follow
+                 WHERE \"subjectDid\" IN (SELECT DISTINCT subject_did FROM _bulk_follow)
+                 GROUP BY \"subjectDid\"
+                 ON CONFLICT (did) DO UPDATE SET \"followersCount\" = EXCLUDED.\"followersCount\"",
+                &[],
+            )
+            .await?;
+    }
     let agg_ms = agg_start.elapsed().as_millis();
 
     // Log if total > 100ms (worth investigating)

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -557,7 +557,7 @@ impl IndexerManager {
 
             // Process the entire batch with batch INSERT statements
             let process_start = Instant::now();
-            let results = Self::process_jobs_batch(&pool, &jobs).await;
+            let results = Self::process_jobs_batch(&pool, &jobs, false).await;
             let process_ms = process_start.elapsed().as_millis();
 
             // Handle results - remove jobs from queue
@@ -1452,6 +1452,7 @@ impl IndexerManager {
     pub async fn process_jobs_batch(
         pool: &Pool,
         jobs: &[(Vec<u8>, IndexJob)],
+        bulk_load: bool,
     ) -> Vec<(Vec<u8>, Result<(), WintermuteError>)> {
         use crate::metrics;
 
@@ -1475,7 +1476,7 @@ impl IndexerManager {
 
         // Process creates in batch (uses parallel COPY for different collection types)
         if !creates.is_empty() {
-            let batch_results = Self::batch_insert_records(pool, &creates).await;
+            let batch_results = Self::batch_insert_records(pool, &creates, bulk_load).await;
             results.extend(batch_results);
         }
 
@@ -1494,6 +1495,7 @@ impl IndexerManager {
     async fn batch_insert_records(
         pool: &Pool,
         jobs: &[&(Vec<u8>, IndexJob)],
+        bulk_load: bool,
     ) -> Vec<(Vec<u8>, Result<(), WintermuteError>)> {
         use crate::metrics;
         use std::time::Instant;
@@ -1644,9 +1646,9 @@ impl IndexerManager {
             blocks_result,
             profiles_result,
         ) = tokio::join!(
-            Self::parallel_copy_posts(pool, &posts),
-            Self::parallel_copy_likes(pool, &likes),
-            Self::parallel_copy_follows(pool, &follows),
+            Self::parallel_copy_posts(pool, &posts, bulk_load),
+            Self::parallel_copy_likes(pool, &likes, bulk_load),
+            Self::parallel_copy_follows(pool, &follows, bulk_load),
             Self::parallel_copy_reposts(pool, &reposts),
             Self::parallel_copy_blocks(pool, &blocks),
             Self::parallel_copy_profiles(pool, &profiles),
@@ -2255,6 +2257,7 @@ impl IndexerManager {
         let mut descriptions: Vec<Option<String>> = Vec::with_capacity(jobs.len());
         let mut avatar_cids: Vec<Option<String>> = Vec::with_capacity(jobs.len());
         let mut banner_cids: Vec<Option<String>> = Vec::with_capacity(jobs.len());
+        let mut created_ats: Vec<String> = Vec::with_capacity(jobs.len());
         let mut indexed_ats: Vec<String> = Vec::with_capacity(jobs.len());
 
         for pj in jobs {
@@ -2274,6 +2277,12 @@ impl IndexerManager {
                     .and_then(|v| v.get("$link"))
                     .and_then(|v| v.as_str())
                     .map(String::from);
+                // profile.createdAt is NOT NULL; records often omit it, so fall back to indexedAt.
+                let created_at = record
+                    .get("createdAt")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(&pj.job.indexed_at)
+                    .to_owned();
 
                 uris.push(uri);
                 cids.push(pj.job.cid.clone());
@@ -2282,6 +2291,7 @@ impl IndexerManager {
                 descriptions.push(description);
                 avatar_cids.push(avatar_cid);
                 banner_cids.push(banner_cid);
+                created_ats.push(created_at);
                 indexed_ats.push(pj.job.indexed_at.clone());
 
                 metrics::INDEXER_PROFILE_EVENTS_TOTAL.inc();
@@ -2290,8 +2300,8 @@ impl IndexerManager {
 
         client
             .execute(
-                "INSERT INTO profile (uri, cid, creator, \"displayName\", description, \"avatarCid\", \"bannerCid\", \"indexedAt\")
-                 SELECT * FROM unnest($1::text[], $2::text[], $3::text[], $4::text[], $5::text[], $6::text[], $7::text[], $8::text[])
+                "INSERT INTO profile (uri, cid, creator, \"displayName\", description, \"avatarCid\", \"bannerCid\", \"createdAt\", \"indexedAt\")
+                 SELECT * FROM unnest($1::text[], $2::text[], $3::text[], $4::text[], $5::text[], $6::text[], $7::text[], $8::text[], $9::text[])
                  ON CONFLICT (uri) DO UPDATE SET
                    cid = EXCLUDED.cid,
                    \"displayName\" = EXCLUDED.\"displayName\",
@@ -2299,7 +2309,7 @@ impl IndexerManager {
                    \"avatarCid\" = EXCLUDED.\"avatarCid\",
                    \"bannerCid\" = EXCLUDED.\"bannerCid\",
                    \"indexedAt\" = EXCLUDED.\"indexedAt\"",
-                &[&uris, &cids, &creators, &display_names, &descriptions, &avatar_cids, &banner_cids, &indexed_ats],
+                &[&uris, &cids, &creators, &display_names, &descriptions, &avatar_cids, &banner_cids, &created_ats, &indexed_ats],
             )
             .await?;
 
@@ -2312,6 +2322,7 @@ impl IndexerManager {
     async fn parallel_copy_posts(
         pool: &Pool,
         jobs: &[&ParsedJob<'_>],
+        bulk_load: bool,
     ) -> (u128, usize, Option<WintermuteError>) {
         let count = jobs.len();
         if count == 0 {
@@ -2322,13 +2333,16 @@ impl IndexerManager {
             Ok(c) => c,
             Err(e) => return (0, count, Some(WintermuteError::Pool(e))),
         };
-        let err = Self::copy_batch_insert_posts(&client, jobs).await.err();
+        let err = Self::copy_batch_insert_posts(&client, jobs, !bulk_load)
+            .await
+            .err();
         (start.elapsed().as_millis(), count, err)
     }
 
     async fn parallel_copy_likes(
         pool: &Pool,
         jobs: &[&ParsedJob<'_>],
+        bulk_load: bool,
     ) -> (u128, usize, Option<WintermuteError>) {
         let count = jobs.len();
         if count == 0 {
@@ -2336,10 +2350,13 @@ impl IndexerManager {
         }
         let start = std::time::Instant::now();
 
-        // Acquire semaphore to serialize like inserts across workers.
-        // The like table's 133GB index causes severe contention when
-        // multiple workers hit it simultaneously.
-        let _permit = LIKE_INSERT_SEMAPHORE.acquire().await;
+        // Serialize live like inserts across workers (the like index causes contention).
+        // The bulk CAR load runs with indexes dropped, so the semaphore would only throttle it.
+        let _permit = if bulk_load {
+            None
+        } else {
+            Some(LIKE_INSERT_SEMAPHORE.acquire().await)
+        };
 
         let client = match pool.get().await {
             Ok(c) => c,
@@ -2352,6 +2369,7 @@ impl IndexerManager {
     async fn parallel_copy_follows(
         pool: &Pool,
         jobs: &[&ParsedJob<'_>],
+        bulk_load: bool,
     ) -> (u128, usize, Option<WintermuteError>) {
         let count = jobs.len();
         if count == 0 {
@@ -2362,7 +2380,9 @@ impl IndexerManager {
             Ok(c) => c,
             Err(e) => return (0, count, Some(WintermuteError::Pool(e))),
         };
-        let err = Self::copy_batch_insert_follows(&client, jobs).await.err();
+        let err = Self::copy_batch_insert_follows(&client, jobs, !bulk_load)
+            .await
+            .err();
         (start.elapsed().as_millis(), count, err)
     }
 
@@ -2422,6 +2442,7 @@ impl IndexerManager {
     async fn copy_batch_insert_posts(
         client: &deadpool_postgres::Client,
         jobs: &[&ParsedJob<'_>],
+        compute_agg: bool,
     ) -> Result<(), WintermuteError> {
         use crate::metrics;
 
@@ -2483,7 +2504,7 @@ impl IndexerManager {
             }
         }
 
-        bulk::copy_insert_posts(client, &post_data).await?;
+        bulk::copy_insert_posts(client, &post_data, compute_agg).await?;
         bulk::copy_insert_feed_items(client, &feed_item_data).await?;
         bulk::copy_insert_post_embed_images(client, &embed_image_data).await?;
         bulk::copy_insert_post_embed_videos(client, &embed_video_data).await?;
@@ -2623,6 +2644,7 @@ impl IndexerManager {
     async fn copy_batch_insert_follows(
         client: &deadpool_postgres::Client,
         jobs: &[&ParsedJob<'_>],
+        compute_agg: bool,
     ) -> Result<(), WintermuteError> {
         use crate::metrics;
 
@@ -2655,7 +2677,7 @@ impl IndexerManager {
             }
         }
 
-        bulk::copy_insert_follows(client, &follow_data).await
+        bulk::copy_insert_follows(client, &follow_data, compute_agg).await
     }
 
     async fn copy_batch_insert_reposts(


### PR DESCRIPTION
Adds a `car_loader` binary that unpacks an on-disk per-repo CAR export into the bsky Postgres schema, reusing the existing CAR→records→PG pipeline. Manifest-driven (SQLite), parallel parse + cross-repo COPY batches, resumable on-disk state with per-repo and per-record failure capture, and `--status` / `--did` / `--retry-failed` / sharding. Runs in a `bulk_load` mode that skips inline aggregates and the like semaphore (aggregates recomputed post-load). Also fixes `batch_insert_profiles` dropping profiles with no `createdAt` (coalesces to `indexedAt`).

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets`
- [x] `cargo build --release`
- [x] Loaded real CAR repos end-to-end into Postgres; verified collection allowlist filtering and per-table row routing with zero record failures