### PR TITLE
harden(rsky-video): bound transcode CPU, memory, disk and runtime

### DIFF
--- a/rsky-video/src/config.rs
+++ b/rsky-video/src/config.rs
@@ -47,6 +47,23 @@ pub struct AppConfig {
     pub daily_video_limit: u32,
     /// Daily byte upload limit per user (default: 10GB)
     pub daily_byte_limit: u64,
+
+    /// Wall-clock ceiling for a single ffmpeg invocation, in seconds
+    /// (default: 120). A transcode that outlives it is killed.
+    pub transcode_timeout_secs: u64,
+    /// How many ffmpeg processes may run at once (default: half the available
+    /// cores, at least one). Bounds total transcode CPU, memory and temp disk.
+    pub transcode_max_concurrent: usize,
+    /// How long an upload waits for a transcode slot before being turned away
+    /// with 429, in seconds (default: 30).
+    pub transcode_queue_timeout_secs: u64,
+    /// Ceiling on ffmpeg output size in bytes (default: 2x `max_video_size`).
+    /// Guards against expansion bombs, where a small input decodes into an
+    /// enormous output.
+    pub transcode_max_output_bytes: u64,
+    /// Threads a single ffmpeg process may use (default: 2). Keeps one
+    /// conversion from saturating every core.
+    pub transcode_threads: u32,
 }
 
 impl AppConfig {
@@ -60,6 +77,11 @@ impl AppConfig {
         } else {
             None
         };
+
+        let max_video_size: u64 = env::var("MAX_VIDEO_SIZE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(100_000_000); // 100MB
 
         Ok(Self {
             host: env::var("VIDEO_HOST").unwrap_or_else(|_| "0.0.0.0".to_string()),
@@ -94,10 +116,7 @@ impl AppConfig {
                 .unwrap_or_else(|_| "https://video.blacksky.community".to_string()),
             signing_key_path: env::var("SIGNING_KEY_PATH").ok(),
 
-            max_video_size: env::var("MAX_VIDEO_SIZE")
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(100_000_000), // 100MB
+            max_video_size,
             max_video_duration: env::var("MAX_VIDEO_DURATION")
                 .ok()
                 .and_then(|s| s.parse().ok())
@@ -110,6 +129,38 @@ impl AppConfig {
                 .ok()
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(10_737_418_240), // 10GB
+
+            transcode_timeout_secs: env::var("TRANSCODE_TIMEOUT_SECS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(120),
+            transcode_max_concurrent: env::var("TRANSCODE_MAX_CONCURRENT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_else(default_transcode_concurrency)
+                .max(1),
+            transcode_queue_timeout_secs: env::var("TRANSCODE_QUEUE_TIMEOUT_SECS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(30),
+            transcode_max_output_bytes: env::var("TRANSCODE_MAX_OUTPUT_BYTES")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(max_video_size.saturating_mul(2)),
+            transcode_threads: env::var("TRANSCODE_THREADS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(2)
+                .max(1),
         })
     }
+}
+
+/// Half the available cores, at least one -- leaves headroom for the request
+/// path while a transcode runs.
+fn default_transcode_concurrency() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get() / 2)
+        .unwrap_or(1)
+        .max(1)
 }

--- a/rsky-video/src/main.rs
+++ b/rsky-video/src/main.rs
@@ -40,6 +40,7 @@ pub struct AppState {
     pub pds_client: pds::PdsClient,
     pub http_client: reqwest::Client,
     pub signer: Option<signing::ServiceAuthSigner>,
+    pub transcode_limits: transcode::Limits,
 }
 
 #[tokio::main]
@@ -117,6 +118,17 @@ async fn main() -> color_eyre::Result<()> {
         }
     };
 
+    // Resource ceilings for ffmpeg conversions
+    let transcode_limits = transcode::Limits::from_config(&config);
+    info!(
+        "Transcode limits: {} concurrent, {}s deadline, {}s queue wait, {} byte output cap, {} threads each",
+        config.transcode_max_concurrent,
+        config.transcode_timeout_secs,
+        config.transcode_queue_timeout_secs,
+        config.transcode_max_output_bytes,
+        config.transcode_threads,
+    );
+
     // Create shared state
     let state = Arc::new(AppState {
         config: config.clone(),
@@ -125,6 +137,7 @@ async fn main() -> color_eyre::Result<()> {
         pds_client,
         http_client,
         signer,
+        transcode_limits,
     });
 
     // Build router
@@ -151,7 +164,11 @@ async fn main() -> color_eyre::Result<()> {
         .route("/health", get(health_check))
         .route("/_health", get(health_check))
         // Add middleware
-        .layer(DefaultBodyLimit::max(5 * 1024 * 1024 * 1024)) // 5GB for video uploads
+        // `upload_video` takes the body as `Bytes`, so axum buffers the whole
+        // request in memory before the handler's own size check can run. Cap
+        // the layer at the same limit so an oversized upload is refused with
+        // 413 while streaming, instead of being allocated first.
+        .layer(DefaultBodyLimit::max(config.max_video_size as usize))
         .layer(TraceLayer::new_for_http())
         .layer(
             CorsLayer::new()
@@ -166,9 +183,39 @@ async fn main() -> color_eyre::Result<()> {
     info!("Listening on {}", addr);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
 
     Ok(())
+}
+
+/// Resolves on SIGTERM or SIGINT.
+///
+/// A redeploy sends SIGTERM; without this the process dies immediately and any
+/// in-flight upload is lost after its job row was already created, leaving the
+/// job stuck. Draining lets running uploads finish first.
+async fn shutdown_signal() {
+    let interrupt = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install SIGINT handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = interrupt => info!("SIGINT received, draining in-flight requests"),
+        _ = terminate => info!("SIGTERM received, draining in-flight requests"),
+    }
 }
 
 async fn health_check() -> &'static str {

--- a/rsky-video/src/transcode.rs
+++ b/rsky-video/src/transcode.rs
@@ -11,15 +11,90 @@ pub fn is_gif(bytes: &[u8]) -> bool {
     bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a")
 }
 
+/// True when the payload is a QuickTime container.
+///
+/// This is what iPhone camera captures and screen recordings ship as -- H.264
+/// and AAC inside a `.mov`. The PDS sniffs blob bytes instead of trusting the
+/// content-type we send, so uploading these verbatim yields a blob tagged
+/// `video/quicktime`, and `app.bsky.embed.video` -- which accepts only
+/// `video/mp4` -- then rejects the record.
+///
+/// The predicate deliberately mirrors what the PDS sniffers treat as
+/// QuickTime, since anything they tag `video/quicktime` fails lexicon
+/// validation: an `ftyp` box with the `qt  ` brand (what iOS writes), or a
+/// leading `moov`/`mdat`/`free`/`wide` box for older MOVs that carry no `ftyp`
+/// at all. Verified against `file-type` 16.x (TypeScript PDS) and the `infer`
+/// crate (rsky-pds). ISO BMFF brands (`isom`, `mp42`, ...) already sniff as
+/// `video/mp4` and are left alone.
+pub fn is_quicktime_container(bytes: &[u8]) -> bool {
+    if bytes.len() < 12 {
+        return false;
+    }
+    match &bytes[4..8] {
+        b"ftyp" => &bytes[8..12] == b"qt  ",
+        b"moov" | b"mdat" | b"free" | b"wide" => true,
+        _ => false,
+    }
+}
+
 /// Convert a GIF to a silent MP4 that Bunny Stream can transcode.
 ///
 /// Bunny's encoder rejects GIF input outright, so GIF uploads are converted
 /// here first. yuv420p and even dimensions are required for broad H.264
 /// playback; faststart keeps the moov atom at the front for streaming.
 pub async fn gif_to_mp4(bytes: &[u8]) -> Result<Vec<u8>> {
+    let mp4 = run_ffmpeg(
+        "gif->mp4",
+        "in.gif",
+        bytes,
+        &[
+            "-movflags",
+            "faststart",
+            "-pix_fmt",
+            "yuv420p",
+            "-vf",
+            "scale=trunc(iw/2)*2:trunc(ih/2)*2",
+            "-an",
+        ],
+    )
+    .await?;
+    info!(
+        "transcoded gif ({} bytes) to mp4 ({} bytes)",
+        bytes.len(),
+        mp4.len()
+    );
+    Ok(mp4)
+}
+
+/// Remux a QuickTime `.mov` to MP4 without re-encoding.
+///
+/// `-c copy` keeps the existing H.264/AAC streams and only rewrites the
+/// container, so this is lossless and fast -- the cost is copying the bytes
+/// once (typically under a second for 100MB). MOVs carrying codecs MP4 cannot
+/// hold (ProRes, for instance) fail here with ffmpeg's own error instead of
+/// producing a blob the PDS would tag `video/quicktime`.
+pub async fn mov_to_mp4(bytes: &[u8]) -> Result<Vec<u8>> {
+    let mp4 = run_ffmpeg(
+        "mov->mp4",
+        "in.mov",
+        bytes,
+        &["-c", "copy", "-movflags", "faststart"],
+    )
+    .await?;
+    info!(
+        "remuxed mov ({} bytes) to mp4 ({} bytes)",
+        bytes.len(),
+        mp4.len()
+    );
+    Ok(mp4)
+}
+
+/// Write `bytes` to a temp file, run `ffmpeg -y -i <in> <args> out.mp4`, and
+/// return the result. `label` names the conversion in error messages.
+async fn run_ffmpeg(label: &str, in_name: &str, bytes: &[u8], args: &[&str]) -> Result<Vec<u8>> {
     let dir = tempfile::tempdir()
         .map_err(|e| Error::Internal(format!("transcode tempdir failed: {e}")))?;
-    let in_path = dir.path().join("in.gif");
+    let in_path = dir.path().join(in_name);
     let out_path = dir.path().join("out.mp4");
 
     let mut infile = tokio::fs::File::create(&in_path)
@@ -39,13 +114,7 @@ pub async fn gif_to_mp4(bytes: &[u8]) -> Result<Vec<u8>> {
         .arg("-y")
         .arg("-i")
         .arg(&in_path)
-        .arg("-movflags")
-        .arg("faststart")
-        .arg("-pix_fmt")
-        .arg("yuv420p")
-        .arg("-vf")
-        .arg("scale=trunc(iw/2)*2:trunc(ih/2)*2")
-        .arg("-an")
+        .args(args)
         .arg(&out_path)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -59,20 +128,14 @@ pub async fn gif_to_mp4(bytes: &[u8]) -> Result<Vec<u8>> {
         let tail: String = stderr.chars().rev().take(300).collect::<String>();
         let tail: String = tail.chars().rev().collect();
         return Err(Error::Internal(format!(
-            "ffmpeg gif->mp4 failed ({}): {tail}",
+            "ffmpeg {label} failed ({}): {tail}",
             output.status
         )));
     }
 
-    let mp4 = tokio::fs::read(&out_path)
+    tokio::fs::read(&out_path)
         .await
-        .map_err(|e| Error::Internal(format!("transcode read failed: {e}")))?;
-    info!(
-        "transcoded gif ({} bytes) to mp4 ({} bytes)",
-        bytes.len(),
-        mp4.len()
-    );
-    Ok(mp4)
+        .map_err(|e| Error::Internal(format!("transcode read failed: {e}")))
 }
 
 #[cfg(test)]
@@ -86,5 +149,101 @@ mod tests {
         assert!(!is_gif(b"\x89PNG\r\n"));
         assert!(!is_gif(b"\x00\x00\x00\x1cftypmp42"));
         assert!(!is_gif(b""));
+    }
+
+    #[test]
+    fn detects_quicktime_brand() {
+        // What an iPhone capture / screen recording actually starts with.
+        assert!(is_quicktime_container(
+            b"\x00\x00\x00\x14ftypqt  \x00\x00\x00\x00"
+        ));
+    }
+
+    #[test]
+    fn iso_bmff_brands_are_not_quicktime() {
+        // Already sniff as video/mp4 on the PDS -- must not be remuxed.
+        assert!(!is_quicktime_container(
+            b"\x00\x00\x00\x18ftypmp42\x00\x00\x00\x00"
+        ));
+        assert!(!is_quicktime_container(
+            b"\x00\x00\x00\x18ftypisom\x00\x00\x02\x00"
+        ));
+    }
+
+    #[test]
+    fn detects_ftyp_less_quicktime() {
+        // Older MOVs lead with a bare box; both PDS sniffers call these
+        // video/quicktime, so they need the remux too.
+        for tag in [b"moov", b"mdat", b"free", b"wide"] {
+            let mut buf = vec![0x00, 0x00, 0x00, 0x14];
+            buf.extend_from_slice(tag);
+            buf.extend_from_slice(&[0u8; 8]);
+            assert!(is_quicktime_container(&buf), "expected {tag:?} to match");
+        }
+    }
+
+    /// End-to-end proof that the remux produces bytes the PDS will tag
+    /// `video/mp4`: builds an H.264/AAC QuickTime file the way iOS ships one,
+    /// runs it through `mov_to_mp4`, and checks the container brand flipped.
+    ///
+    /// Run from the repository root with:
+    /// `cargo test -p rsky-video mov_remux -- --ignored`
+    #[tokio::test]
+    #[ignore = "requires ffmpeg on PATH"]
+    async fn mov_remux_yields_an_mp4_brand() {
+        let dir = tempfile::tempdir().unwrap();
+        let mov_path = dir.path().join("fixture.mov");
+        let status = Command::new("ffmpeg")
+            .args([
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "testsrc=size=320x240:rate=30",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=440",
+                "-c:v",
+                "libx264",
+                "-c:a",
+                "aac",
+                "-t",
+                "1",
+                "-f",
+                "mov",
+            ])
+            .arg(&mov_path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .expect("ffmpeg should be on PATH");
+        assert!(status.success(), "fixture generation failed");
+
+        let mov = tokio::fs::read(&mov_path).await.unwrap();
+        assert!(
+            is_quicktime_container(&mov),
+            "ffmpeg -f mov should emit the `qt  ` brand"
+        );
+
+        let mp4 = mov_to_mp4(&mov).await.expect("remux should succeed");
+        assert_eq!(&mp4[4..8], b"ftyp", "output should be ISO BMFF");
+        assert!(
+            !is_quicktime_container(&mp4),
+            "output still sniffs as QuickTime: brand {:?}",
+            String::from_utf8_lossy(&mp4[8..12])
+        );
+    }
+
+    #[test]
+    fn non_quicktime_payloads_are_rejected() {
+        assert!(!is_quicktime_container(b""));
+        assert!(!is_quicktime_container(b"GIF89a\x00\x00\x00\x00\x00\x00"));
+        assert!(!is_quicktime_container(
+            b"\x00\x00\x00\x14skip\x00\x00\x00\x00"
+        ));
+        // Shorter than the 12 bytes the brand check needs -- must not panic.
+        assert!(!is_quicktime_container(b"\x00\x00\x00\x14ftypqt"));
     }
 }

--- a/rsky-video/src/transcode.rs
+++ b/rsky-video/src/transcode.rs
@@ -1,10 +1,54 @@
+use std::path::Path;
 use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
 
-use tokio::io::AsyncWriteExt;
-use tokio::process::Command;
-use tracing::info;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::{Child, Command};
+use tokio::sync::Semaphore;
+use tracing::{info, warn};
 
+use crate::config::AppConfig;
 use crate::error::{Error, Result};
+
+/// How often the supervisor checks the growing output file against the size
+/// ceiling.
+const OUTPUT_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Cap on the ffmpeg stderr we buffer for error messages.
+const STDERR_CAPTURE_LIMIT: u64 = 64 * 1024;
+
+/// Resource ceilings applied to every ffmpeg invocation.
+///
+/// Transcoding is the only place this service hands an attacker-supplied file
+/// to a CPU- and memory-hungry subprocess, so each conversion runs under a
+/// wall-clock deadline, an output-size ceiling, a thread cap, and a global
+/// concurrency limit. Cloning is cheap -- the semaphore is shared.
+#[derive(Clone)]
+pub struct Limits {
+    timeout: Duration,
+    queue_timeout: Duration,
+    max_output_bytes: u64,
+    threads: u32,
+    slots: Arc<Semaphore>,
+}
+
+impl Limits {
+    pub fn from_config(config: &AppConfig) -> Self {
+        Self {
+            timeout: Duration::from_secs(config.transcode_timeout_secs),
+            queue_timeout: Duration::from_secs(config.transcode_queue_timeout_secs),
+            max_output_bytes: config.transcode_max_output_bytes,
+            threads: config.transcode_threads,
+            slots: Arc::new(Semaphore::new(config.transcode_max_concurrent)),
+        }
+    }
+
+    /// Slots not currently held by a running conversion.
+    pub fn available_slots(&self) -> usize {
+        self.slots.available_permits()
+    }
+}
 
 /// True when the payload is an animated/static GIF (magic bytes GIF87a/GIF89a).
 pub fn is_gif(bytes: &[u8]) -> bool {
@@ -42,10 +86,12 @@ pub fn is_quicktime_container(bytes: &[u8]) -> bool {
 /// Bunny's encoder rejects GIF input outright, so GIF uploads are converted
 /// here first. yuv420p and even dimensions are required for broad H.264
 /// playback; faststart keeps the moov atom at the front for streaming.
-pub async fn gif_to_mp4(bytes: &[u8]) -> Result<Vec<u8>> {
+pub async fn gif_to_mp4(limits: &Limits, bytes: &[u8]) -> Result<Vec<u8>> {
     let mp4 = run_ffmpeg(
+        limits,
         "gif->mp4",
         "in.gif",
+        "gif",
         bytes,
         &[
             "-movflags",
@@ -73,10 +119,13 @@ pub async fn gif_to_mp4(bytes: &[u8]) -> Result<Vec<u8>> {
 /// once (typically under a second for 100MB). MOVs carrying codecs MP4 cannot
 /// hold (ProRes, for instance) fail here with ffmpeg's own error instead of
 /// producing a blob the PDS would tag `video/quicktime`.
-pub async fn mov_to_mp4(bytes: &[u8]) -> Result<Vec<u8>> {
+pub async fn mov_to_mp4(limits: &Limits, bytes: &[u8]) -> Result<Vec<u8>> {
     let mp4 = run_ffmpeg(
+        limits,
         "mov->mp4",
         "in.mov",
+        // The QuickTime/ISO BMFF demuxer, named for every brand it handles.
+        "mov,mp4,m4a,3gp,3g2,mj2",
         bytes,
         &["-c", "copy", "-movflags", "faststart"],
     )
@@ -89,9 +138,39 @@ pub async fn mov_to_mp4(bytes: &[u8]) -> Result<Vec<u8>> {
     Ok(mp4)
 }
 
-/// Write `bytes` to a temp file, run `ffmpeg -y -i <in> <args> out.mp4`, and
-/// return the result. `label` names the conversion in error messages.
-async fn run_ffmpeg(label: &str, in_name: &str, bytes: &[u8], args: &[&str]) -> Result<Vec<u8>> {
+/// Write `bytes` to a temp file, run ffmpeg over it under `limits`, and return
+/// the result. `label` names the conversion in error messages; `input_format`
+/// pins the demuxer.
+async fn run_ffmpeg(
+    limits: &Limits,
+    label: &str,
+    in_name: &str,
+    input_format: &str,
+    bytes: &[u8],
+    args: &[&str],
+) -> Result<Vec<u8>> {
+    // Hold a slot for the whole conversion. Without this, N concurrent uploads
+    // mean N concurrent ffmpeg processes, and the box runs out of CPU, memory
+    // and temp disk at once.
+    let _permit = match tokio::time::timeout(
+        limits.queue_timeout,
+        Arc::clone(&limits.slots).acquire_owned(),
+    )
+    .await
+    {
+        Ok(Ok(permit)) => permit,
+        Ok(Err(_)) => return Err(Error::Internal("transcode semaphore closed".to_string())),
+        Err(_) => {
+            warn!(
+                "transcode queue saturated: {label} waited {}s for a slot",
+                limits.queue_timeout.as_secs()
+            );
+            return Err(Error::RateLimited(
+                "video transcoding is at capacity, please retry".to_string(),
+            ));
+        }
+    };
+
     let dir = tempfile::tempdir()
         .map_err(|e| Error::Internal(format!("transcode tempdir failed: {e}")))?;
     let in_path = dir.path().join(in_name);
@@ -110,26 +189,59 @@ async fn run_ffmpeg(label: &str, in_name: &str, bytes: &[u8], args: &[&str]) -> 
         .map_err(|e| Error::Internal(format!("transcode flush failed: {e}")))?;
     drop(infile);
 
-    let output = Command::new("ffmpeg")
+    // `-f <input_format>` pins the demuxer to the one the magic bytes already
+    // implied, and `-protocol_whitelist file` keeps a crafted input from
+    // steering ffmpeg into a playlist-style demuxer that opens other paths or
+    // URLs. `-loglevel error` keeps stderr small enough that the process can
+    // never block on a full pipe while we supervise it.
+    let mut child = Command::new("ffmpeg")
+        .arg("-nostdin")
+        .arg("-hide_banner")
+        .arg("-nostats")
+        .arg("-loglevel")
+        .arg("error")
+        .arg("-protocol_whitelist")
+        .arg("file")
+        .arg("-f")
+        .arg(input_format)
         .arg("-y")
         .arg("-i")
         .arg(&in_path)
+        .arg("-threads")
+        .arg(limits.threads.to_string())
         .args(args)
         .arg(&out_path)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
-        .output()
-        .await
+        // If the handler future is dropped -- a client that disconnects
+        // mid-upload, or shutdown -- the child dies with it instead of
+        // lingering as an orphan burning CPU.
+        .kill_on_drop(true)
+        .spawn()
         .map_err(|e| Error::Internal(format!("ffmpeg spawn failed: {e}")))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+    let status = supervise(&mut child, limits, label, &out_path).await?;
+
+    if !status.success() {
+        let stderr = capture_stderr(&mut child).await;
         let tail: String = stderr.chars().rev().take(300).collect::<String>();
         let tail: String = tail.chars().rev().collect();
         return Err(Error::Internal(format!(
-            "ffmpeg {label} failed ({}): {tail}",
-            output.status
+            "ffmpeg {label} failed ({status}): {tail}"
+        )));
+    }
+
+    // The poll below can miss a burst of writes between ticks, so re-check the
+    // finished file before reading it into memory.
+    let written = tokio::fs::metadata(&out_path)
+        .await
+        .map_err(|e| Error::Internal(format!("transcode stat failed: {e}")))?
+        .len();
+    if written > limits.max_output_bytes {
+        return Err(Error::VideoTooLarge(format!(
+            "{label} produced {written} bytes, over the {} byte transcode limit",
+            limits.max_output_bytes
         )));
     }
 
@@ -138,9 +250,167 @@ async fn run_ffmpeg(label: &str, in_name: &str, bytes: &[u8], args: &[&str]) -> 
         .map_err(|e| Error::Internal(format!("transcode read failed: {e}")))
 }
 
+/// Wait for ffmpeg, killing it if it outlives the deadline or its output grows
+/// past the ceiling.
+///
+/// ffmpeg's own `-fs` flag is not used: it is silently ignored for stream-copy
+/// remuxes *and* re-encodes (verified against ffmpeg 8.1), so the ceiling is
+/// enforced here by watching the file and killing the process.
+async fn supervise(
+    child: &mut Child,
+    limits: &Limits,
+    label: &str,
+    out_path: &Path,
+) -> Result<std::process::ExitStatus> {
+    enum Outcome {
+        Exited(std::io::Result<std::process::ExitStatus>),
+        Deadline,
+        TooBig(u64),
+    }
+
+    let deadline = tokio::time::sleep(limits.timeout);
+    tokio::pin!(deadline);
+    let mut poll = tokio::time::interval(OUTPUT_POLL_INTERVAL);
+    poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    // Scoped so the `wait()` borrow of `child` ends before we kill it.
+    let outcome = {
+        let waiter = child.wait();
+        tokio::pin!(waiter);
+        loop {
+            tokio::select! {
+                status = &mut waiter => break Outcome::Exited(status),
+                _ = &mut deadline => break Outcome::Deadline,
+                _ = poll.tick() => {
+                    if let Ok(meta) = tokio::fs::metadata(out_path).await {
+                        if meta.len() > limits.max_output_bytes {
+                            break Outcome::TooBig(meta.len());
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    match outcome {
+        Outcome::Exited(status) => {
+            status.map_err(|e| Error::Internal(format!("ffmpeg {label} wait failed: {e}")))
+        }
+        Outcome::Deadline => {
+            kill(child, label, "deadline exceeded").await;
+            Err(Error::Internal(format!(
+                "ffmpeg {label} exceeded the {}s transcode deadline",
+                limits.timeout.as_secs()
+            )))
+        }
+        Outcome::TooBig(written) => {
+            kill(child, label, "output ceiling exceeded").await;
+            Err(Error::VideoTooLarge(format!(
+                "{label} output grew past {} bytes ({written} written)",
+                limits.max_output_bytes
+            )))
+        }
+    }
+}
+
+/// SIGKILL the child and reap it, so no ffmpeg survives a rejected conversion.
+async fn kill(child: &mut Child, label: &str, reason: &str) {
+    warn!("killing ffmpeg {label}: {reason}");
+    if let Err(e) = child.kill().await {
+        warn!("failed to kill ffmpeg {label}: {e}");
+    }
+}
+
+/// Read at most [`STDERR_CAPTURE_LIMIT`] of ffmpeg's stderr for diagnostics.
+async fn capture_stderr(child: &mut Child) -> String {
+    let Some(mut pipe) = child.stderr.take() else {
+        return String::new();
+    };
+    let mut buf = Vec::new();
+    if let Err(e) = (&mut pipe)
+        .take(STDERR_CAPTURE_LIMIT)
+        .read_to_end(&mut buf)
+        .await
+    {
+        warn!("failed to read ffmpeg stderr: {e}");
+    }
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Generous ceilings, so limit tests can tighten only the one they exercise.
+    fn test_limits() -> Limits {
+        Limits {
+            timeout: Duration::from_secs(60),
+            queue_timeout: Duration::from_secs(5),
+            max_output_bytes: 64 * 1024 * 1024,
+            threads: 2,
+            slots: Arc::new(Semaphore::new(2)),
+        }
+    }
+
+    /// Build a fixture with ffmpeg and return its bytes.
+    async fn ffmpeg_fixture(name: &str, args: &[&str]) -> Vec<u8> {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(name);
+        let status = Command::new("ffmpeg")
+            .args(args)
+            .arg(&path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .expect("ffmpeg should be on PATH");
+        assert!(status.success(), "generating {name} failed");
+        tokio::fs::read(&path).await.unwrap()
+    }
+
+    async fn mov_fixture() -> Vec<u8> {
+        ffmpeg_fixture(
+            "fixture.mov",
+            &[
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "testsrc=size=320x240:rate=30",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=440",
+                "-c:v",
+                "libx264",
+                "-c:a",
+                "aac",
+                "-t",
+                "1",
+                "-f",
+                "mov",
+            ],
+        )
+        .await
+    }
+
+    async fn gif_fixture() -> Vec<u8> {
+        ffmpeg_fixture(
+            "fixture.gif",
+            &[
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "testsrc=size=320x240:rate=25",
+                "-t",
+                "2",
+                "-f",
+                "gif",
+            ],
+        )
+        .await
+    }
 
     #[test]
     fn detects_gif_magic() {
@@ -191,48 +461,99 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires ffmpeg on PATH"]
     async fn mov_remux_yields_an_mp4_brand() {
-        let dir = tempfile::tempdir().unwrap();
-        let mov_path = dir.path().join("fixture.mov");
-        let status = Command::new("ffmpeg")
-            .args([
-                "-y",
-                "-f",
-                "lavfi",
-                "-i",
-                "testsrc=size=320x240:rate=30",
-                "-f",
-                "lavfi",
-                "-i",
-                "sine=frequency=440",
-                "-c:v",
-                "libx264",
-                "-c:a",
-                "aac",
-                "-t",
-                "1",
-                "-f",
-                "mov",
-            ])
-            .arg(&mov_path)
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await
-            .expect("ffmpeg should be on PATH");
-        assert!(status.success(), "fixture generation failed");
-
-        let mov = tokio::fs::read(&mov_path).await.unwrap();
+        let mov = mov_fixture().await;
         assert!(
             is_quicktime_container(&mov),
             "ffmpeg -f mov should emit the `qt  ` brand"
         );
 
-        let mp4 = mov_to_mp4(&mov).await.expect("remux should succeed");
+        let mp4 = mov_to_mp4(&test_limits(), &mov)
+            .await
+            .expect("remux should succeed");
         assert_eq!(&mp4[4..8], b"ftyp", "output should be ISO BMFF");
         assert!(
             !is_quicktime_container(&mp4),
             "output still sniffs as QuickTime: brand {:?}",
             String::from_utf8_lossy(&mp4[8..12])
+        );
+    }
+
+    /// A saturated queue must turn uploads away rather than pile up unbounded
+    /// waiters. No ffmpeg runs here -- the slot wait fails first.
+    #[tokio::test]
+    async fn saturated_queue_is_rejected_with_429() {
+        let mut limits = test_limits();
+        limits.slots = Arc::new(Semaphore::new(1));
+        limits.queue_timeout = Duration::from_millis(50);
+
+        let held = Arc::clone(&limits.slots).acquire_owned().await.unwrap();
+        assert_eq!(limits.available_slots(), 0);
+
+        let err = mov_to_mp4(&limits, b"\x00\x00\x00\x14ftypqt  \x00\x00\x00\x00")
+            .await
+            .expect_err("should be turned away while the only slot is held");
+        assert!(
+            matches!(err, Error::RateLimited(_)),
+            "expected RateLimited, got: {err}"
+        );
+
+        drop(held);
+        assert_eq!(limits.available_slots(), 1);
+    }
+
+    /// The GIF path is already in production, so cover it end to end with the
+    /// pinned demuxer and protocol whitelist in place.
+    #[tokio::test]
+    #[ignore = "requires ffmpeg on PATH"]
+    async fn gif_converts_to_an_mp4() {
+        let gif = gif_fixture().await;
+        assert!(is_gif(&gif));
+
+        let mp4 = gif_to_mp4(&test_limits(), &gif)
+            .await
+            .expect("gif conversion should succeed");
+        assert_eq!(&mp4[4..8], b"ftyp", "output should be ISO BMFF");
+        assert!(!is_quicktime_container(&mp4));
+    }
+
+    /// The deadline must kill a conversion that outlives it, and the permit
+    /// must come back afterward so one slow upload cannot wedge a slot.
+    #[tokio::test]
+    #[ignore = "requires ffmpeg on PATH"]
+    async fn deadline_kills_a_slow_transcode() {
+        let gif = gif_fixture().await;
+        let mut limits = test_limits();
+        limits.timeout = Duration::from_millis(1);
+
+        let err = gif_to_mp4(&limits, &gif)
+            .await
+            .expect_err("1ms is not enough to re-encode a 2s gif");
+        assert!(
+            err.to_string().contains("deadline"),
+            "expected a deadline error, got: {err}"
+        );
+        assert_eq!(
+            limits.available_slots(),
+            2,
+            "the permit should be released after a killed transcode"
+        );
+    }
+
+    /// Output ceiling: guards against a small input expanding into an enormous
+    /// output. ffmpeg's own `-fs` does not enforce this (see `supervise`).
+    #[tokio::test]
+    #[ignore = "requires ffmpeg on PATH"]
+    async fn output_ceiling_rejects_oversized_output() {
+        let gif = gif_fixture().await;
+        let mut limits = test_limits();
+        limits.max_output_bytes = 1000;
+
+        let err = gif_to_mp4(&limits, &gif)
+            .await
+            .expect_err("a 2s 320x240 encode is larger than 1000 bytes");
+        assert!(
+            matches!(err, Error::VideoTooLarge(_)),
+            "expected VideoTooLarge, got: {err}"
         );
     }
 

--- a/rsky-video/src/xrpc/mod.rs
+++ b/rsky-video/src/xrpc/mod.rs
@@ -193,8 +193,14 @@ pub async fn upload_video(
     let job_id = job.job_id;
     info!("Created job: {}", job_id);
 
-    // Bunny cannot transcode GIF input, so convert GIFs to MP4 up front; the
-    // PDS blob and Bunny then both receive real video/mp4 bytes.
+    // Normalize the container to MP4 before either upload below.
+    //
+    // Bunny cannot transcode GIF input at all, and the PDS tags blobs by
+    // sniffing their bytes rather than the content-type we send -- so a
+    // QuickTime `.mov` (every iPhone capture) would come back as
+    // `video/quicktime` and be rejected by app.bsky.embed.video, which accepts
+    // only `video/mp4`. Converting here means the PDS blob and Bunny both
+    // receive real MP4 bytes.
     let body = if crate::transcode::is_gif(&body) {
         match crate::transcode::gif_to_mp4(&body).await {
             Ok(mp4) => Bytes::from(mp4),
@@ -206,6 +212,15 @@ pub async fn upload_video(
                     &format!("GIF transcode failed: {}", e),
                 )
                 .await?;
+                return Err(e);
+            }
+        }
+    } else if crate::transcode::is_quicktime_container(&body) {
+        match crate::transcode::mov_to_mp4(&body).await {
+            Ok(mp4) => Bytes::from(mp4),
+            Err(e) => {
+                error!("MOV remux failed: {}", e);
+                db::fail_job(&state.db_pool, job_id, &format!("MOV remux failed: {}", e)).await?;
                 return Err(e);
             }
         }

--- a/rsky-video/src/xrpc/mod.rs
+++ b/rsky-video/src/xrpc/mod.rs
@@ -202,7 +202,7 @@ pub async fn upload_video(
     // only `video/mp4`. Converting here means the PDS blob and Bunny both
     // receive real MP4 bytes.
     let body = if crate::transcode::is_gif(&body) {
-        match crate::transcode::gif_to_mp4(&body).await {
+        match crate::transcode::gif_to_mp4(&state.transcode_limits, &body).await {
             Ok(mp4) => Bytes::from(mp4),
             Err(e) => {
                 error!("GIF transcode failed: {}", e);
@@ -216,7 +216,7 @@ pub async fn upload_video(
             }
         }
     } else if crate::transcode::is_quicktime_container(&body) {
-        match crate::transcode::mov_to_mp4(&body).await {
+        match crate::transcode::mov_to_mp4(&state.transcode_limits, &body).await {
             Ok(mp4) => Bytes::from(mp4),
             Err(e) => {
                 error!("MOV remux failed: {}", e);


### PR DESCRIPTION
## Summary

> **Targets `main`, and carries #210's commit as a dependency.** The hardening builds directly on the MOV
> remux path introduced in #210, so this branch contains both commits: `b17b22e` (the fix) and `9ce330b`
> (this hardening). To review the hardening alone, read `9ce330b` on its own. If #210 merges first, this
> diff reduces to that commit automatically; if this one merges first, #210 becomes redundant and can be
> closed.

Transcoding is the one place this service hands an **attacker-supplied file to a CPU- and memory-hungry subprocess**, and until now that subprocess ran with no ceiling of any kind: no deadline, no output cap, no thread cap, and no limit on how many could run at once. A single crafted upload could pin the box, and N concurrent uploads meant N concurrent `ffmpeg` processes competing for CPU, RAM and temp disk.

## Ceilings

Every conversion now runs under `transcode::Limits`, all env-overridable:

| Knob | Default | Bounds |
| --- | --- | --- |
| `TRANSCODE_TIMEOUT_SECS` | 120 | Wall-clock per conversion. Overrunning ffmpeg is SIGKILLed and reaped. |
| `TRANSCODE_MAX_CONCURRENT` | half the cores, min 1 | **Total** transcode CPU, memory and temp disk. |
| `TRANSCODE_QUEUE_TIMEOUT_SECS` | 30 | How long an upload waits for a slot before 429 — so waiters can't pile up unbounded. |
| `TRANSCODE_MAX_OUTPUT_BYTES` | 2× `MAX_VIDEO_SIZE` | Expansion bombs: a small input that decodes into an enormous output. |
| `TRANSCODE_THREADS` | 2 | Per-process, so one conversion can't saturate every core. |

### Why not ffmpeg's `-fs`?

Because **it does not work.** `-fs` is silently ignored both for stream-copy remuxes and for re-encodes — verified against ffmpeg 8.1.2:

```
-fs 50000  -c copy       -> 158022 bytes written   (cap ignored)
-fs 20000  -c:v libx264  ->  68755 bytes written   (cap ignored)
```

Shipping `-fs` would have been a cap that does nothing. The ceiling is instead enforced by watching the output file and killing the process, which doesn't depend on ffmpeg honoring anything.

## Other subprocess hardening

- **`kill_on_drop(true)`** — tokio does *not* kill a child when its future is dropped. Before this, a client that disconnected mid-upload left `ffmpeg` running to completion; repeated connect/disconnect was unbounded free CPU with no request left to attribute it to.
- **Pinned demuxer + protocol whitelist** — `-f <format>` pins ffmpeg to the format the magic bytes already implied, and `-protocol_whitelist file` keeps a crafted input from steering ffmpeg into a playlist-style demuxer that opens other local paths or URLs.
- **Bounded stderr** — `-loglevel error -nostats` keeps stderr small enough that ffmpeg can never block writing to a full pipe while we supervise it, and the capture itself is capped at 64KB. (It also makes failure messages *more* useful: real error lines instead of progress spam.)

## Two fixes outside `transcode.rs`

**`DefaultBodyLimit` was 5GB.** `upload_video` takes the body as `Bytes`, which axum buffers **entirely in memory** before the handler runs — so the handler's own `MAX_VIDEO_SIZE` check (100MB) happened *after* the allocation and did nothing to prevent it. One request could force a multi-GB allocation; a few concurrently would OOM the host. The layer now uses `max_video_size`, so oversized uploads are refused with 413 while streaming.

**No graceful shutdown.** `axum::serve` had none, so a redeploy's SIGTERM killed in-flight uploads *after* their job rows were created, leaving jobs stuck. It now drains on SIGTERM/SIGINT — relevant given a redeploy is imminent.

## Verification

`cargo test -p rsky-video`: 11 passed. With `-- --ignored`: 4 passed. Clippy: no new warnings. `cargo fmt`: clean.

- `saturated_queue_is_rejected_with_429` — turns uploads away instead of queueing forever, without spawning ffmpeg at all.
- `deadline_kills_a_slow_transcode` — deadline fires **and** the permit is released, so one slow upload can't wedge a slot permanently.
- `output_ceiling_rejects_oversized_output` — `VideoTooLarge` rather than an unbounded write.
- `gif_converts_to_an_mp4` / `mov_remux_yields_an_mp4_brand` — both real paths still convert correctly with the pinned demuxer and whitelist in place.

The kill was also verified out of band, since a TTL that doesn't actually kill is worth nothing: a 720p encode interrupted at 1ms leaves **no surviving ffmpeg process**, checked while that same encode was independently measured at 1.72s real / 3.70s user of work — so an unkilled process would still have been plainly visible.

## Note

`max_video_duration` (90s) is config'd but **enforced nowhere** in the codebase — it predates this PR. I left it alone deliberately: the natural fix is ffmpeg `-t`, but that would *silently truncate* a user's video rather than reject it, which is a product decision rather than a hardening one. Worth a follow-up.

## Related Issues

Follow-up to #210, which introduced the MOV remux path and made ffmpeg load user-controlled.

## Changes
- [x] Other (please specify): resource-exhaustion and subprocess hardening

## Checklist
- [x] I have tested the changes (including writing unit tests).
- [x] I confirm that my implementation aligns with the [canonical Typescript implementation](https://github.com/bluesky-social/atproto) and/or [atproto spec](https://atproto.com/specs/atp)
- [x] I have updated relevant documentation. (New env vars are documented as doc comments in `config.rs`, matching how the existing ones are — this crate has no README.)
- [x] I have formatted my code correctly
- [x] I have provided examples for how this code works or will be used

🤖 Generated with [Claude Code](https://claude.com/claude-code)
