### PR TITLE
fix(wintermute): pg array literals for post langs/tags; revert unindexed supersede sweeps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/src/indexer/bulk.rs
+++ b/rsky-wintermute/src/indexer/bulk.rs
@@ -35,8 +35,35 @@ fn escape_copy_opt(v: Option<&str>) -> std::borrow::Cow<'_, str> {
     v.map_or(std::borrow::Cow::Borrowed("\\N"), escape_copy_field)
 }
 
+/// Render JSON array items as a Postgres array literal (`{"en","es"}`) for
+/// `text[]`/`varchar[]` columns. Elements are always double-quoted with `\`
+/// and `"` escaped; non-string items are skipped. COPY-level escaping is
+/// applied separately by `escape_copy_field`, so the two layers compose.
+pub fn pg_text_array_literal(items: &[serde_json::Value]) -> String {
+    let mut out = String::from("{");
+    let mut first = true;
+    for item in items {
+        let Some(s) = item.as_str() else { continue };
+        if !first {
+            out.push(',');
+        }
+        first = false;
+        out.push('"');
+        for c in s.chars() {
+            match c {
+                '\\' => out.push_str("\\\\"),
+                '"' => out.push_str("\\\""),
+                _ => out.push(c),
+            }
+        }
+        out.push('"');
+    }
+    out.push('}');
+    out
+}
+
 /// A post row for bulk `COPY`. `reply_*` are `None` for non-replies; `langs`/`tags`
-/// hold compact JSON text destined for the `jsonb` columns, `None` when absent.
+/// hold Postgres array literals destined for the `varchar[]` columns, `None` when absent.
 pub struct PostCopyRow {
     pub uri: String,
     pub cid: String,
@@ -270,8 +297,8 @@ pub async fn copy_insert_posts(
                 reply_parent_cid text,
                 created_at text NOT NULL,
                 indexed_at text NOT NULL,
-                langs jsonb,
-                tags jsonb
+                langs text[],
+                tags text[]
             )",
             &[],
         )
