### PR TITLE
fix(pds): return ExpiredToken on an expired token, not InvalidRequest

### DIFF
--- a/rsky-pds/src/apis/mod.rs
+++ b/rsky-pds/src/apis/mod.rs
@@ -1,4 +1,4 @@
-use crate::auth_verifier::{AccessStandard, AuthScope, Credentials};
+use crate::auth_verifier::{AccessStandard, AuthError, AuthScope, Credentials};
 use crate::handle;
 use crate::handle::errors::ErrorKind;
 use crate::pipethrough::{
@@ -480,6 +480,22 @@ impl<'r, 'o: 'r> ::rocket::response::Responder<'r, 'o> for ApiError {
 impl From<Error> for ApiError {
     fn from(_value: Error) -> Self {
         ApiError::RuntimeError
+    }
+}
+
+/// Renders an [`AuthError`] as its wire-facing [`ApiError`].
+///
+/// This is the single place auth guards translate a verification failure into
+/// the rendered error body. Previously every guard hardcoded `InvalidRequest`,
+/// which made an expired token indistinguishable from a malformed one; routing
+/// through here surfaces `ExpiredToken` so clients know to refresh, while every
+/// other case keeps its historical `InvalidRequest` rendering unchanged.
+impl From<&AuthError> for ApiError {
+    fn from(error: &AuthError) -> Self {
+        match error {
+            AuthError::ExpiredToken => ApiError::ExpiredToken,
+            other => ApiError::InvalidRequest(other.to_string()),
+        }
     }
 }
 

--- a/rsky-pds/src/auth_verifier.rs
+++ b/rsky-pds/src/auth_verifier.rs
@@ -23,6 +23,23 @@ use thiserror::Error;
 
 const INFINITY: u64 = u64::MAX;
 
+/// True when `err` is jwt-simple's expiry error (`JWTError::TokenHasExpired`),
+/// as opposed to a signature, format, or other verification failure.
+///
+/// jwt-simple raises the error via `ensure!(..., JWTError::TokenHasExpired)`,
+/// so the concrete cause is wrapped in the `anyhow::Error` that propagates out
+/// of [`verify_jwt`]; `downcast_ref` recovers it. This lets an expired token
+/// surface as `ExpiredToken` instead of being collapsed into a generic
+/// `BadJwt`. jwt-simple verifies the signature *before* validating claims, so a
+/// token signed by a different key fails at signature (never at expiry) and is
+/// unaffected.
+pub(crate) fn is_expired_jwt(err: &anyhow::Error) -> bool {
+    matches!(
+        err.downcast_ref::<jwt_simple::JWTError>(),
+        Some(jwt_simple::JWTError::TokenHasExpired)
+    )
+}
+
 pub static PDS_JWT_KEYPAIR: LazyLock<ES256kKeyPair> = LazyLock::new(|| {
     let secp = Secp256k1::new();
     let private_key = env::var("PDS_JWT_KEY_K256_PRIVATE_KEY_HEX").unwrap();
@@ -134,6 +151,8 @@ pub struct JwtPayload {
 
 #[derive(Error, Debug)]
 pub enum AuthError {
+    #[error("ExpiredToken: `Token is expired`")]
+    ExpiredToken,
     #[error("BadJwt: `{0}`")]
     BadJwt(String),
     #[error("BadJwtAudience: `{0}`")]
@@ -184,14 +203,21 @@ impl<'r> FromRequest<'r> for Refresh {
                     None => {
                         let error =
                             AuthError::BadJwt("Unexpected missing refresh token id".to_owned());
-                        req.local_cache(|| Some(ApiError::InvalidRequest(error.to_string())));
+                        req.local_cache(|| Some(ApiError::from(&error)));
                         return Outcome::Error((Status::BadRequest, error));
                     }
                 }
             }
             Err(error) => {
-                let error = AuthError::BadJwt(error.to_string());
-                req.local_cache(|| Some(ApiError::InvalidRequest(error.to_string())));
+                // The refresh guard bypasses `access_check`, so map expiry here
+                // too: an expired REFRESH token on refreshSession must surface as
+                // ExpiredToken so clients know the session is unrecoverable.
+                let error = if is_expired_jwt(&error) {
+                    AuthError::ExpiredToken
+                } else {
+                    AuthError::BadJwt(error.to_string())
+                };
+                req.local_cache(|| Some(ApiError::from(&error)));
                 return Outcome::Error((Status::BadRequest, error));
             }
         };
@@ -233,6 +259,9 @@ pub async fn access_check(
                 Status::BadRequest,
                 AuthError::AccountTakedown(error.to_string()),
             )),
+            _ if is_expired_jwt(&error) => {
+                Outcome::Error((Status::BadRequest, AuthError::ExpiredToken))
+            }
             _ => Outcome::Error((Status::BadRequest, AuthError::BadJwt(error.to_string()))),
         },
     }
