### PR TITLE
fix(rsky-pds): getServiceAuth exp is seconds, not milliseconds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8209,7 +8209,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-pds"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "argon2",

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-pds"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust reference implementation of an atproto PDS."
 license = "Apache-2.0"

--- a/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
+++ b/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
@@ -10,6 +10,28 @@ use rsky_common::time::{from_micros_to_utc, HOUR, MINUTE};
 use rsky_lexicon::com::atproto::server::GetServiceAuthOutput;
 use std::time::SystemTime;
 
+/// Validate a requested service-auth expiry against atproto's bounds.
+///
+/// `exp` is a Unix timestamp in seconds (per the lexicon); it is converted to
+/// microseconds for [`from_micros_to_utc`]. A method-less token may sit at most
+/// a minute in the future, any token at most an hour.
+fn validate_service_auth_exp(
+    exp_seconds: u64,
+    now: DateTime<UtcOffset>,
+    has_lxm: bool,
+) -> Result<()> {
+    let exp_micros = (exp_seconds as i64) * 1_000_000;
+    let diff = from_micros_to_utc(exp_micros) - now;
+    if diff.num_milliseconds() < 0 {
+        bail!("BadExpiration: expiration is in past");
+    } else if diff.num_milliseconds() > HOUR as i64 {
+        bail!("BadExpiration: cannot request a token with an expiration more than an hour in the future");
+    } else if !has_lxm && diff.num_milliseconds() > MINUTE as i64 {
+        bail!("BadExpiration: cannot request a method-less token with an expiration more than a minute in the future");
+    }
+    Ok(())
+}
+
 pub async fn inner_get_service_auth(
     aud: String,
     exp: Option<u64>,
@@ -18,18 +40,9 @@ pub async fn inner_get_service_auth(
 ) -> Result<String> {
     let credentials = auth.access.credentials.unwrap();
     let did = credentials.clone().did.unwrap();
-    let exp = exp.map(|exp| exp * 1000);
     if let Some(exp) = exp {
-        let system_time = SystemTime::now();
-        let now: DateTime<UtcOffset> = system_time.into();
-        let diff = from_micros_to_utc(exp as i64) - now;
-        if diff.num_milliseconds() < 0 {
-            bail!("BadExpiration: expiration is in past");
-        } else if diff.num_milliseconds() > HOUR as i64 {
-            bail!("BadExpiration: cannot request a token with an expiration more than an hour in the future");
-        } else if lxm.is_none() && diff.num_milliseconds() > MINUTE as i64 {
-            bail!("BadExpiration: cannot request a method-less token with an expiration more than a minute in the future");
-        }
+        let now: DateTime<UtcOffset> = SystemTime::now().into();
+        validate_service_auth_exp(exp, now, lxm.is_some())?;
     }
     if let Some(ref lxm) = lxm {
         if PROTECTED_METHODS.contains(lxm.as_str()) {
@@ -68,5 +81,53 @@ pub async fn get_service_auth(
             tracing::error!("Internal Error: {error}");
             Err(ApiError::RuntimeError)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_service_auth_exp;
+    use chrono::offset::Utc as UtcOffset;
+    use chrono::{DateTime, TimeZone};
+
+    // A fixed "now": 2023-11-14T22:13:20Z (1_700_000_000 seconds).
+    fn now() -> DateTime<UtcOffset> {
+        UtcOffset.timestamp_opt(1_700_000_000, 0).unwrap()
+    }
+
+    #[test]
+    fn accepts_expiry_thirty_minutes_out_with_lxm() {
+        // Regression: the old code multiplied seconds by 1_000 (milliseconds)
+        // before a microsecond-based conversion, so every real expiry landed
+        // near 1970 and failed "expiration is in past".
+        let exp = 1_700_000_000 + 30 * 60;
+        assert!(validate_service_auth_exp(exp, now(), true).is_ok());
+    }
+
+    #[test]
+    fn accepts_method_less_expiry_under_a_minute() {
+        let exp = 1_700_000_000 + 30;
+        assert!(validate_service_auth_exp(exp, now(), false).is_ok());
+    }
+
+    #[test]
+    fn rejects_expiry_in_the_past() {
+        let exp = 1_700_000_000 - 1;
+        let err = validate_service_auth_exp(exp, now(), true).unwrap_err();
+        assert!(err.to_string().contains("in past"));
+    }
+
+    #[test]
+    fn rejects_expiry_more_than_an_hour_out() {
+        let exp = 1_700_000_000 + 60 * 60 + 1;
+        let err = validate_service_auth_exp(exp, now(), true).unwrap_err();
+        assert!(err.to_string().contains("more than an hour"));
+    }
+
+    #[test]
+    fn rejects_method_less_expiry_over_a_minute() {
+        let exp = 1_700_000_000 + 61;
+        let err = validate_service_auth_exp(exp, now(), false).unwrap_err();
+        assert!(err.to_string().contains("method-less"));
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #206. `getServiceAuth` converted its `exp` param (a Unix timestamp in **seconds**, per the lexicon) with `exp * 1_000` (milliseconds) before passing it to `from_micros_to_utc`. Since #206 that function correctly interprets its argument as **microseconds**, so the value was 1000x too small, landed near 1970, and every request with a requested `exp` failed `BadExpiration: expiration is in past`. This converts with `1_000_000` and extracts the bounds check into a pure, testable helper.

## Note (separate, not fixed here)

`inner_get_service_auth` validates the requested `exp` but then passes `exp: None` to `create_service_jwt`, so the minted token always uses the default 60s lifetime regardless of the (now correctly validated) request. Left for a separate change to keep this scoped to the unit bug.

## Test plan

- `cargo test -p rsky-pds --lib get_service_auth` — 5 regression tests (valid 30-min and sub-minute method-less expiries accepted; past, >1h, and >1min-method-less rejected). All fail on the previous `* 1_000` and pass on the fix.