### PR TITLE
fix(rsky-video): transcode GIF uploads to MP4 before Bunny

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8463,7 +8463,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-video"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "atrium-api 0.25.7",
  "atrium-xrpc",

--- a/rsky-video/Cargo.toml
+++ b/rsky-video/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-video"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Blacksky video service - handles video uploads, transcoding via Bunny Stream, and playback"
@@ -66,6 +66,7 @@ prometheus = { version = "0.13", features = ["process"] }
 # rsky crates
 rsky-syntax = { workspace = true }
 
+tempfile = "3"
+
 [dev-dependencies]
 mockito = "1.7.0"
-tempfile = "3"

--- a/rsky-video/src/main.rs
+++ b/rsky-video/src/main.rs
@@ -26,6 +26,7 @@ mod db;
 mod error;
 mod pds;
 mod signing;
+mod transcode;
 mod xrpc;
 
 pub use config::AppConfig;

--- a/rsky-video/src/transcode.rs
+++ b/rsky-video/src/transcode.rs
@@ -1,0 +1,90 @@
+use std::process::Stdio;
+
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+use tracing::info;
+
+use crate::error::{Error, Result};
+
+/// True when the payload is an animated/static GIF (magic bytes GIF87a/GIF89a).
+pub fn is_gif(bytes: &[u8]) -> bool {
+    bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a")
+}
+
+/// Convert a GIF to a silent MP4 that Bunny Stream can transcode.
+///
+/// Bunny's encoder rejects GIF input outright, so GIF uploads are converted
+/// here first. yuv420p and even dimensions are required for broad H.264
+/// playback; faststart keeps the moov atom at the front for streaming.
+pub async fn gif_to_mp4(bytes: &[u8]) -> Result<Vec<u8>> {
+    let dir = tempfile::tempdir()
+        .map_err(|e| Error::Internal(format!("transcode tempdir failed: {e}")))?;
+    let in_path = dir.path().join("in.gif");
+    let out_path = dir.path().join("out.mp4");
+
+    let mut infile = tokio::fs::File::create(&in_path)
+        .await
+        .map_err(|e| Error::Internal(format!("transcode write failed: {e}")))?;
+    infile
+        .write_all(bytes)
+        .await
+        .map_err(|e| Error::Internal(format!("transcode write failed: {e}")))?;
+    infile
+        .flush()
+        .await
+        .map_err(|e| Error::Internal(format!("transcode flush failed: {e}")))?;
+    drop(infile);
+
+    let output = Command::new("ffmpeg")
+        .arg("-y")
+        .arg("-i")
+        .arg(&in_path)
+        .arg("-movflags")
+        .arg("faststart")
+        .arg("-pix_fmt")
+        .arg("yuv420p")
+        .arg("-vf")
+        .arg("scale=trunc(iw/2)*2:trunc(ih/2)*2")
+        .arg("-an")
+        .arg(&out_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .map_err(|e| Error::Internal(format!("ffmpeg spawn failed: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let tail: String = stderr.chars().rev().take(300).collect::<String>();
+        let tail: String = tail.chars().rev().collect();
+        return Err(Error::Internal(format!(
+            "ffmpeg gif->mp4 failed ({}): {tail}",
+            output.status
+        )));
+    }
+
+    let mp4 = tokio::fs::read(&out_path)
+        .await
+        .map_err(|e| Error::Internal(format!("transcode read failed: {e}")))?;
+    info!(
+        "transcoded gif ({} bytes) to mp4 ({} bytes)",
+        bytes.len(),
+        mp4.len()
+    );
+    Ok(mp4)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_gif_magic() {
+        assert!(is_gif(b"GIF89a\x01\x02"));
+        assert!(is_gif(b"GIF87a\x01\x02"));
+        assert!(!is_gif(b"\x89PNG\r\n"));
+        assert!(!is_gif(b"\x00\x00\x00\x1cftypmp42"));
+        assert!(!is_gif(b""));
+    }
+}

--- a/rsky-video/src/xrpc/mod.rs
+++ b/rsky-video/src/xrpc/mod.rs
@@ -193,6 +193,26 @@ pub async fn upload_video(
     let job_id = job.job_id;
     info!("Created job: {}", job_id);
 
+    // Bunny cannot transcode GIF input, so convert GIFs to MP4 up front; the
+    // PDS blob and Bunny then both receive real video/mp4 bytes.
+    let body = if crate::transcode::is_gif(&body) {
+        match crate::transcode::gif_to_mp4(&body).await {
+            Ok(mp4) => Bytes::from(mp4),
+            Err(e) => {
+                error!("GIF transcode failed: {}", e);
+                db::fail_job(
+                    &state.db_pool,
+                    job_id,
+                    &format!("GIF transcode failed: {}", e),
+                )
+                .await?;
+                return Err(e);
+            }
+        }
+    } else {
+        body
+    };
+
     // STEP 1: Upload blob to user's PDS FIRST
     // Forward the client's service auth token to the PDS.
     // The token should have aud: user's PDS DID (not video service).


### PR DESCRIPTION
Bunny Stream rejects GIF input, so every GIF upload failed encoding. Detect GIF magic bytes and convert to a silent faststart yuv420p MP4 via ffmpeg before the PDS blob upload and Bunny transcode, so both receive real video/mp4 bytes.

## Test plan
- [ ] `cargo build -p rsky-video` / `cargo test -p rsky-video` / `cargo clippy -p rsky-video`
- [ ] ffmpeg args validated against production ffmpeg 6.1 (odd-dimension GIF scales to even, h264/yuv420p)
- [ ] Upload a .gif from desktop; job completes and plays with gif presentation