@@ -320,7 +347,7 @@ pub async fn copy_insert_posts(
     client
         .execute(
             "INSERT INTO post (uri, cid, creator, text, \"replyRoot\", \"replyRootCid\", \"replyParent\", \"replyParentCid\", \"createdAt\", \"indexedAt\", langs, tags)
-             SELECT uri, cid, creator, text, reply_root, reply_root_cid, reply_parent, reply_parent_cid, created_at, indexed_at, langs, tags
+             SELECT uri, cid, creator, text, reply_root, reply_root_cid, reply_parent, reply_parent_cid, created_at, indexed_at, langs::varchar[], tags::varchar[]
              FROM _bulk_post
              ON CONFLICT DO NOTHING",
             &[],
@@ -1096,7 +1123,38 @@ pub async fn copy_insert_post_embed_videos(
 
 #[cfg(test)]
 mod tests {
-    use super::{escape_copy_field, escape_copy_opt};
+    use super::{escape_copy_field, escape_copy_opt, pg_text_array_literal};
+
+    #[test]
+    fn array_literal_renders_quoted_elements() {
+        let items = vec![serde_json::json!("en"), serde_json::json!("pt-BR")];
+        assert_eq!(pg_text_array_literal(&items), r#"{"en","pt-BR"}"#);
+    }
+
+    #[test]
+    fn array_literal_escapes_quotes_and_backslashes() {
+        let items = vec![
+            serde_json::json!(r#"tag "quoted""#),
+            serde_json::json!(r"back\slash"),
+            serde_json::json!("with,comma"),
+            serde_json::json!("with{brace}"),
+        ];
+        assert_eq!(
+            pg_text_array_literal(&items),
+            r#"{"tag \"quoted\"","back\\slash","with,comma","with{brace}"}"#
+        );
+    }
+
+    #[test]
+    fn array_literal_empty_and_non_string_items() {
+        assert_eq!(pg_text_array_literal(&[]), "{}");
+        let items = vec![
+            serde_json::json!(42),
+            serde_json::json!("kept"),
+            serde_json::json!(null),
+        ];
+        assert_eq!(pg_text_array_literal(&items), r#"{"kept"}"#);
+    }
 
     #[test]
     fn escapes_backslash_and_whitespace_for_copy() {

--- a/rsky-wintermute/src/indexer/bulk.rs
+++ b/rsky-wintermute/src/indexer/bulk.rs
@@ -512,23 +512,6 @@ pub async fn copy_insert_likes(
     sink.close().await?;
     let copy_ms = copy_start.elapsed().as_millis();
 
-    // A fresh record supersedes any stale row for the same pair left by a
-    // missed delete; without this the pair-unique index rejects the new row.
-    client
-        .execute(
-            "WITH del AS (
-                 DELETE FROM \"like\" l USING _bulk_like b
-                 WHERE l.subject = b.subject AND l.creator = b.creator
-                   AND l.uri != b.uri
-                 RETURNING l.uri
-             ), delrec AS (
-                 DELETE FROM record WHERE uri IN (SELECT uri FROM del)
-             )
-             DELETE FROM notification WHERE \"recordUri\" IN (SELECT uri FROM del)",
-            &[],
-        )
-        .await?;
-
     // Phase 3: INSERT...ON CONFLICT
     let insert_start = Instant::now();
     client
@@ -618,23 +601,6 @@ pub async fn copy_insert_follows(
     sink.send(bytes::Bytes::from(buffer)).await?;
     sink.close().await?;
     let copy_ms = copy_start.elapsed().as_millis();
-
-    // A fresh record supersedes any stale row for the same pair left by a
-    // missed delete; without this the pair-unique index rejects the new row.
-    client
-        .execute(
-            "WITH del AS (
-                 DELETE FROM follow f USING _bulk_follow b
-                 WHERE f.creator = b.creator AND f.\"subjectDid\" = b.subject_did
-                   AND f.uri != b.uri
-                 RETURNING f.uri
-             ), delrec AS (
-                 DELETE FROM record WHERE uri IN (SELECT uri FROM del)
-             )
-             DELETE FROM notification WHERE \"recordUri\" IN (SELECT uri FROM del)",
-            &[],
-        )
-        .await?;
 
     // Phase 3: INSERT...ON CONFLICT
     let insert_start = Instant::now();
@@ -755,25 +721,6 @@ pub async fn copy_insert_reposts(
     sink.send(bytes::Bytes::from(buffer)).await?;
     sink.close().await?;
     let copy_ms = copy_start.elapsed().as_millis();
-
-    // A fresh record supersedes any stale row for the same pair left by a
-    // missed delete; without this the pair-unique index rejects the new row.
-    client
-        .execute(
-            "WITH del AS (
-                 DELETE FROM repost r USING _bulk_repost b
-                 WHERE r.creator = b.creator AND r.subject = b.subject
-                   AND r.uri != b.uri
-                 RETURNING r.uri
-             ), delrec AS (
-                 DELETE FROM record WHERE uri IN (SELECT uri FROM del)
-             ), delfeed AS (
-                 DELETE FROM feed_item WHERE uri IN (SELECT uri FROM del)
-             )
-             DELETE FROM notification WHERE \"recordUri\" IN (SELECT uri FROM del)",
-            &[],
-        )
-        .await?;
 
     // Phase 3: INSERT...ON CONFLICT
     let insert_start = Instant::now();
@@ -949,21 +896,6 @@ pub async fn copy_insert_blocks(
     sink.send(bytes::Bytes::from(buffer)).await?;
     sink.close().await?;
     let copy_ms = copy_start.elapsed().as_millis();
-
-    // A fresh record supersedes any stale row for the same pair left by a
-    // missed delete; without this the pair-unique index rejects the new row.
-    client
-        .execute(
-            "WITH del AS (
-                 DELETE FROM actor_block a USING _bulk_block b
-                 WHERE a.creator = b.creator AND a.\"subjectDid\" = b.subject
-                   AND a.uri != b.uri
-                 RETURNING a.uri
-             )
-             DELETE FROM record WHERE uri IN (SELECT uri FROM del)",
-            &[],
-        )
-        .await?;
 
     // Phase 3: INSERT...ON CONFLICT
     let insert_start = Instant::now();

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -3780,18 +3780,6 @@ impl IndexerManager {
             .and_then(|v| v.get("cid"))
             .and_then(|v| v.as_str());
 
-        client
-            .execute(
-                "WITH del AS (
-                     DELETE FROM \"like\" WHERE subject = $1 AND creator = $2 AND uri != $3
-                     RETURNING uri
-                 ), delrec AS (
-                     DELETE FROM record WHERE uri IN (SELECT uri FROM del)
-                 )
-                 DELETE FROM notification WHERE \"recordUri\" IN (SELECT uri FROM del)",
-                &[&subject, &did, &uri],
-            )
-            .await?;
         let row_count = client
             .execute(
                 "INSERT INTO \"like\" (uri, cid, creator, subject, \"subjectCid\", via, \"viaCid\", \"createdAt\", \"indexedAt\")
@@ -3894,18 +3882,6 @@ impl IndexerManager {
             }
         }
 
-        client
-            .execute(
-                "WITH del AS (
-                     DELETE FROM follow WHERE creator = $1 AND \"subjectDid\" = $2 AND uri != $3
-                     RETURNING uri
-                 ), delrec AS (
-                     DELETE FROM record WHERE uri IN (SELECT uri FROM del)
-                 )
-                 DELETE FROM notification WHERE \"recordUri\" IN (SELECT uri FROM del)",
-                &[&did, &subject, &uri],
-            )
-            .await?;
         let row_count = client
             .execute(
                 "INSERT INTO follow (uri, cid, creator, \"subjectDid\", \"createdAt\", \"indexedAt\")
@@ -4028,20 +4004,6 @@ impl IndexerManager {
             .and_then(|v| v.get("cid"))
             .and_then(|v| v.as_str());
 
-        client
-            .execute(
-                "WITH del AS (
-                     DELETE FROM repost WHERE creator = $1 AND subject = $2 AND uri != $3
-                     RETURNING uri
-                 ), delrec AS (
-                     DELETE FROM record WHERE uri IN (SELECT uri FROM del)
-                 ), delfeed AS (
-                     DELETE FROM feed_item WHERE uri IN (SELECT uri FROM del)
-                 )
-                 DELETE FROM notification WHERE \"recordUri\" IN (SELECT uri FROM del)",
-                &[&did, &subject, &uri],
-            )
-            .await?;
         let row_count = client
             .execute(
                 "INSERT INTO repost (uri, cid, creator, subject, \"subjectCid\", via, \"viaCid\", \"createdAt\", \"indexedAt\")
@@ -4164,16 +4126,6 @@ impl IndexerManager {
             }
         }
 
-        client
-            .execute(
-                "WITH del AS (
-                     DELETE FROM actor_block WHERE creator = $1 AND \"subjectDid\" = $2 AND uri != $3
-                     RETURNING uri
-                 )
-                 DELETE FROM record WHERE uri IN (SELECT uri FROM del)",
-                &[&did, &subject, &uri],
-            )
-            .await?;
         client
             .execute(
                 "INSERT INTO actor_block (uri, cid, creator, \"subjectDid\", \"createdAt\", \"indexedAt\")
@@ -4432,16 +4384,6 @@ impl IndexerManager {
 
         client
             .execute(
-                "WITH del AS (
-                     DELETE FROM list_item WHERE \"listUri\" = $1 AND \"subjectDid\" = $2 AND uri != $3
-                     RETURNING uri
-                 )
-                 DELETE FROM record WHERE uri IN (SELECT uri FROM del)",
-                &[&list_uri, &subject, &uri],
-            )
-            .await?;
-        client
-            .execute(
                 "INSERT INTO list_item (uri, cid, creator, \"listUri\", \"subjectDid\", \"createdAt\", \"indexedAt\")
                  VALUES ($1, $2, $3, $4, $5, $6, $7)
                  ON CONFLICT DO NOTHING",
@@ -4483,16 +4425,6 @@ impl IndexerManager {
             .and_then(|v| v.as_str())
             .unwrap_or(indexed_at);
 
-        client
-            .execute(
-                "WITH del AS (
-                     DELETE FROM list_block WHERE creator = $1 AND \"subjectUri\" = $2 AND uri != $3
-                     RETURNING uri
-                 )
-                 DELETE FROM record WHERE uri IN (SELECT uri FROM del)",
-                &[&did, &subject, &uri],
-            )
-            .await?;
         client
             .execute(
                 "INSERT INTO list_block (uri, cid, creator, \"subjectUri\", \"createdAt\", \"indexedAt\")
@@ -4891,18 +4823,6 @@ impl IndexerManager {
             .and_then(|v| v.as_str())
             .unwrap_or(indexed_at);
 
-        client
-            .execute(
-                "WITH del AS (
-                     DELETE FROM verification WHERE subject = $1 AND creator = $2 AND uri != $3
-                     RETURNING uri
-                 ), delrec AS (
-                     DELETE FROM record WHERE uri IN (SELECT uri FROM del)
-                 )
-                 DELETE FROM notification WHERE \"recordUri\" IN (SELECT uri FROM del)",
-                &[&subject, &did, &uri],
-            )
-            .await?;
         client
             .execute(
                 "INSERT INTO verification (uri, cid, rkey, creator, subject, handle, \"displayName\", \"createdAt\", \"indexedAt\")

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -2757,12 +2757,12 @@ impl IndexerManager {
                     .map(str::to_owned);
                 let langs = record
                     .get("langs")
-                    .filter(|v| !v.is_null())
-                    .map(std::string::ToString::to_string);
+                    .and_then(serde_json::Value::as_array)
+                    .map(|items| bulk::pg_text_array_literal(items));
                 let tags = record
                     .get("tags")
-                    .filter(|v| !v.is_null())
-                    .map(std::string::ToString::to_string);
+                    .and_then(serde_json::Value::as_array)
+                    .map(|items| bulk::pg_text_array_literal(items));
 
                 post_data.push(bulk::PostCopyRow {
                     uri: uri.clone(),

--- a/rsky-wintermute/src/indexer/tests.rs
+++ b/rsky-wintermute/src/indexer/tests.rs
@@ -10,35 +10,11 @@ mod indexer_tests {
     use crate::backfiller::BackfillerManager;
     use crate::indexer::IndexerManager;
     use crate::storage::Storage;
-    use crate::types::{BackfillJob, IndexJob, LabelEvent, WriteAction};
+    use crate::types::{BackfillJob, LabelEvent, WriteAction};
     use deadpool_postgres::{Config, ManagerConfig, Pool, RecyclingMethod, Runtime};
     use std::sync::Arc;
     use tempfile::TempDir;
     use tokio_postgres::NoTls;
-
-    // A record whose pair key (e.g. follow creator+subject) is already
-    // claimed supersedes the older row, so repos containing same-key
-    // duplicates index to one row per key.
-    fn pair_key(job: &IndexJob) -> Option<String> {
-        let collection = job.uri.split('/').nth(3)?;
-        let record = job.record.as_ref()?;
-        let key = match collection {
-            "app.bsky.feed.like" | "app.bsky.feed.repost" => {
-                record.get("subject")?.get("uri")?.as_str()?.to_owned()
-            }
-            "app.bsky.graph.follow"
-            | "app.bsky.graph.block"
-            | "app.bsky.graph.listblock"
-            | "app.bsky.graph.verification" => record.get("subject")?.as_str()?.to_owned(),
-            "app.bsky.graph.listitem" => format!(
-                "{}\n{}",
-                record.get("list")?.as_str()?,
-                record.get("subject")?.as_str()?
-            ),
-            _ => return None,
-        };
-        Some(format!("{collection}\n{key}"))
-    }
 
     fn setup_test_storage() -> (Storage, TempDir) {
         let temp_dir = TempDir::with_prefix("indexer_test_").unwrap();
@@ -165,8 +141,6 @@ mod indexer_tests {
         });
         let indexer = IndexerManager::new(Arc::new(storage), &database_url).unwrap();
 
-        let mut pair_counts: std::collections::HashMap<String, u32> =
-            std::collections::HashMap::new();
         let mut processed = 0;
         let batch_size = 100;
         let mut consecutive_empty = 0;
@@ -177,9 +151,6 @@ mod indexer_tests {
             for _ in 0..batch_size {
                 match indexer.storage.dequeue_firehose_backfill() {
                     Ok(Some((key, index_job))) => {
-                        if let Some(k) = pair_key(&index_job) {
-                            *pair_counts.entry(k).or_insert(0) += 1;
-                        }
                         let result =
                             IndexerManager::process_job(&indexer.pool_backfill, &index_job).await;
 
@@ -252,35 +223,11 @@ mod indexer_tests {
             .get(0);
         tracing::info!("notifications created: {notification_count}");
 
-        let collapsed: i64 = pair_counts.values().map(|n| i64::from(n - 1)).sum();
-        let expected_records =
-            i64::try_from(queue_len).expect("queue_len should fit in i64") - collapsed;
         assert_eq!(
-            record_count, expected_records,
-            "expected {expected_records} records in generic record table ({queue_len} queued minus {collapsed} superseded same-pair duplicates), found {record_count}"
+            record_count,
+            i64::try_from(queue_len).expect("queue_len should fit in i64"),
+            "expected all {queue_len} records in generic record table, found {record_count}"
         );
-
-        for (table, key_cols) in [
-            ("\"like\"", "subject, creator"),
-            ("repost", "creator, subject"),
-            ("follow", "creator, \"subjectDid\""),
-            ("actor_block", "creator, \"subjectDid\""),
-            ("list_item", "\"listUri\", \"subjectDid\""),
-            ("list_block", "creator, \"subjectUri\""),
-            ("verification", "subject, creator"),
-        ] {
-            let dup_groups: i64 = client
-                .query_one(
-                    &format!(
-                        "SELECT COUNT(*) FROM (SELECT 1 FROM {table} WHERE creator = $1 GROUP BY {key_cols} HAVING COUNT(*) > 1) t"
-                    ),
-                    &[&test_did],
-                )
-                .await
-                .unwrap()
-                .get(0);
-            assert_eq!(dup_groups, 0, "{table} still holds duplicate pair keys");
-        }
 
         let post_count: i64 = client
             .query_one("SELECT COUNT(*) FROM post WHERE creator = $1", &[&test_did])

--- a/rsky-wintermute/src/indexer/tests.rs
+++ b/rsky-wintermute/src/indexer/tests.rs
@@ -1883,4 +1883,58 @@ mod indexer_tests {
 
         cleanup_test_data(&pool, test_did).await;
     }
+
+    #[tokio::test]
+    async fn bulk_post_langs_tags_round_trip_as_arrays() {
+        use crate::indexer::bulk::{self, PostCopyRow};
+
+        let pool = setup_test_pool();
+        let test_did = "did:plc:wintermute-test-langs-arrays";
+        cleanup_test_data(&pool, test_did).await;
+
+        let client = pool.get().await.unwrap();
+        client
+            .execute(
+                "INSERT INTO actor (did, \"indexedAt\") VALUES ($1, NOW()) \
+                 ON CONFLICT (did) DO NOTHING",
+                &[&test_did],
+            )
+            .await
+            .unwrap();
+
+        let uri = format!("at://{test_did}/app.bsky.feed.post/langstest1");
+        let langs_json = vec![serde_json::json!("en"), serde_json::json!("pt-BR")];
+        let tags_json = vec![serde_json::json!(r#"tag "quoted""#)];
+        let row = PostCopyRow {
+            uri: uri.clone(),
+            cid: "bafyreihhl5mpvjkrhnnagen2fomozzhnhhdq2jr6cego2nzbvmwewv5rd4".to_owned(),
+            creator: test_did.to_owned(),
+            text: "langs round trip".to_owned(),
+            reply_root: None,
+            reply_root_cid: None,
+            reply_parent: None,
+            reply_parent_cid: None,
+            created_at: "2026-07-30T00:00:00.000Z".to_owned(),
+            indexed_at: "2026-07-30T00:00:00.000Z".to_owned(),
+            langs: Some(bulk::pg_text_array_literal(&langs_json)),
+            tags: Some(bulk::pg_text_array_literal(&tags_json)),
+        };
+        bulk::copy_insert_posts(&client, &[row], true)
+            .await
+            .unwrap();
+
+        let db_row = client
+            .query_one(
+                "SELECT langs::text[], tags::text[] FROM post WHERE uri = $1",
+                &[&uri],
+            )
+            .await
+            .unwrap();
+        let langs: Vec<String> = db_row.get(0);
+        let tags: Vec<String> = db_row.get(1);
+        assert_eq!(langs, vec!["en".to_owned(), "pt-BR".to_owned()]);
+        assert_eq!(tags, vec![r#"tag "quoted""#.to_owned()]);
+
+        cleanup_test_data(&pool, test_did).await;
+    }
 }


### PR DESCRIPTION
post.langs/tags are varchar[] but the bulk loader staged them as jsonb JSON text, failing every post batch; langs/tags now render as escaped Postgres array literals through a text[] staging table. Reverts the #213 supersede sweeps: their pair-key DELETE joins seq-scan the multi-TB like/follow/repost tables (no pair indexes exist yet), stalling batches at the 300s statement timeout — to return with CREATE INDEX CONCURRENTLY groundwork. Note: test-db post.langs/tags were jsonb while prod is varchar[] (schema drift that let this ship); local bsky_test aligned, server bsky_test needs the same ALTER.