### PR TITLE
fix(common): from_micros_to_utc panics on real timestamps, 500ing refreshSession

### DIFF
--- a/rsky-common/src/time.rs
+++ b/rsky-common/src/time.rs
@@ -48,10 +48,16 @@ pub fn from_str_to_utc(str: &str) -> Result<DateTime<UtcOffset>> {
         .map_err(|e| anyhow!("failed to parse datetime {:?}: {}", str, e))
 }
 
-#[allow(deprecated)]
 pub fn from_micros_to_utc(micros: i64) -> DateTime<UtcOffset> {
-    let nanoseconds = 230 * 1000000;
-    DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(micros, nanoseconds), Utc)
+    // NaiveDateTime::from_timestamp interprets its argument as SECONDS, so
+    // passing a microsecond value overflowed chrono's representable range and
+    // panicked ("invalid or out-of-range datetime"). rotate_refresh_token
+    // formats the rotated expiry through from_micros_to_str, so this panic
+    // surfaced as a 500 on every com.atproto.server.refreshSession call.
+    // (The old code also stamped a fixed 230ms of sub-second noise onto every
+    // converted instant, which this drops.)
+    DateTime::from_timestamp_micros(micros)
+        .unwrap_or_else(|| panic!("timestamp out of range: {micros} micros"))
 }
 
 pub fn from_micros_to_str(micros: i64) -> String {
@@ -74,6 +80,26 @@ mod tests {
 
     const SAMPLE_PRIMARY: &str = "2023-11-14T22:13:20.000Z";
     const SAMPLE_OFFSET: &str = "2023-11-14T22:13:20+00:00";
+
+    #[test]
+    fn from_micros_to_utc_handles_a_current_era_timestamp() {
+        // Regression: the previous implementation passed microseconds to
+        // NaiveDateTime::from_timestamp (which expects seconds), so any real
+        // timestamp overflowed chrono's range and panicked. This asserts the
+        // conversion both survives and is correct for a present-day instant.
+        let micros = 1_700_000_000_000_000_i64; // 2023-11-14T22:13:20 UTC
+        let dt = from_micros_to_utc(micros);
+        assert_eq!(dt.timestamp_micros(), micros);
+        assert_eq!(dt.to_rfc3339(), "2023-11-14T22:13:20+00:00");
+    }
+
+    #[test]
+    fn from_micros_to_utc_preserves_sub_second_precision() {
+        // The old code discarded the caller's sub-second component and stamped
+        // a fixed 230ms onto every instant; the fix round-trips microseconds.
+        let micros = 1_700_000_000_123_456_i64;
+        assert_eq!(from_micros_to_utc(micros).timestamp_micros(), micros);
+    }
 
     #[test]
     fn from_str_to_micros_parses_primary_format() {


### PR DESCRIPTION
## Problem

`rsky_common::time::from_micros_to_utc` passes its **microsecond** argument to `NaiveDateTime::from_timestamp`, which interprets the value as **seconds**:

```rust
pub fn from_micros_to_utc(micros: i64) -> DateTime<UtcOffset> {
    let nanoseconds = 230 * 1000000;
    DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(micros, nanoseconds), Utc)
}
```

Any present-day timestamp (~`1.7e15` µs) is far outside chrono's representable second range, so the call panics:

```
panicked at chrono-0.4.41/src/lib.rs:709: invalid or out-of-range datetime
```

`AccountManager::rotate_refresh_token` formats the rotated expiry through `from_micros_to_str` → `from_micros_to_utc`, so **`com.atproto.server.refreshSession` returns a 500 on every call**:

```
>> Handler create_session panicked.
>> Outcome: Error(500 Internal Server Error)
```

The existing tests never caught it because the only in-tree callers pass tiny literals (`from_micros_to_str(1_000_000)`), and `1_000_000` seconds is a valid (if 1970-era) datetime.

## Fix

Use `DateTime::from_timestamp_micros`, which interprets the argument as microseconds and returns an `Option` rather than panicking internally. This also drops the fixed `230ms` of sub-second noise the old code stamped onto every converted instant.

## Tests

Added two regression tests in the existing `time` module. Both **panic with `invalid or out-of-range datetime` on the previous implementation** and pass on the fix:
- `from_micros_to_utc_handles_a_current_era_timestamp` — a 2023 timestamp round-trips and formats correctly.
- `from_micros_to_utc_preserves_sub_second_precision` — microsecond precision survives the round-trip.

Verified the whole `account_manager` suite (23 tests, incl. the token-rotation / expiry paths that consume `from_micros_to_str`) still passes — the fix preserves the "distant past = expired" semantics those tests rely on.

Scope is deliberately minimal: one function body plus tests, no signature or API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)