@@ -271,7 +300,7 @@ impl<'r> FromRequest<'r> for AccessFull {
         match access_check(req, vec![AuthScope::Access], None).await {
             Outcome::Success(access) => Outcome::Success(AccessFull { access }),
             Outcome::Error(error) => {
-                req.local_cache(|| Some(ApiError::InvalidRequest(error.1.to_string())));
+                req.local_cache(|| Some(ApiError::from(&error.1)));
                 Outcome::Error(error)
             }
             Outcome::Forward(_) => panic!("Outcome::Forward returned"),
@@ -297,7 +326,7 @@ impl<'r> FromRequest<'r> for AccessPrivileged {
         {
             Outcome::Success(access) => Outcome::Success(Self { access }),
             Outcome::Error(error) => {
-                req.local_cache(|| Some(ApiError::InvalidRequest(error.1.to_string())));
+                req.local_cache(|| Some(ApiError::from(&error.1)));
                 Outcome::Error(error)
             }
             Outcome::Forward(_) => panic!("Outcome::Forward returned"),
@@ -327,7 +356,7 @@ impl<'r> FromRequest<'r> for AccessStandard {
         {
             Outcome::Success(access) => Outcome::Success(AccessStandard { access }),
             Outcome::Error(error) => {
-                req.local_cache(|| Some(ApiError::InvalidRequest(error.1.to_string())));
+                req.local_cache(|| Some(ApiError::from(&error.1)));
                 Outcome::Error(error)
             }
             Outcome::Forward(_) => panic!("Outcome::Forward returned"),
@@ -361,7 +390,7 @@ impl<'r> FromRequest<'r> for AccessStandardIncludeChecks {
         {
             Outcome::Success(access) => Outcome::Success(AccessStandardIncludeChecks { access }),
             Outcome::Error(error) => {
-                req.local_cache(|| Some(ApiError::InvalidRequest(error.1.to_string())));
+                req.local_cache(|| Some(ApiError::from(&error.1)));
                 Outcome::Error(error)
             }
             Outcome::Forward(_) => panic!("Outcome::Forward returned"),
@@ -395,7 +424,7 @@ impl<'r> FromRequest<'r> for AccessStandardCheckTakedown {
         {
             Outcome::Success(access) => Outcome::Success(AccessStandardCheckTakedown { access }),
             Outcome::Error(error) => {
-                req.local_cache(|| Some(ApiError::InvalidRequest(error.1.to_string())));
+                req.local_cache(|| Some(ApiError::from(&error.1)));
                 Outcome::Error(error)
             }
             Outcome::Forward(_) => panic!("Outcome::Forward returned"),
@@ -426,7 +455,7 @@ impl<'r> FromRequest<'r> for AccessStandardSignupQueued {
         {
             Outcome::Success(access) => Outcome::Success(AccessStandardSignupQueued { access }),
             Outcome::Error(error) => {
-                req.local_cache(|| Some(ApiError::InvalidRequest(error.1.to_string())));
+                req.local_cache(|| Some(ApiError::from(&error.1)));
                 Outcome::Error(error)
             }
             Outcome::Forward(_) => panic!("Outcome::Forward returned"),
@@ -453,13 +482,20 @@ impl<'r> FromRequest<'r> for RevokeRefreshToken {
                 Some(jti) => Outcome::Success(RevokeRefreshToken { id: jti }),
                 None => {
                     let error = AuthError::BadJwt("Unexpected missing refresh token id".to_owned());
-                    req.local_cache(|| Some(ApiError::InvalidRequest(error.to_string())));
+                    req.local_cache(|| Some(ApiError::from(&error)));
                     Outcome::Error((Status::BadRequest, error))
                 }
             },
             Err(error) => {
-                req.local_cache(|| Some(ApiError::InvalidRequest(error.to_string())));
-                Outcome::Error((Status::BadRequest, AuthError::BadJwt(error.to_string())))
+                // RevokeRefreshToken also bypasses `access_check`; surface expiry
+                // rather than collapsing it into BadJwt.
+                let error = if is_expired_jwt(&error) {
+                    AuthError::ExpiredToken
+                } else {
+                    AuthError::BadJwt(error.to_string())
+                };
+                req.local_cache(|| Some(ApiError::from(&error)));
+                Outcome::Error((Status::BadRequest, error))
             }
         }
     }
@@ -527,7 +563,7 @@ impl<'r> FromRequest<'r> for UserDidAuthOptional {
                     access: Some(output.access),
                 }),
                 Outcome::Error(err) => {
-                    req.local_cache(|| Some(ApiError::InvalidRequest(err.1.to_string())));
+                    req.local_cache(|| Some(ApiError::from(&err.1)));
                     Outcome::Error(err)
                 }
                 _ => panic!("Unexpected outcome during UserDidAuthOptional"),
@@ -617,7 +653,7 @@ impl<'r> FromRequest<'r> for Moderator {
                     access: output.access,
                 }),
                 Outcome::Error(err) => {
-                    req.local_cache(|| Some(ApiError::InvalidRequest(err.1.to_string())));
+                    req.local_cache(|| Some(ApiError::from(&err.1)));
                     Outcome::Error(err)
                 }
                 _ => panic!("Unexpected outcome during Moderator"),
@@ -628,7 +664,7 @@ impl<'r> FromRequest<'r> for Moderator {
                     access: output.access,
                 }),
                 Outcome::Error(err) => {
-                    req.local_cache(|| Some(ApiError::InvalidRequest(err.1.to_string())));
+                    req.local_cache(|| Some(ApiError::from(&err.1)));
                     Outcome::Error(err)
                 }
                 _ => panic!("Unexpected outcome during Moderator"),
@@ -703,7 +739,7 @@ impl<'r> FromRequest<'r> for OptionalAccessOrAdminToken {
                     access: Some(output.access),
                 }),
                 Outcome::Error(err) => {
-                    req.local_cache(|| Some(ApiError::InvalidRequest(err.1.to_string())));
+                    req.local_cache(|| Some(ApiError::from(&err.1)));
                     Outcome::Error(err)
                 }
                 _ => panic!("Unexpected outcome during OptionalAccessOrAdminToken"),
@@ -714,7 +750,7 @@ impl<'r> FromRequest<'r> for OptionalAccessOrAdminToken {
                     access: Some(output.access),
                 }),
                 Outcome::Error(err) => {
-                    req.local_cache(|| Some(ApiError::InvalidRequest(err.1.to_string())));
+                    req.local_cache(|| Some(ApiError::from(&err.1)));
                     Outcome::Error(err)
                 }
                 _ => panic!("Unexpected outcome during OptionalAccessOrAdminToken"),

--- a/rsky-pds/tests/expired_token_tests.rs
+++ b/rsky-pds/tests/expired_token_tests.rs
@@ -1,0 +1,149 @@
+//! Regression tests for expired-token error surfacing.
+//!
+//! An expired access or refresh token must render as
+//! `400 {"error":"ExpiredToken","message":"Token is expired"}` so clients can
+//! distinguish an expired session (call refreshSession / re-login) from a
+//! genuinely malformed token (`InvalidRequest`). Historically every auth guard
+//! collapsed both cases into `InvalidRequest`, leaving clients unable to tell
+//! the two apart.
+
+use jwt_simple::prelude::*;
+use rocket::http::{ContentType, Header, Status};
+use rocket::local::asynchronous::Client;
+use rocket::serde::json::json;
+use rsky_pds::account_manager::helpers::auth::CustomClaimObj;
+use rsky_pds::auth_verifier::{AuthScope, PDS_JWT_KEYPAIR};
+
+mod common;
+
+/// Signs an already-EXPIRED JWT with the PDS's own signing key so it passes
+/// signature verification and fails purely on the expiry claim.
+///
+/// jwt-simple's default time tolerance is 900s, so the token is backdated to
+/// have expired a full hour ago -- well beyond the tolerance -- otherwise the
+/// "expired" token would still verify and the test would be vacuous.
+fn sign_expired_token(scope: AuthScope, did: &str, aud: &str, jti: Option<String>) -> String {
+    let mut claims = Claims::with_custom_claims(
+        CustomClaimObj {
+            scope: scope.as_str().to_owned(),
+        },
+        Duration::from_hours(2),
+    )
+    .with_audience(aud.to_owned())
+    .with_subject(did.to_owned());
+    if let Some(jti) = jti {
+        claims = claims.with_jwt_id(jti);
+    }
+    let now = Clock::now_since_epoch();
+    // Issued three hours ago, expired one hour ago.
+    claims.issued_at = Some(now - Duration::from_hours(3));
+    claims.expires_at = Some(now - Duration::from_hours(1));
+    PDS_JWT_KEYPAIR
+        .sign(claims)
+        .expect("sign token with PDS keypair")
+}
+
+fn service_did() -> String {
+    std::env::var("PDS_SERVICE_DID").expect("PDS_SERVICE_DID set by test env")
+}
+
+const TEST_DID: &str = "did:plc:khvyd3oiw46vif5gm7hijslk";
+
+/// Creates an account and returns a genuine, unexpired access token minted by
+/// the server's own createSession flow (not one we sign by hand).
+async fn real_access_token(client: &Client) -> String {
+    let (identifier, password) = common::create_account(client).await;
+    let response = client
+        .post("/xrpc/com.atproto.server.createSession")
+        .header(ContentType::JSON)
+        .body(json!({ "identifier": identifier, "password": password }).to_string())
+        .dispatch()
+        .await;
+    assert_eq!(response.status(), Status::Ok);
+    let body: serde_json::Value = response.into_json().await.expect("session json");
+    body["accessJwt"].as_str().expect("accessJwt").to_string()
+}
+
+/// DoD 1: an expired ACCESS token yields 400 ExpiredToken.
+#[tokio::test]
+async fn expired_access_token_returns_expired_token() {
+    let (_dir, client) = common::get_client().await;
+    let aud = service_did();
+    let token = sign_expired_token(AuthScope::Access, TEST_DID, &aud, None);
+
+    let response = client
+        .get("/xrpc/com.atproto.server.getSession")
+        .header(Header::new("Authorization", format!("Bearer {token}")))
+        .dispatch()
+        .await;
+
+    let status = response.status();
+    let body: serde_json::Value = response.into_json().await.expect("json error body");
+    assert_eq!(status, Status::BadRequest, "body was {body}");
+    assert_eq!(body["error"], "ExpiredToken", "body was {body}");
+    assert_eq!(body["message"], "Token is expired", "body was {body}");
+}
+
+/// DoD 2: an expired REFRESH token on refreshSession yields 400 ExpiredToken.
+#[tokio::test]
+async fn expired_refresh_token_returns_expired_token() {
+    let (_dir, client) = common::get_client().await;
+    let aud = service_did();
+    let token = sign_expired_token(
+        AuthScope::Refresh,
+        TEST_DID,
+        &aud,
+        Some("refresh-jti-123".to_string()),
+    );
+
+    let response = client
+        .post("/xrpc/com.atproto.server.refreshSession")
+        .header(Header::new("Authorization", format!("Bearer {token}")))
+        .dispatch()
+        .await;
+
+    let status = response.status();
+    let body: serde_json::Value = response.into_json().await.expect("json error body");
+    assert_eq!(status, Status::BadRequest, "body was {body}");
+    assert_eq!(body["error"], "ExpiredToken", "body was {body}");
+    assert_eq!(body["message"], "Token is expired", "body was {body}");
+}
+
+/// DoD 3: a malformed token must NOT be reported as ExpiredToken -- it stays
+/// InvalidRequest so the two failure modes remain distinguishable.
+#[tokio::test]
+async fn malformed_token_returns_invalid_request_not_expired() {
+    let (_dir, client) = common::get_client().await;
+
+    let response = client
+        .get("/xrpc/com.atproto.server.getSession")
+        .header(Header::new("Authorization", "Bearer not.a.valid.jwt"))
+        .dispatch()
+        .await;
+
+    let status = response.status();
+    let body: serde_json::Value = response.into_json().await.expect("json error body");
+    assert_eq!(status, Status::BadRequest, "body was {body}");
+    assert_ne!(body["error"], "ExpiredToken", "body was {body}");
+    assert_eq!(body["error"], "InvalidRequest", "body was {body}");
+}
+
+/// DoD 4: a valid, unexpired access token for an existing account still
+/// authenticates and returns 200 -- no regression from routing auth errors
+/// through the new mapping. Uses `getRecommendedDidCredentials`, an
+/// `AccessStandard`-guarded endpoint that resolves accounts with
+/// `include_deactivated` and needs no repo/actor store, so it returns 200 for
+/// the freshly (admin-)created account without extra setup.
+#[tokio::test]
+async fn valid_access_token_still_authenticates() {
+    let (_dir, client) = common::get_client().await;
+    let token = real_access_token(&client).await;
+
+    let response = client
+        .get("/xrpc/com.atproto.identity.getRecommendedDidCredentials")
+        .header(Header::new("Authorization", format!("Bearer {token}")))
+        .dispatch()
+        .await;
+
+    assert_eq!(response.status(), Status::Ok);
+}


### PR DESCRIPTION
## Problem

An expired access or refresh token is reported as `400 {"error":"InvalidRequest","message":"BadJwt: \`Token has expired\`"}` — indistinguishable from a malformed token. A client can't tell that it should call `refreshSession`. The reference Bluesky PDS returns `400 {"error":"ExpiredToken","message":"Token is expired"}`.

## Fix

`ApiError::ExpiredToken` already exists and already renders the correct response — but it was only reachable from the refresh-rotation path, never from JWT expiry, because two layers erased the signal:

1. `access_check` collapsed every verify error into `AuthError::BadJwt`. This adds an `AuthError::ExpiredToken` variant and an `is_expired_jwt` helper that downcasts to `jwt_simple::JWTError::TokenHasExpired` (jwt-simple's `Error` *is* `anyhow::Error`, so the concrete enum is the real cause).
2. The guard sites hardcoded `ApiError::InvalidRequest` when populating the render cache. This adds `impl From<&AuthError> for ApiError` — `ExpiredToken → ExpiredToken`, **every other variant preserves the existing `InvalidRequest` rendering** — and routes the sites through it. The `Refresh` and `RevokeRefreshToken` guards, which bypass `access_check`, map expiry directly, so an expired *refresh* token on `refreshSession` also yields `ExpiredToken`.

Scope is deliberately minimal: only the expiry code path changes; all other auth errors render exactly as before.

## Tests

New integration tests (SQLite harness): expired access → `ExpiredToken`, expired refresh on `refreshSession` → `ExpiredToken`, malformed → still `InvalidRequest`, valid → 200. Tokens are backdated an hour, past jwt-simple's 900s tolerance. Verified the expiry tests fail on `main` for the right reason (`InvalidRequest` / "Token has expired") and pass with the change; full `rsky-pds` suite (259 lib + integration + oauth + space) stays green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)