### PR TITLE
fix(wintermute): populate quote table in bulk car_loader path

### DIFF
--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/src/indexer/bulk.rs
+++ b/rsky-wintermute/src/indexer/bulk.rs
@@ -677,6 +677,86 @@ pub async fn copy_insert_reposts(
     Ok(())
 }
 
+/// Bulk insert quotes using `COPY` protocol.
+pub async fn copy_insert_quotes(
+    client: &deadpool_postgres::Client,
+    data: &[(String, String, String, String, String, String)], // uri, cid, subject, subject_cid, created_at, indexed_at
+) -> Result<(), WintermuteError> {
+    use std::time::Instant;
+
+    if data.is_empty() {
+        return Ok(());
+    }
+
+    let count = data.len();
+
+    let setup_start = Instant::now();
+    client
+        .execute(
+            "CREATE TEMP TABLE IF NOT EXISTS _bulk_quote (
+                uri text NOT NULL,
+                cid text NOT NULL,
+                subject text NOT NULL,
+                subject_cid text NOT NULL,
+                created_at text NOT NULL,
+                indexed_at text NOT NULL
+            )",
+            &[],
+        )
+        .await?;
+
+    client.execute("TRUNCATE _bulk_quote", &[]).await?;
+    let setup_ms = setup_start.elapsed().as_millis();
+
+    let copy_start = Instant::now();
+    let copy_stmt = client
+        .copy_in("COPY _bulk_quote (uri, cid, subject, subject_cid, created_at, indexed_at) FROM STDIN WITH (FORMAT text, DELIMITER E'\\t', NULL '')")
+        .await?;
+
+    let sink = copy_stmt;
+    pin_mut!(sink);
+
+    let mut buffer = Vec::with_capacity(data.len() * 250);
+    for (uri, cid, subject, subject_cid, created_at, indexed_at) in data {
+        writeln!(
+            buffer,
+            "{uri}\t{cid}\t{subject}\t{subject_cid}\t{created_at}\t{indexed_at}"
+        )
+        .map_err(|e| WintermuteError::Other(format!("buffer write error: {e}")))?;
+    }
+
+    sink.send(bytes::Bytes::from(buffer)).await?;
+    sink.close().await?;
+    let copy_ms = copy_start.elapsed().as_millis();
+
+    // sortAt is GENERATED ALWAYS; creator is unread by the appview so neither is written.
+    let insert_start = Instant::now();
+    client
+        .execute(
+            "INSERT INTO quote (uri, cid, subject, \"subjectCid\", \"createdAt\", \"indexedAt\")
+             SELECT uri, cid, subject, subject_cid, created_at, indexed_at
+             FROM _bulk_quote
+             ON CONFLICT DO NOTHING",
+            &[],
+        )
+        .await?;
+    let insert_ms = insert_start.elapsed().as_millis();
+
+    let total_ms = setup_ms + copy_ms + insert_ms;
+    if total_ms > 100 {
+        tracing::warn!(
+            "SLOW quote bulk: {}ms total (setup={}ms, copy={}ms, insert={}ms) for {} rows",
+            total_ms,
+            setup_ms,
+            copy_ms,
+            insert_ms,
+            count
+        );
+    }
+
+    Ok(())
+}
+
 /// Bulk insert blocks using `COPY` protocol.
 pub async fn copy_insert_blocks(
     client: &deadpool_postgres::Client,

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -2456,6 +2456,7 @@ impl IndexerManager {
             Vec::with_capacity(jobs.len());
         let mut embed_image_data: Vec<(String, String, String, String)> = Vec::new();
         let mut embed_video_data: Vec<(String, String, Option<String>)> = Vec::new();
+        let mut quote_data: Vec<(String, String, String, String, String, String)> = Vec::new();
 
         for pj in jobs {
             if let Some(record) = &pj.job.record {
@@ -2477,7 +2478,7 @@ impl IndexerManager {
                     pj.job.cid.clone(),
                     pj.did.clone(),
                     text,
-                    created_at,
+                    created_at.clone(),
                     pj.job.indexed_at.clone(),
                 ));
 
@@ -2498,6 +2499,14 @@ impl IndexerManager {
                         &mut embed_image_data,
                         &mut embed_video_data,
                     );
+                    Self::extract_quote(
+                        embed,
+                        &uri,
+                        &pj.job.cid,
+                        &created_at,
+                        &pj.job.indexed_at,
+                        &mut quote_data,
+                    );
                 }
 
                 metrics::INDEXER_POST_EVENTS_TOTAL.inc();
@@ -2508,8 +2517,44 @@ impl IndexerManager {
         bulk::copy_insert_feed_items(client, &feed_item_data).await?;
         bulk::copy_insert_post_embed_images(client, &embed_image_data).await?;
         bulk::copy_insert_post_embed_videos(client, &embed_video_data).await?;
+        bulk::copy_insert_quotes(client, &quote_data).await?;
 
         Ok(())
+    }
+
+    /// Extract a quote subject (uri, cid) from a post's embed, mirroring the live path.
+    fn extract_quote(
+        embed: &serde_json::Value,
+        post_uri: &str,
+        post_cid: &str,
+        created_at: &str,
+        indexed_at: &str,
+        quote_data: &mut Vec<(String, String, String, String, String, String)>,
+    ) {
+        let embed_type = embed.get("$type").and_then(|t| t.as_str()).unwrap_or("");
+        let quoted = if embed_type == "app.bsky.embed.record" {
+            embed.get("record")
+        } else if embed_type == "app.bsky.embed.recordWithMedia" {
+            embed.get("record").and_then(|r| r.get("record"))
+        } else {
+            None
+        };
+        if let Some(quoted) = quoted {
+            let subject = quoted.get("uri").and_then(|v| v.as_str());
+            let subject_cid = quoted.get("cid").and_then(|v| v.as_str());
+            if let (Some(subject), Some(subject_cid)) = (subject, subject_cid) {
+                if subject.contains("/app.bsky.feed.post/") {
+                    quote_data.push((
+                        post_uri.to_owned(),
+                        post_cid.to_owned(),
+                        subject.to_owned(),
+                        subject_cid.to_owned(),
+                        created_at.to_owned(),
+                        indexed_at.to_owned(),
+                    ));
+                }
+            }
+        }
     }
 
     /// Extract embed data (images and videos) from a post's embed field


### PR DESCRIPTION
The bulk COPY post path wrote post/feed_item/post_embed_* but never the `quote` table, so a full bulk load left `quote` empty. Adds `copy_insert_quotes` and quote extraction in `copy_batch_insert_posts`, mirroring the live `handle_embed_record` path (embed.record / recordWithMedia → a post subject). Columns match the live insert (no `creator`; `sortAt` is GENERATED), and the agg/notification side-effects stay deferred.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy`
- [x] `cargo build --release`
- [x] Re-ran the loader on real repos: `quote` populated, every row maps to a real quoting post; `createdAt`/`sortAt` correct