### PR TITLE
fix(wintermute): isolate car_loader parse panics per-repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/src/bin/car_loader.rs
+++ b/rsky-wintermute/src/bin/car_loader.rs
@@ -295,8 +295,16 @@ async fn run_full_load(args: Args, pool: Pool) -> Result<()> {
                     rx.recv().await
                 };
                 let Some(row) = row else { break };
-                match parse_repo_to_jobs(&args.car_dump_dir, &row).await {
-                    Ok(mut parsed) => {
+                // Isolate parsing in a child task so a panic in rsky-repo (e.g. an
+                // invalid MST key) is recorded as a repo failure instead of killing
+                // the worker, which would otherwise deplete the pool and stall.
+                let cdd = args.car_dump_dir.clone();
+                let row_for_parse = row.clone();
+                let parse_result =
+                    tokio::spawn(async move { parse_repo_to_jobs(&cdd, &row_for_parse).await })
+                        .await;
+                match parse_result {
+                    Ok(Ok(mut parsed)) => {
                         let failures = std::mem::take(&mut parsed.record_failures);
                         if !failures.is_empty() {
                             counters
@@ -306,12 +314,20 @@ async fn run_full_load(args: Args, pool: Pool) -> Result<()> {
                         }
                         let _ = parsed_tx.send(parsed).await;
                     }
-                    Err(e) => {
+                    Ok(Err(e)) => {
                         counters.repos_failed.fetch_add(1, Ordering::Relaxed);
                         let _ = state_tx.send(StateMsg::RepoFailed {
                             did: row.did.clone(),
                             path: row.path.clone(),
                             error: format!("{e:#}"),
+                        });
+                    }
+                    Err(join_err) => {
+                        counters.repos_failed.fetch_add(1, Ordering::Relaxed);
+                        let _ = state_tx.send(StateMsg::RepoFailed {
+                            did: row.did.clone(),
+                            path: row.path.clone(),
+                            error: format!("parse panicked: {join_err}"),
                         });
                     }
                 }


### PR DESCRIPTION
A panic during repo parsing (e.g. an invalid MST key in rsky-repo) killed the worker task permanently, which over many repos would deplete the worker pool and stall the load (and lost the repo silently). Isolate each parse in a child task so a panic is caught as a `JoinError` and recorded as a repo failure (queryable, retryable); the worker survives.

## Test plan
- [x] `cargo build --release`
- [x] Verified on the full load: panicking repos now increment `failed_repos` instead of degrading the process; workers stay alive and throughput holds