### PR TITLE
feat(wintermute): LIVE_AGGREGATES toggle to defer live aggregate updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/src/config.rs
+++ b/rsky-wintermute/src/config.rs
@@ -142,6 +142,14 @@ pub fn backfiller_timeout() -> Duration {
 
 // Inline processing concurrency for firehose events
 // Should be proportional to DB_POOL_SIZE to avoid excessive connection contention
+/// Live indexing updates aggregates inline (`post_agg`/`profile_agg`). Set `LIVE_AGGREGATES=false`
+/// to defer them (e.g. while a bulk load runs and a full recompute will follow).
+pub static LIVE_AGGREGATES: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var("LIVE_AGGREGATES")
+        .map(|v| v != "false" && v != "0")
+        .unwrap_or(true)
+});
+
 pub static INLINE_CONCURRENCY: LazyLock<usize> = LazyLock::new(|| {
     std::env::var("INLINE_CONCURRENCY")
         .ok()

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -557,7 +557,8 @@ impl IndexerManager {
 
             // Process the entire batch with batch INSERT statements
             let process_start = Instant::now();
-            let (results, _batch_failed) = Self::process_jobs_batch(&pool, &jobs, false).await;
+            let bulk_mode = !*crate::config::LIVE_AGGREGATES;
+            let (results, _batch_failed) = Self::process_jobs_batch(&pool, &jobs, bulk_mode).await;
             let process_ms = process_start.elapsed().as_millis();
 
             // Handle results - remove jobs from queue


### PR DESCRIPTION
Adds LIVE_AGGREGATES=false to defer inline post_agg/profile_agg updates during bulk loads (a full recompute follows), keeping the firehose_live queue drain fast under write pressure.