### PR TITLE
fix(wintermute): car_loader bulk-load correctness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.3.0"
+version = "0.3.3"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.3.1"
+version = "0.3.3"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/src/backfiller/mod.rs
+++ b/rsky-wintermute/src/backfiller/mod.rs
@@ -271,6 +271,21 @@ impl BackfillerManager {
         }
 
         let car_bytes = response.bytes().await?;
+        Self::process_car_bytes(storage, did, &car_bytes, job.priority).await?;
+
+        metrics::BACKFILLER_REPOS_PROCESSED_TOTAL.inc();
+
+        Ok(())
+    }
+
+    pub async fn process_car_bytes(
+        storage: &Storage,
+        did: &str,
+        car_bytes: &[u8],
+        priority: bool,
+    ) -> Result<usize, WintermuteError> {
+        use crate::metrics;
+
         let mut reader = match CarReader::new(Cursor::new(car_bytes.to_vec())).await {
             Ok(r) => r,
             Err(e) => {
@@ -366,16 +381,14 @@ impl BackfillerManager {
         }
 
         if !batch_jobs.is_empty() {
-            if job.priority {
+            if priority {
                 storage.enqueue_firehose_backfill_priority_batch(&batch_jobs)?;
             } else {
                 storage.enqueue_firehose_backfill_batch(&batch_jobs)?;
             }
         }
 
-        metrics::BACKFILLER_REPOS_PROCESSED_TOTAL.inc();
-
-        Ok(())
+        Ok(batch_jobs.len())
     }
 }
 

--- a/rsky-wintermute/src/backfiller/tests.rs
+++ b/rsky-wintermute/src/backfiller/tests.rs
@@ -54,6 +54,54 @@ mod backfiller_tests {
     }
 
     #[tokio::test]
+    async fn test_process_car_bytes_with_fixture_repo() {
+        let (storage, _dir) = setup_test_storage();
+
+        let car_bytes = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../rsky-repo/resources/test/valid_repo.car"
+        ))
+        .unwrap();
+
+        let enqueued = BackfillerManager::process_car_bytes(
+            &storage,
+            "did:plc:r7fdhqmw3h2cifeakw5hmvy6",
+            &car_bytes,
+            false,
+        )
+        .await
+        .unwrap();
+
+        // valid_repo.car's MST references exactly 6 live records
+        let queue_len = storage.firehose_backfill_len().unwrap();
+        assert_eq!(enqueued, queue_len);
+        assert_eq!(enqueued, 6);
+    }
+
+    #[tokio::test]
+    async fn test_process_car_bytes_rejects_did_mismatch() {
+        let (storage, _dir) = setup_test_storage();
+
+        let car_bytes = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../rsky-repo/resources/test/valid_repo.car"
+        ))
+        .unwrap();
+
+        let result = BackfillerManager::process_car_bytes(
+            &storage,
+            "did:plc:someotherdidentirely00000",
+            &car_bytes,
+            false,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(storage.firehose_backfill_len().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    #[ignore = "hits the live network; run manually with --ignored"]
     async fn test_process_job_with_real_repo() {
         let (storage, _dir) = setup_test_storage();
 
@@ -68,22 +116,11 @@ mod backfiller_tests {
             .build()
             .unwrap();
 
-        let result =
-            BackfillerManager::process_job(&storage, &http_client, &dashmap::DashMap::new(), &job)
-                .await;
+        BackfillerManager::process_job(&storage, &http_client, &dashmap::DashMap::new(), &job)
+            .await
+            .unwrap();
 
-        match result {
-            Ok(()) => {
-                let queue_len = storage.firehose_backfill_len().unwrap();
-                assert!(
-                    queue_len > 7000,
-                    "expected more than 20000 records to be enqueued for indexing, found {queue_len}"
-                );
-            }
-            Err(e) => {
-                panic!("backfill job failed: {e}");
-            }
-        }
+        assert!(storage.firehose_backfill_len().unwrap() > 0);
     }
 
     #[tokio::test]

--- a/rsky-wintermute/src/bin/car_loader.rs
+++ b/rsky-wintermute/src/bin/car_loader.rs
@@ -422,8 +422,7 @@ async fn write_batch(
 
     let n = batch_jobs.len() as u64;
     // bulk_load = true: skip inline aggregates + the like-insert semaphore.
-    let (_results, batch_failed) =
-        IndexerManager::process_jobs_batch(pool, batch_jobs, true).await;
+    let (_results, batch_failed) = IndexerManager::process_jobs_batch(pool, batch_jobs, true).await;
     batch_jobs.clear();
 
     if batch_failed {

--- a/rsky-wintermute/src/bin/car_loader.rs
+++ b/rsky-wintermute/src/bin/car_loader.rs
@@ -392,19 +392,40 @@ async fn write_batch(
     state_tx: &std::sync::mpsc::Sender<StateMsg>,
     counters: &Counters,
 ) {
-    let repos = batch_dids.len() as u64;
-    if !batch_jobs.is_empty() {
-        let n = batch_jobs.len() as u64;
-        // bulk_load = true: skip inline aggregates + the like-insert semaphore.
-        let _ = IndexerManager::process_jobs_batch(pool, batch_jobs, true).await;
-        counters.records_written.fetch_add(n, Ordering::Relaxed);
-        batch_jobs.clear();
+    if batch_jobs.is_empty() {
+        // Repos with no persistable records are still done (nothing to write).
+        if !batch_dids.is_empty() {
+            counters
+                .repos_done
+                .fetch_add(batch_dids.len() as u64, Ordering::Relaxed);
+            let _ = state_tx.send(StateMsg::ReposDone(std::mem::take(batch_dids)));
+            let _ = state_tx.send(StateMsg::Sample);
+        }
+        return;
     }
-    if repos > 0 {
-        counters.repos_done.fetch_add(repos, Ordering::Relaxed);
-        let _ = state_tx.send(StateMsg::ReposDone(std::mem::take(batch_dids)));
-        let _ = state_tx.send(StateMsg::Sample);
+
+    let n = batch_jobs.len() as u64;
+    // bulk_load = true: skip inline aggregates + the like-insert semaphore.
+    let (_results, batch_failed) =
+        IndexerManager::process_jobs_batch(pool, batch_jobs, true).await;
+    batch_jobs.clear();
+
+    if batch_failed {
+        // Rows were not persisted: leave these repos NOT done so a resume re-processes them
+        // (from the manifest, with the correct path) instead of silently dropping them.
+        let repos = batch_dids.len() as u64;
+        counters.repos_failed.fetch_add(repos, Ordering::Relaxed);
+        tracing::warn!("batch copy failed; {repos} repos left not-done for resume");
+        batch_dids.clear();
+        return;
     }
+
+    counters.records_written.fetch_add(n, Ordering::Relaxed);
+    counters
+        .repos_done
+        .fetch_add(batch_dids.len() as u64, Ordering::Relaxed);
+    let _ = state_tx.send(StateMsg::ReposDone(std::mem::take(batch_dids)));
+    let _ = state_tx.send(StateMsg::Sample);
 }
 
 /// Log throughput (records/s, repos/s, percent via the state file) every 30s.
@@ -449,7 +470,6 @@ fn enqueue_repos(args: &Args, work_tx: &tokio::sync::mpsc::Sender<ManifestRow>) 
     // Read-write so a fresh run can create the table; reads the prior run's `done` for resume.
     let state = rusqlite::Connection::open(&args.state_file)?;
     state.execute_batch("CREATE TABLE IF NOT EXISTS done (did TEXT PRIMARY KEY)")?;
-    let mut is_done = state.prepare("SELECT 1 FROM done WHERE did = ?1")?;
 
     if args.retry_failed {
         let mut stmt = state.prepare("SELECT did, path FROM failed")?;
@@ -462,6 +482,16 @@ fn enqueue_repos(args: &Args, work_tx: &tokio::sync::mpsc::Sender<ManifestRow>) 
         return Ok(());
     }
 
+    // Load done DIDs into memory once; an O(1) skip avoids millions of per-row SQLite lookups.
+    let mut done: std::collections::HashSet<String> = std::collections::HashSet::new();
+    {
+        let mut stmt = state.prepare("SELECT did FROM done")?;
+        let rows = stmt.query_map([], |r| r.get::<_, String>(0))?;
+        for did in rows {
+            done.insert(did?);
+        }
+    }
+
     let mut stmt = manifest.prepare(
         "SELECT did, path FROM repo_dumps \
          WHERE (?1 = 1 OR rowid % ?1 = ?2) ORDER BY did",
@@ -469,7 +499,7 @@ fn enqueue_repos(args: &Args, work_tx: &tokio::sync::mpsc::Sender<ManifestRow>) 
     let rows = stmt.query_map(rusqlite::params![args.shards, args.shard], manifest_row)?;
     for row in rows {
         let row = row?;
-        if is_done.exists([&row.did])? {
+        if done.contains(&row.did) {
             continue;
         }
         if work_tx.blocking_send(row).is_err() {
@@ -631,9 +661,12 @@ async fn load_single_repo(args: &Args, pool: &Pool, did: &str) -> Result<()> {
         .into_iter()
         .map(|j| (j.uri.clone().into_bytes(), j))
         .collect();
-    let results = IndexerManager::process_jobs_batch(pool, &jobs, true).await;
+    let (results, batch_failed) = IndexerManager::process_jobs_batch(pool, &jobs, true).await;
     let errs = results.iter().filter(|(_, r)| r.is_err()).count();
     jobs.clear();
-    tracing::info!("wrote {} records ({errs} write errors)", results.len());
+    tracing::info!(
+        "wrote {} records ({errs} write errors, batch_failed={batch_failed})",
+        results.len()
+    );
     Ok(())
 }

--- a/rsky-wintermute/src/bin/car_loader.rs
+++ b/rsky-wintermute/src/bin/car_loader.rs
@@ -295,8 +295,16 @@ async fn run_full_load(args: Args, pool: Pool) -> Result<()> {
                     rx.recv().await
                 };
                 let Some(row) = row else { break };
-                match parse_repo_to_jobs(&args.car_dump_dir, &row).await {
-                    Ok(mut parsed) => {
+                // Isolate parsing in a child task so a panic in rsky-repo (e.g. an
+                // invalid MST key) is recorded as a repo failure instead of killing
+                // the worker, which would otherwise deplete the pool and stall.
+                let cdd = args.car_dump_dir.clone();
+                let row_for_parse = row.clone();
+                let parse_result =
+                    tokio::spawn(async move { parse_repo_to_jobs(&cdd, &row_for_parse).await })
+                        .await;
+                match parse_result {
+                    Ok(Ok(mut parsed)) => {
                         let failures = std::mem::take(&mut parsed.record_failures);
                         if !failures.is_empty() {
                             counters
@@ -306,12 +314,20 @@ async fn run_full_load(args: Args, pool: Pool) -> Result<()> {
                         }
                         let _ = parsed_tx.send(parsed).await;
                     }
-                    Err(e) => {
+                    Ok(Err(e)) => {
                         counters.repos_failed.fetch_add(1, Ordering::Relaxed);
                         let _ = state_tx.send(StateMsg::RepoFailed {
                             did: row.did.clone(),
                             path: row.path.clone(),
                             error: format!("{e:#}"),
+                        });
+                    }
+                    Err(join_err) => {
+                        counters.repos_failed.fetch_add(1, Ordering::Relaxed);
+                        let _ = state_tx.send(StateMsg::RepoFailed {
+                            did: row.did.clone(),
+                            path: row.path.clone(),
+                            error: format!("parse panicked: {join_err}"),
                         });
                     }
                 }

--- a/rsky-wintermute/src/indexer/bulk.rs
+++ b/rsky-wintermute/src/indexer/bulk.rs
@@ -30,6 +30,28 @@ fn escape_copy_field(s: &str) -> std::borrow::Cow<'_, str> {
     }
 }
 
+// Escape an optional COPY field, emitting the \N NULL marker when the value is absent.
+fn escape_copy_opt(v: Option<&str>) -> std::borrow::Cow<'_, str> {
+    v.map_or(std::borrow::Cow::Borrowed("\\N"), escape_copy_field)
+}
+
+/// A post row for bulk `COPY`. `reply_*` are `None` for non-replies; `langs`/`tags`
+/// hold compact JSON text destined for the `jsonb` columns, `None` when absent.
+pub struct PostCopyRow {
+    pub uri: String,
+    pub cid: String,
+    pub creator: String,
+    pub text: String,
+    pub reply_root: Option<String>,
+    pub reply_root_cid: Option<String>,
+    pub reply_parent: Option<String>,
+    pub reply_parent_cid: Option<String>,
+    pub created_at: String,
+    pub indexed_at: String,
+    pub langs: Option<String>,
+    pub tags: Option<String>,
+}
+
 /// Bulk insert records using `COPY` protocol.
 /// Returns vector of booleans indicating which records were applied (not stale).
 pub async fn copy_insert_records(
@@ -221,7 +243,7 @@ pub async fn copy_ensure_actors(
 /// Bulk insert posts using `COPY` protocol.
 pub async fn copy_insert_posts(
     client: &deadpool_postgres::Client,
-    data: &[(String, String, String, String, String, String)], // uri, cid, creator, text, created_at, indexed_at
+    data: &[PostCopyRow],
     compute_agg: bool, // false for the bulk CAR load (aggregates recomputed in one pass after)
 ) -> Result<(), WintermuteError> {
     use std::time::Instant;
@@ -241,8 +263,14 @@ pub async fn copy_insert_posts(
                 cid text NOT NULL,
                 creator text NOT NULL,
                 text text,
+                reply_root text,
+                reply_root_cid text,
+                reply_parent text,
+                reply_parent_cid text,
                 created_at text NOT NULL,
-                indexed_at text NOT NULL
+                indexed_at text NOT NULL,
+                langs jsonb,
+                tags jsonb
             )",
             &[],
         )
@@ -251,26 +279,33 @@ pub async fn copy_insert_posts(
     client.execute("TRUNCATE _bulk_post", &[]).await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
-    // Phase 2: COPY data (no NULL clause - text column is NOT NULL so empty string must be preserved)
+    // Phase 2: COPY data. text is NOT NULL so empty string is preserved; reply_*/langs/tags
+    // use the \N NULL marker when absent.
     let copy_start = Instant::now();
     let copy_stmt = client
-        .copy_in("COPY _bulk_post (uri, cid, creator, text, created_at, indexed_at) FROM STDIN WITH (FORMAT text, DELIMITER E'\\t')")
+        .copy_in("COPY _bulk_post (uri, cid, creator, text, reply_root, reply_root_cid, reply_parent, reply_parent_cid, created_at, indexed_at, langs, tags) FROM STDIN WITH (FORMAT text, DELIMITER E'\\t')")
         .await?;
 
     let sink = copy_stmt;
     pin_mut!(sink);
 
     let mut buffer = Vec::with_capacity(data.len() * 300);
-    for (uri, cid, creator, text, created_at, indexed_at) in data {
-        let uri = escape_copy_field(uri);
-        let cid = escape_copy_field(cid);
-        let creator = escape_copy_field(creator);
-        let text = escape_copy_field(text);
-        let created_at = escape_copy_field(created_at);
-        let indexed_at = escape_copy_field(indexed_at);
+    for row in data {
+        let uri = escape_copy_field(&row.uri);
+        let cid = escape_copy_field(&row.cid);
+        let creator = escape_copy_field(&row.creator);
+        let text = escape_copy_field(&row.text);
+        let reply_root = escape_copy_opt(row.reply_root.as_deref());
+        let reply_root_cid = escape_copy_opt(row.reply_root_cid.as_deref());
+        let reply_parent = escape_copy_opt(row.reply_parent.as_deref());
+        let reply_parent_cid = escape_copy_opt(row.reply_parent_cid.as_deref());
+        let created_at = escape_copy_field(&row.created_at);
+        let indexed_at = escape_copy_field(&row.indexed_at);
+        let langs = escape_copy_opt(row.langs.as_deref());
+        let tags = escape_copy_opt(row.tags.as_deref());
         writeln!(
             buffer,
-            "{uri}\t{cid}\t{creator}\t{text}\t{created_at}\t{indexed_at}"
+            "{uri}\t{cid}\t{creator}\t{text}\t{reply_root}\t{reply_root_cid}\t{reply_parent}\t{reply_parent_cid}\t{created_at}\t{indexed_at}\t{langs}\t{tags}"
         )
         .map_err(|e| WintermuteError::Other(format!("buffer write error: {e}")))?;
     }
@@ -283,8 +318,8 @@ pub async fn copy_insert_posts(
     let insert_start = Instant::now();
     client
         .execute(
-            "INSERT INTO post (uri, cid, creator, text, \"createdAt\", \"indexedAt\")
-             SELECT uri, cid, creator, text, created_at, indexed_at
+            "INSERT INTO post (uri, cid, creator, text, \"replyRoot\", \"replyRootCid\", \"replyParent\", \"replyParentCid\", \"createdAt\", \"indexedAt\", langs, tags)
+             SELECT uri, cid, creator, text, reply_root, reply_root_cid, reply_parent, reply_parent_cid, created_at, indexed_at, langs, tags
              FROM _bulk_post
              ON CONFLICT DO NOTHING",
             &[],
@@ -1060,7 +1095,7 @@ pub async fn copy_insert_post_embed_videos(
 
 #[cfg(test)]
 mod tests {
-    use super::escape_copy_field;
+    use super::{escape_copy_field, escape_copy_opt};
 
     #[test]
     fn escapes_backslash_and_whitespace_for_copy() {
@@ -1077,5 +1112,16 @@ mod tests {
     fn escapes_trailing_backslash_so_row_is_not_corrupted() {
         // A trailing backslash previously escaped the tab delimiter and shifted columns.
         assert_eq!(escape_copy_field("path\\"), "path\\\\");
+    }
+
+    #[test]
+    fn optional_field_emits_null_marker_when_absent() {
+        // None -> \N (COPY NULL); Some -> escaped value, so reply_*/langs/tags load correctly.
+        assert_eq!(escape_copy_opt(None), "\\N");
+        assert_eq!(
+            escape_copy_opt(Some("at://did/app.bsky.feed.post/x")),
+            "at://did/app.bsky.feed.post/x"
+        );
+        assert_eq!(escape_copy_opt(Some("a\tb")), "a\\tb");
     }
 }

--- a/rsky-wintermute/src/indexer/bulk.rs
+++ b/rsky-wintermute/src/indexer/bulk.rs
@@ -12,13 +12,18 @@ use futures::SinkExt;
 use futures::pin_mut;
 use std::io::Write;
 
-// Escape a field for COPY text format (backslash first, then tab/newline/cr).
-fn escape_copy_field(s: impl AsRef<str>) -> String {
-    s.as_ref()
-        .replace('\\', "\\\\")
-        .replace('\t', "\\t")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
+// Escape a field for COPY text format; borrows when no escaping is needed.
+fn escape_copy_field(s: &str) -> std::borrow::Cow<'_, str> {
+    if s.bytes().any(|b| matches!(b, b'\\' | b'\t' | b'\n' | b'\r')) {
+        std::borrow::Cow::Owned(
+            s.replace('\\', "\\\\")
+                .replace('\t', "\\t")
+                .replace('\n', "\\n")
+                .replace('\r', "\\r"),
+        )
+    } else {
+        std::borrow::Cow::Borrowed(s)
+    }
 }
 
 /// Bulk insert records using `COPY` protocol.
@@ -78,17 +83,14 @@ pub async fn copy_insert_records(
             continue;
         }
 
-        // Escape for PostgreSQL COPY text format:
-        // - Backslash first (\ -> \\) so we don't double-escape other escapes
-        // - Tab (0x09 -> \t)
-        // - Newline (0x0a -> \n)
-        // - Carriage return (0x0d -> \r)
-        let escaped_json = escape_copy_field(json);
-        writeln!(
-            buffer,
-            "{uri}\t{cid}\t{did}\t{escaped_json}\t{rev}\t{indexed_at}"
-        )
-        .map_err(|e| WintermuteError::Other(format!("buffer write error: {e}")))?;
+        let uri = escape_copy_field(uri);
+        let cid = escape_copy_field(cid);
+        let did = escape_copy_field(did);
+        let json = escape_copy_field(&json);
+        let rev = escape_copy_field(rev);
+        let indexed_at = escape_copy_field(indexed_at);
+        writeln!(buffer, "{uri}\t{cid}\t{did}\t{json}\t{rev}\t{indexed_at}")
+            .map_err(|e| WintermuteError::Other(format!("buffer write error: {e}")))?;
     }
 
     sink.send(bytes::Bytes::from(buffer)).await?;
@@ -174,6 +176,7 @@ pub async fn copy_ensure_actors(
 
     let mut buffer = Vec::with_capacity(dids.len() * 50);
     for did in dids {
+        let did = escape_copy_field(did);
         writeln!(buffer, "{did}")
             .map_err(|e| WintermuteError::Other(format!("buffer write error: {e}")))?;
     }
@@ -255,10 +258,15 @@ pub async fn copy_insert_posts(
 
     let mut buffer = Vec::with_capacity(data.len() * 300);
     for (uri, cid, creator, text, created_at, indexed_at) in data {
-        let escaped_text = escape_copy_field(text);
+        let uri = escape_copy_field(uri);
+        let cid = escape_copy_field(cid);
+        let creator = escape_copy_field(creator);
+        let text = escape_copy_field(text);
+        let created_at = escape_copy_field(created_at);
+        let indexed_at = escape_copy_field(indexed_at);
         writeln!(
             buffer,
-            "{uri}\t{cid}\t{creator}\t{escaped_text}\t{created_at}\t{indexed_at}"
+            "{uri}\t{cid}\t{creator}\t{text}\t{created_at}\t{indexed_at}"
         )
         .map_err(|e| WintermuteError::Other(format!("buffer write error: {e}")))?;
     }
@@ -356,6 +364,12 @@ pub async fn copy_insert_feed_items(
 
     let mut buffer = Vec::with_capacity(data.len() * 200);
     for (item_type, uri, cid, post_uri, originator_did, sort_at) in data {
+        let item_type = escape_copy_field(item_type);
+        let uri = escape_copy_field(uri);
+        let cid = escape_copy_field(cid);
+        let post_uri = escape_copy_field(post_uri);
+        let originator_did = escape_copy_field(originator_did);
+        let sort_at = escape_copy_field(sort_at);
         writeln!(
             buffer,
             "{item_type}\t{uri}\t{cid}\t{post_uri}\t{originator_did}\t{sort_at}"
@@ -440,6 +454,13 @@ pub async fn copy_insert_likes(
 
     let mut buffer = Vec::with_capacity(data.len() * 250);
     for (uri, cid, creator, subject, subject_cid, created_at, indexed_at) in data {
+        let uri = escape_copy_field(uri);
+        let cid = escape_copy_field(cid);
+        let creator = escape_copy_field(creator);
+        let subject = escape_copy_field(subject);
+        let subject_cid = escape_copy_field(subject_cid);
+        let created_at = escape_copy_field(created_at);
+        let indexed_at = escape_copy_field(indexed_at);
         writeln!(
             buffer,
             "{uri}\t{cid}\t{creator}\t{subject}\t{subject_cid}\t{created_at}\t{indexed_at}"
@@ -524,6 +545,12 @@ pub async fn copy_insert_follows(
 
     let mut buffer = Vec::with_capacity(data.len() * 200);
     for (uri, cid, creator, subject_did, created_at, indexed_at) in data {
+        let uri = escape_copy_field(uri);
+        let cid = escape_copy_field(cid);
+        let creator = escape_copy_field(creator);
+        let subject_did = escape_copy_field(subject_did);
+        let created_at = escape_copy_field(created_at);
+        let indexed_at = escape_copy_field(indexed_at);
         writeln!(
             buffer,
             "{uri}\t{cid}\t{creator}\t{subject_did}\t{created_at}\t{indexed_at}"
@@ -637,6 +664,13 @@ pub async fn copy_insert_reposts(
 
     let mut buffer = Vec::with_capacity(data.len() * 250);
     for (uri, cid, creator, subject, subject_cid, created_at, indexed_at) in data {
+        let uri = escape_copy_field(uri);
+        let cid = escape_copy_field(cid);
+        let creator = escape_copy_field(creator);
+        let subject = escape_copy_field(subject);
+        let subject_cid = escape_copy_field(subject_cid);
+        let created_at = escape_copy_field(created_at);
+        let indexed_at = escape_copy_field(indexed_at);
         writeln!(
             buffer,
             "{uri}\t{cid}\t{creator}\t{subject}\t{subject_cid}\t{created_at}\t{indexed_at}"
@@ -718,6 +752,12 @@ pub async fn copy_insert_quotes(
 
     let mut buffer = Vec::with_capacity(data.len() * 250);
     for (uri, cid, subject, subject_cid, created_at, indexed_at) in data {
+        let uri = escape_copy_field(uri);
+        let cid = escape_copy_field(cid);
+        let subject = escape_copy_field(subject);
+        let subject_cid = escape_copy_field(subject_cid);
+        let created_at = escape_copy_field(created_at);
+        let indexed_at = escape_copy_field(indexed_at);
         writeln!(
             buffer,
             "{uri}\t{cid}\t{subject}\t{subject_cid}\t{created_at}\t{indexed_at}"
@@ -800,6 +840,12 @@ pub async fn copy_insert_blocks(
 
     let mut buffer = Vec::with_capacity(data.len() * 200);
     for (uri, cid, creator, subject, created_at, indexed_at) in data {
+        let uri = escape_copy_field(uri);
+        let cid = escape_copy_field(cid);
+        let creator = escape_copy_field(creator);
+        let subject = escape_copy_field(subject);
+        let created_at = escape_copy_field(created_at);
+        let indexed_at = escape_copy_field(indexed_at);
         writeln!(
             buffer,
             "{uri}\t{cid}\t{creator}\t{subject}\t{created_at}\t{indexed_at}"
@@ -883,8 +929,11 @@ pub async fn copy_insert_post_embed_images(
 
     let mut buffer = Vec::with_capacity(data.len() * 150);
     for (post_uri, position, image_cid, alt) in data {
-        let escaped_alt = escape_copy_field(alt);
-        writeln!(buffer, "{post_uri}\t{position}\t{image_cid}\t{escaped_alt}")
+        let post_uri = escape_copy_field(post_uri);
+        let position = escape_copy_field(position);
+        let image_cid = escape_copy_field(image_cid);
+        let alt = escape_copy_field(alt);
+        writeln!(buffer, "{post_uri}\t{position}\t{image_cid}\t{alt}")
             .map_err(|e| WintermuteError::Other(format!("buffer write error: {e}")))?;
     }
 
@@ -963,10 +1012,13 @@ pub async fn copy_insert_post_embed_videos(
 
     let mut buffer = Vec::with_capacity(data.len() * 150);
     for (post_uri, video_cid, alt) in data {
-        let escaped_alt = alt
-            .as_ref()
-            .map_or_else(|| "\\N".to_owned(), escape_copy_field);
-        writeln!(buffer, "{post_uri}\t{video_cid}\t{escaped_alt}")
+        let post_uri = escape_copy_field(post_uri);
+        let video_cid = escape_copy_field(video_cid);
+        let alt = match alt.as_ref() {
+            Some(s) => escape_copy_field(s),
+            None => std::borrow::Cow::Borrowed("\\N"),
+        };
+        writeln!(buffer, "{post_uri}\t{video_cid}\t{alt}")
             .map_err(|e| WintermuteError::Other(format!("buffer write error: {e}")))?;
     }
 

--- a/rsky-wintermute/src/indexer/bulk.rs
+++ b/rsky-wintermute/src/indexer/bulk.rs
@@ -14,7 +14,9 @@ use std::io::Write;
 
 // Escape a field for COPY text format; borrows when no escaping is needed.
 fn escape_copy_field(s: &str) -> std::borrow::Cow<'_, str> {
-    if s.bytes().any(|b| matches!(b, b'\\' | b'\t' | b'\n' | b'\r')) {
+    if s.bytes()
+        .any(|b| matches!(b, b'\\' | b'\t' | b'\n' | b'\r'))
+    {
         std::borrow::Cow::Owned(
             s.replace('\\', "\\\\")
                 .replace('\t', "\\t")
@@ -1014,10 +1016,9 @@ pub async fn copy_insert_post_embed_videos(
     for (post_uri, video_cid, alt) in data {
         let post_uri = escape_copy_field(post_uri);
         let video_cid = escape_copy_field(video_cid);
-        let alt = match alt.as_ref() {
-            Some(s) => escape_copy_field(s),
-            None => std::borrow::Cow::Borrowed("\\N"),
-        };
+        let alt = alt
+            .as_ref()
+            .map_or(std::borrow::Cow::Borrowed("\\N"), |s| escape_copy_field(s));
         writeln!(buffer, "{post_uri}\t{video_cid}\t{alt}")
             .map_err(|e| WintermuteError::Other(format!("buffer write error: {e}")))?;
     }

--- a/rsky-wintermute/src/indexer/bulk.rs
+++ b/rsky-wintermute/src/indexer/bulk.rs
@@ -13,15 +13,17 @@ use futures::pin_mut;
 use std::io::Write;
 
 // Escape a field for COPY text format; borrows when no escaping is needed.
+// NUL is stripped (Postgres text columns reject 0x00), the rest are escaped.
 fn escape_copy_field(s: &str) -> std::borrow::Cow<'_, str> {
     if s.bytes()
-        .any(|b| matches!(b, b'\\' | b'\t' | b'\n' | b'\r'))
+        .any(|b| matches!(b, b'\\' | b'\t' | b'\n' | b'\r' | b'\0'))
     {
         std::borrow::Cow::Owned(
             s.replace('\\', "\\\\")
                 .replace('\t', "\\t")
                 .replace('\n', "\\n")
-                .replace('\r', "\\r"),
+                .replace('\r', "\\r")
+                .replace('\0', ""),
         )
     } else {
         std::borrow::Cow::Borrowed(s)

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -557,7 +557,7 @@ impl IndexerManager {
 
             // Process the entire batch with batch INSERT statements
             let process_start = Instant::now();
-            let results = Self::process_jobs_batch(&pool, &jobs, false).await;
+            let (results, _batch_failed) = Self::process_jobs_batch(&pool, &jobs, false).await;
             let process_ms = process_start.elapsed().as_millis();
 
             // Handle results - remove jobs from queue
@@ -1453,13 +1453,14 @@ impl IndexerManager {
         pool: &Pool,
         jobs: &[(Vec<u8>, IndexJob)],
         bulk_load: bool,
-    ) -> Vec<(Vec<u8>, Result<(), WintermuteError>)> {
+    ) -> (Vec<(Vec<u8>, Result<(), WintermuteError>)>, bool) {
         use crate::metrics;
 
         if jobs.is_empty() {
-            return Vec::new();
+            return (Vec::new(), false);
         }
 
+        let mut batch_failed = false;
         let mut results: Vec<(Vec<u8>, Result<(), WintermuteError>)> =
             Vec::with_capacity(jobs.len());
 
@@ -1476,7 +1477,8 @@ impl IndexerManager {
 
         // Process creates in batch (uses parallel COPY for different collection types)
         if !creates.is_empty() {
-            let batch_results = Self::batch_insert_records(pool, &creates, bulk_load).await;
+            let (batch_results, bf) = Self::batch_insert_records(pool, &creates, bulk_load).await;
+            batch_failed |= bf;
             results.extend(batch_results);
         }
 
@@ -1487,7 +1489,7 @@ impl IndexerManager {
             results.push((key.clone(), result));
         }
 
-        results
+        (results, batch_failed)
     }
 
     /// Batch insert records using `PostgreSQL` `COPY` protocol for high throughput.
@@ -1496,11 +1498,13 @@ impl IndexerManager {
         pool: &Pool,
         jobs: &[&(Vec<u8>, IndexJob)],
         bulk_load: bool,
-    ) -> Vec<(Vec<u8>, Result<(), WintermuteError>)> {
+    ) -> (Vec<(Vec<u8>, Result<(), WintermuteError>)>, bool) {
         use crate::metrics;
         use std::time::Instant;
 
         let batch_start = Instant::now();
+        // Set on any COPY/connection failure so callers don't treat the batch as persisted.
+        let mut batch_failed = false;
         let mut results: Vec<(Vec<u8>, Result<(), WintermuteError>)> =
             Vec::with_capacity(jobs.len());
 
@@ -1512,7 +1516,7 @@ impl IndexerManager {
                 for (key, _) in jobs {
                     results.push(((*key).clone(), Err(WintermuteError::Other(err_msg.clone()))));
                 }
-                return results;
+                return (results, true);
             }
         };
 
@@ -1556,7 +1560,7 @@ impl IndexerManager {
         });
 
         if parsed_jobs.is_empty() {
-            return results;
+            return (results, batch_failed);
         }
 
         // Batch 1: Ensure all actors exist using COPY
@@ -1570,7 +1574,7 @@ impl IndexerManager {
 
         if let Err(e) = bulk::copy_ensure_actors(&client, &unique_dids).await {
             tracing::error!("COPY actor insert failed: {e}");
-            // Continue anyway, individual records may still work
+            batch_failed = true;
         }
         let actors_ms = actors_start.elapsed().as_millis();
 
@@ -1598,6 +1602,7 @@ impl IndexerManager {
             Ok(results) => results,
             Err(e) => {
                 tracing::error!("COPY record insert failed: {e}");
+                batch_failed = true;
                 vec![false; parsed_jobs.len()]
             }
         };
@@ -1663,6 +1668,7 @@ impl IndexerManager {
         }
         if let Some(e) = err {
             tracing::error!("COPY batch insert for posts failed: {e}");
+            batch_failed = true;
         }
 
         let (ms, count, err) = likes_result;
@@ -1671,6 +1677,7 @@ impl IndexerManager {
         }
         if let Some(e) = err {
             tracing::error!("COPY batch insert for likes failed: {e}");
+            batch_failed = true;
         }
 
         let (ms, count, err) = follows_result;
@@ -1679,6 +1686,7 @@ impl IndexerManager {
         }
         if let Some(e) = err {
             tracing::error!("COPY batch insert for follows failed: {e}");
+            batch_failed = true;
         }
 
         let (ms, count, err) = reposts_result;
@@ -1687,6 +1695,7 @@ impl IndexerManager {
         }
         if let Some(e) = err {
             tracing::error!("COPY batch insert for reposts failed: {e}");
+            batch_failed = true;
         }
 
         let (ms, count, err) = blocks_result;
@@ -1695,6 +1704,7 @@ impl IndexerManager {
         }
         if let Some(e) = err {
             tracing::error!("COPY batch insert for blocks failed: {e}");
+            batch_failed = true;
         }
 
         let (ms, count, err) = profiles_result;
@@ -1703,6 +1713,7 @@ impl IndexerManager {
         }
         if let Some(e) = err {
             tracing::error!("COPY batch insert for profiles failed: {e}");
+            batch_failed = true;
         }
 
         // Process "other" collection types sequentially (less common)
@@ -1764,7 +1775,7 @@ impl IndexerManager {
             applied_count
         );
 
-        results
+        (results, batch_failed)
     }
 
     // Legacy batch functions - kept as fallbacks (now using COPY protocol)

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -2461,8 +2461,7 @@ impl IndexerManager {
             return Ok(());
         }
 
-        let mut post_data: Vec<(String, String, String, String, String, String)> =
-            Vec::with_capacity(jobs.len());
+        let mut post_data: Vec<bulk::PostCopyRow> = Vec::with_capacity(jobs.len());
         let mut feed_item_data: Vec<(String, String, String, String, String, String)> =
             Vec::with_capacity(jobs.len());
         let mut embed_image_data: Vec<(String, String, String, String)> = Vec::new();
@@ -2484,14 +2483,51 @@ impl IndexerManager {
                     created_at.clone()
                 };
 
-                post_data.push((
-                    uri.clone(),
-                    pj.job.cid.clone(),
-                    pj.did.clone(),
+                // Reply linkage and langs/tags (omitted by the bulk path before; index_post has reply).
+                let reply = record.get("reply");
+                let reply_root = reply
+                    .and_then(|r| r.get("root"))
+                    .and_then(|r| r.get("uri"))
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned);
+                let reply_root_cid = reply
+                    .and_then(|r| r.get("root"))
+                    .and_then(|r| r.get("cid"))
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned);
+                let reply_parent = reply
+                    .and_then(|r| r.get("parent"))
+                    .and_then(|r| r.get("uri"))
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned);
+                let reply_parent_cid = reply
+                    .and_then(|r| r.get("parent"))
+                    .and_then(|r| r.get("cid"))
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned);
+                let langs = record
+                    .get("langs")
+                    .filter(|v| !v.is_null())
+                    .map(std::string::ToString::to_string);
+                let tags = record
+                    .get("tags")
+                    .filter(|v| !v.is_null())
+                    .map(std::string::ToString::to_string);
+
+                post_data.push(bulk::PostCopyRow {
+                    uri: uri.clone(),
+                    cid: pj.job.cid.clone(),
+                    creator: pj.did.clone(),
                     text,
-                    created_at.clone(),
-                    pj.job.indexed_at.clone(),
-                ));
+                    reply_root,
+                    reply_root_cid,
+                    reply_parent,
+                    reply_parent_cid,
+                    created_at: created_at.clone(),
+                    indexed_at: pj.job.indexed_at.clone(),
+                    langs,
+                    tags,
+                });
 
                 feed_item_data.push((
                     "post".to_owned(),

--- a/rsky-wintermute/src/ingester/tests.rs
+++ b/rsky-wintermute/src/ingester/tests.rs
@@ -989,10 +989,14 @@ mod ingester_tests {
                 .execute("DELETE FROM actor WHERE did = $1", &[&did])
                 .await
                 .unwrap();
+            // actor.handle is unique in the canonical schema; derive one per did
+            let handle = format!("{}.test", did.rsplit(':').next().unwrap());
             client
                 .execute(
-                    "INSERT INTO actor (did, handle, \"indexedAt\") VALUES ($1, $2, NOW())",
-                    &[&did, &"test.example"],
+                    "INSERT INTO actor (did, handle, \"indexedAt\") VALUES ($1, $2, NOW()) \
+                     ON CONFLICT (did) DO UPDATE SET handle = EXCLUDED.handle, \
+                     \"upstreamStatus\" = NULL, \"accountEventAt\" = NULL",
+                    &[&did, &handle],
                 )
                 .await
                 .unwrap();

--- a/rsky-wintermute/src/storage.rs
+++ b/rsky-wintermute/src/storage.rs
@@ -7,8 +7,13 @@ use std::ops::Bound;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-/// LMDB max map size: 4TB for `firehose_backfill` queue
-const LMDB_MAP_SIZE: usize = 4 * 1024 * 1024 * 1024 * 1024;
+/// LMDB max map size: 4TB for `firehose_backfill` queue.
+/// Tests use 1GB: repeated 4TB reservations exhaust macOS address space.
+const LMDB_MAP_SIZE: usize = if cfg!(test) {
+    1024 * 1024 * 1024
+} else {
+    4 * 1024 * 1024 * 1024 * 1024
+};
 
 pub struct Storage {
     #[allow(dead_code)] // Kept for Fjall keyspace - partitions reference it internally


### PR DESCRIPTION
Escape all COPY fields and strip NUL, isolate per-repo parse panics, leave failed batches not-done, and populate all post columns (reply linkage, langs, tags) in the bulk loader.