### PR TITLE
fix(wintermute): upsert actor on identity events so new-account handles are never dropped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/src/ingester/mod.rs
+++ b/rsky-wintermute/src/ingester/mod.rs
@@ -962,24 +962,23 @@ impl IngesterManager {
             }
         };
 
-        // Update actor table
+        // Identity events arrive before any commit for brand-new accounts,
+        // so an update-only write would drop the handle the event carries.
         let client = pool.get().await?;
-        let result = client
+        client
             .execute(
-                "UPDATE actor SET handle = $1, \"indexedAt\" = $2 WHERE did = $3",
-                &[&handle, &timestamp, &did],
+                "INSERT INTO actor (did, handle, \"indexedAt\") VALUES ($1, $2, $3) \
+                 ON CONFLICT (did) DO UPDATE SET handle = EXCLUDED.handle, \
+                 \"indexedAt\" = EXCLUDED.\"indexedAt\"",
+                &[&did, &handle, &timestamp],
             )
             .await?;
 
-        if result > 0 {
-            tracing::info!(
-                "updated handle for {} to {:?}",
-                did,
-                handle.as_deref().unwrap_or("null")
-            );
-        } else {
-            tracing::debug!("no actor found to update for {}", did);
-        }
+        tracing::info!(
+            "upserted handle for {} to {:?}",
+            did,
+            handle.as_deref().unwrap_or("null")
+        );
 
         Ok(())
     }

--- a/rsky-wintermute/src/ingester/tests.rs
+++ b/rsky-wintermute/src/ingester/tests.rs
@@ -1157,6 +1157,95 @@ mod ingester_tests {
         }
     }
 
+    mod identity_event_upsert {
+        use crate::ingester::IngesterManager;
+        use deadpool_postgres::{Config, ManagerConfig, Pool, RecyclingMethod, Runtime};
+        use tokio_postgres::NoTls;
+
+        fn setup_test_pool() -> Pool {
+            let database_url = std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+                "postgresql://postgres:postgres@localhost:5432/bsky_test".to_owned()
+            });
+            let mut pg_config = Config::new();
+            pg_config.url = Some(database_url);
+            pg_config.manager = Some(ManagerConfig {
+                recycling_method: RecyclingMethod::Fast,
+            });
+            pg_config.create_pool(Some(Runtime::Tokio1), NoTls).unwrap()
+        }
+
+        async fn delete_actor(pool: &Pool, did: &str) {
+            let client = pool.get().await.unwrap();
+            client
+                .execute("DELETE FROM actor WHERE did = $1", &[&did])
+                .await
+                .unwrap();
+        }
+
+        async fn read_handle(pool: &Pool, did: &str) -> Option<Option<String>> {
+            let client = pool.get().await.unwrap();
+            client
+                .query_opt("SELECT handle FROM actor WHERE did = $1", &[&did])
+                .await
+                .unwrap()
+                .map(|row| row.get(0))
+        }
+
+        #[tokio::test]
+        async fn creates_actor_row_for_unseen_did() {
+            let pool = setup_test_pool();
+            let did = "did:plc:wintermute-test-identity-new";
+            delete_actor(&pool, did).await;
+
+            IngesterManager::process_identity_event(
+                &pool,
+                did,
+                "2026-07-29T12:00:00.000Z",
+                Some("Identity-New.Test"),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                read_handle(&pool, did).await,
+                Some(Some("identity-new.test".to_owned()))
+            );
+            delete_actor(&pool, did).await;
+        }
+
+        #[tokio::test]
+        async fn updates_handle_for_known_did() {
+            let pool = setup_test_pool();
+            let did = "did:plc:wintermute-test-identity-known";
+            delete_actor(&pool, did).await;
+            let client = pool.get().await.unwrap();
+            let inserted = client
+                .execute(
+                    "INSERT INTO actor (did, handle, \"indexedAt\") \
+                     VALUES ($1, 'identity-old.test', '2026-01-01T00:00:00.000Z')",
+                    &[&did],
+                )
+                .await
+                .unwrap();
+            assert_eq!(inserted, 1);
+
+            IngesterManager::process_identity_event(
+                &pool,
+                did,
+                "2026-07-29T12:00:00.000Z",
+                Some("identity-renamed.test"),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                read_handle(&pool, did).await,
+                Some(Some("identity-renamed.test".to_owned()))
+            );
+            delete_actor(&pool, did).await;
+        }
+    }
+
     mod pds_verification {
         use crate::ingester::parse_active_flag;
 


### PR DESCRIPTION
Firehose #identity events carry the handle inline and arrive before any commit for brand-new accounts, but process_identity_event used a bare UPDATE that matched zero rows for unseen DIDs — discarding the handle and leaving new signups as handle.invalid until the slow resolver loop caught up. Upsert instead, matching the index_handle write shape.