### PR TITLE
fix(wintermute): emit notifications and exact post_agg deltas from batch live drain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.4.11"
+version = "0.4.13"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.4.12"
+version = "0.4.13"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/src/bin/cleanup_stale_deactivated.rs
+++ b/rsky-wintermute/src/bin/cleanup_stale_deactivated.rs
@@ -247,7 +247,7 @@ async fn mark_event_at_now(pool: &Pool, did: &str) -> Result<()> {
 }
 
 async fn resolve_pds(plc_url: &str, did: &str) -> Result<Option<String>> {
-    let mut resolver = IdResolver::new(IdentityResolverOpts {
+    let resolver = IdResolver::new(IdentityResolverOpts {
         timeout: Some(std::time::Duration::from_secs(5)),
         plc_url: Some(plc_url.to_owned()),
         did_cache: None,

--- a/rsky-wintermute/src/bin/direct_index.rs
+++ b/rsky-wintermute/src/bin/direct_index.rs
@@ -88,7 +88,7 @@ async fn process_did(
         did_cache: None,
         backup_nameservers: None,
     };
-    let mut resolver = IdResolver::new(resolver_opts);
+    let resolver = IdResolver::new(resolver_opts);
     let doc = resolver
         .did
         .resolve(did.to_string(), None)

--- a/rsky-wintermute/src/indexer/bulk.rs
+++ b/rsky-wintermute/src/indexer/bulk.rs
@@ -79,6 +79,77 @@ pub struct PostCopyRow {
     pub tags: Option<String>,
 }
 
+/// A notification destined for the `notification` table.
+pub struct NotificationRow {
+    pub did: String,
+    pub author: String,
+    pub record_uri: String,
+    pub record_cid: String,
+    pub reason: &'static str,
+    pub reason_subject: Option<String>,
+    pub sort_at: String,
+}
+
+/// Bulk insert notifications in one statement. Deduped on
+/// `(did, "recordUri", reason)` so replays add nothing.
+pub async fn copy_insert_notifications(
+    client: &deadpool_postgres::Client,
+    rows: &[NotificationRow],
+) -> Result<(), WintermuteError> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    let mut dids = Vec::with_capacity(rows.len());
+    let mut authors = Vec::with_capacity(rows.len());
+    let mut uris = Vec::with_capacity(rows.len());
+    let mut cids = Vec::with_capacity(rows.len());
+    let mut reasons = Vec::with_capacity(rows.len());
+    let mut subjects: Vec<Option<&str>> = Vec::with_capacity(rows.len());
+    let mut sort_ats = Vec::with_capacity(rows.len());
+    for row in rows {
+        dids.push(row.did.as_str());
+        authors.push(row.author.as_str());
+        uris.push(row.record_uri.as_str());
+        cids.push(row.record_cid.as_str());
+        reasons.push(row.reason);
+        subjects.push(row.reason_subject.as_deref());
+        sort_ats.push(row.sort_at.as_str());
+    }
+    client
+        .execute(
+            "INSERT INTO notification (did, author, \"recordUri\", \"recordCid\", reason, \"reasonSubject\", \"sortAt\")
+             SELECT * FROM unnest($1::text[], $2::text[], $3::text[], $4::text[], $5::text[], $6::text[], $7::text[])
+             ON CONFLICT (did, \"recordUri\", reason) DO NOTHING",
+            &[&dids, &authors, &uris, &cids, &reasons, &subjects, &sort_ats],
+        )
+        .await?;
+    Ok(())
+}
+
+/// Increment a `post_agg` count column by exact per-uri deltas.
+async fn increment_post_agg(
+    client: &deadpool_postgres::Client,
+    column: &str,
+    counts: std::collections::HashMap<String, i64>,
+) -> Result<(), WintermuteError> {
+    if counts.is_empty() {
+        return Ok(());
+    }
+    let (uris, deltas): (Vec<String>, Vec<i64>) = counts.into_iter().unzip();
+    client
+        .execute(
+            &format!(
+                "INSERT INTO post_agg (uri, \"{column}\")
+                 SELECT * FROM unnest($1::text[], $2::int8[])
+                 ON CONFLICT (uri) DO UPDATE
+                   SET \"{column}\" = COALESCE(post_agg.\"{column}\", 0) + EXCLUDED.\"{column}\""
+            ),
+            &[&uris, &deltas],
+        )
+        .await?;
+    Ok(())
+}
+
 /// Bulk insert records using `COPY` protocol.
 /// Returns vector of booleans indicating which records were applied (not stale).
 pub async fn copy_insert_records(
@@ -273,11 +344,11 @@ pub async fn copy_insert_posts(
     client: &deadpool_postgres::Client,
     data: &[PostCopyRow],
     compute_agg: bool, // false for the bulk CAR load (aggregates recomputed in one pass after)
-) -> Result<(), WintermuteError> {
+) -> Result<std::collections::HashSet<String>, WintermuteError> {
     use std::time::Instant;
 
     if data.is_empty() {
-        return Ok(());
+        return Ok(std::collections::HashSet::new());
     }
 
     let count = data.len();
@@ -342,8 +413,9 @@ pub async fn copy_insert_posts(
     sink.close().await?;
     let copy_ms = copy_start.elapsed().as_millis();
 
-    // Phase 3: INSERT...ON CONFLICT, returning creators of rows actually
-    // inserted so aggregates can increment exactly (dupes/replays add zero).
+    // Phase 3: INSERT...ON CONFLICT, returning rows actually inserted so
+    // aggregates can increment exactly (dupes/replays add zero) and callers
+    // can run per-post side effects only for applied rows.
     let insert_start = Instant::now();
     let inserted = client
         .query(
@@ -351,31 +423,40 @@ pub async fn copy_insert_posts(
              SELECT uri, cid, creator, text, reply_root, reply_root_cid, reply_parent, reply_parent_cid, created_at, indexed_at, langs::varchar[], tags::varchar[]
              FROM _bulk_post
              ON CONFLICT DO NOTHING
-             RETURNING creator",
+             RETURNING uri, creator, \"replyParent\"",
             &[],
         )
         .await?;
     let insert_ms = insert_start.elapsed().as_millis();
 
-    // Phase 4: increment profile_agg postsCount by exact per-creator deltas.
-    // A full recount here scales with each creator's lifetime post count and
-    // dominated batch time on large tables.
+    // Phase 4: increment profile_agg postsCount and post_agg replyCount by
+    // exact per-key deltas. A full recount here scales with each creator's
+    // lifetime post count and dominated batch time on large tables.
     let agg_start = Instant::now();
-    if compute_agg && !inserted.is_empty() {
+    let mut applied = std::collections::HashSet::with_capacity(inserted.len());
+    if !inserted.is_empty() {
         let mut counts: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+        let mut replies: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
         for row in &inserted {
-            *counts.entry(row.get::<_, String>(0)).or_insert(0) += 1;
+            applied.insert(row.get::<_, String>(0));
+            *counts.entry(row.get::<_, String>(1)).or_insert(0) += 1;
+            if let Some(parent) = row.get::<_, Option<String>>(2) {
+                *replies.entry(parent).or_insert(0) += 1;
+            }
         }
-        let (dids, deltas): (Vec<String>, Vec<i64>) = counts.into_iter().unzip();
-        client
-            .execute(
-                "INSERT INTO profile_agg (did, \"postsCount\")
-                 SELECT * FROM unnest($1::text[], $2::int8[])
-                 ON CONFLICT (did) DO UPDATE
-                   SET \"postsCount\" = COALESCE(profile_agg.\"postsCount\", 0) + EXCLUDED.\"postsCount\"",
-                &[&dids, &deltas],
-            )
-            .await?;
+        if compute_agg {
+            let (dids, deltas): (Vec<String>, Vec<i64>) = counts.into_iter().unzip();
+            client
+                .execute(
+                    "INSERT INTO profile_agg (did, \"postsCount\")
+                     SELECT * FROM unnest($1::text[], $2::int8[])
+                     ON CONFLICT (did) DO UPDATE
+                       SET \"postsCount\" = COALESCE(profile_agg.\"postsCount\", 0) + EXCLUDED.\"postsCount\"",
+                    &[&dids, &deltas],
+                )
+                .await?;
+            increment_post_agg(client, "replyCount", replies).await?;
+        }
     }
     let agg_ms = agg_start.elapsed().as_millis();
 
@@ -393,7 +474,7 @@ pub async fn copy_insert_posts(
         );
     }
 
-    Ok(())
+    Ok(applied)
 }
 
 /// Bulk insert `feed_item` records using `COPY` protocol.
@@ -489,11 +570,12 @@ pub async fn copy_insert_feed_items(
 pub async fn copy_insert_likes(
     client: &deadpool_postgres::Client,
     data: &[(String, String, String, String, String, String, String)], // uri, cid, creator, subject, subject_cid, created_at, indexed_at
-) -> Result<(), WintermuteError> {
+    compute_agg: bool, // false for the bulk CAR load (aggregates recomputed in one pass after)
+) -> Result<std::collections::HashSet<String>, WintermuteError> {
     use std::time::Instant;
 
     if data.is_empty() {
-        return Ok(());
+        return Ok(std::collections::HashSet::new());
     }
 
     let count = data.len();
@@ -547,33 +629,48 @@ pub async fn copy_insert_likes(
     sink.close().await?;
     let copy_ms = copy_start.elapsed().as_millis();
 
-    // Phase 3: INSERT...ON CONFLICT
+    // Phase 3: INSERT...ON CONFLICT, returning rows actually inserted so
+    // likeCount increments exactly (dupes/replays add zero).
     let insert_start = Instant::now();
-    client
-        .execute(
+    let inserted = client
+        .query(
             "INSERT INTO \"like\" (uri, cid, creator, subject, \"subjectCid\", \"createdAt\", \"indexedAt\")
              SELECT uri, cid, creator, subject, subject_cid, created_at, indexed_at
              FROM _bulk_like
-             ON CONFLICT DO NOTHING",
+             ON CONFLICT DO NOTHING
+             RETURNING uri, subject",
             &[],
         )
         .await?;
     let insert_ms = insert_start.elapsed().as_millis();
 
+    let agg_start = Instant::now();
+    let mut applied = std::collections::HashSet::with_capacity(inserted.len());
+    let mut likes: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    for row in &inserted {
+        applied.insert(row.get::<_, String>(0));
+        *likes.entry(row.get::<_, String>(1)).or_insert(0) += 1;
+    }
+    if compute_agg {
+        increment_post_agg(client, "likeCount", likes).await?;
+    }
+    let agg_ms = agg_start.elapsed().as_millis();
+
     // Log if total > 100ms (worth investigating)
-    let total_ms = setup_ms + copy_ms + insert_ms;
+    let total_ms = setup_ms + copy_ms + insert_ms + agg_ms;
     if total_ms > 100 {
         tracing::warn!(
-            "SLOW like bulk: {}ms total (setup={}ms, copy={}ms, insert={}ms) for {} rows",
+            "SLOW like bulk: {}ms total (setup={}ms, copy={}ms, insert={}ms, agg={}ms) for {} rows",
             total_ms,
             setup_ms,
             copy_ms,
             insert_ms,
+            agg_ms,
             count
         );
     }
 
-    Ok(())
+    Ok(applied)
 }
 
 /// Bulk insert follows using `COPY` protocol.
@@ -581,11 +678,11 @@ pub async fn copy_insert_follows(
     client: &deadpool_postgres::Client,
     data: &[(String, String, String, String, String, String)], // uri, cid, creator, subject_did, created_at, indexed_at
     compute_agg: bool, // false for the bulk CAR load (aggregates recomputed in one pass after)
-) -> Result<(), WintermuteError> {
+) -> Result<std::collections::HashSet<String>, WintermuteError> {
     use std::time::Instant;
 
     if data.is_empty() {
-        return Ok(());
+        return Ok(std::collections::HashSet::new());
     }
 
     let count = data.len();
@@ -646,7 +743,7 @@ pub async fn copy_insert_follows(
              SELECT uri, cid, creator, subject_did, created_at, indexed_at
              FROM _bulk_follow
              ON CONFLICT DO NOTHING
-             RETURNING creator, \"subjectDid\"",
+             RETURNING uri, creator, \"subjectDid\"",
             &[],
         )
         .await?;
@@ -656,13 +753,17 @@ pub async fn copy_insert_follows(
     // recounts here scale with each account's lifetime follow graph (a
     // popular subject re-counted every follower on every new follow).
     let agg_start = Instant::now();
+    let mut applied = std::collections::HashSet::with_capacity(inserted.len());
+    for row in &inserted {
+        applied.insert(row.get::<_, String>(0));
+    }
     if compute_agg && !inserted.is_empty() {
         let mut follows: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
         let mut followers: std::collections::HashMap<String, i64> =
             std::collections::HashMap::new();
         for row in &inserted {
-            *follows.entry(row.get::<_, String>(0)).or_insert(0) += 1;
-            *followers.entry(row.get::<_, String>(1)).or_insert(0) += 1;
+            *follows.entry(row.get::<_, String>(1)).or_insert(0) += 1;
+            *followers.entry(row.get::<_, String>(2)).or_insert(0) += 1;
         }
         let (f_dids, f_deltas): (Vec<String>, Vec<i64>) = follows.into_iter().unzip();
         client
@@ -701,18 +802,19 @@ pub async fn copy_insert_follows(
         );
     }
 
-    Ok(())
+    Ok(applied)
 }
 
 /// Bulk insert reposts using `COPY` protocol.
 pub async fn copy_insert_reposts(
     client: &deadpool_postgres::Client,
     data: &[(String, String, String, String, String, String, String)], // uri, cid, creator, subject, subject_cid, created_at, indexed_at
-) -> Result<(), WintermuteError> {
+    compute_agg: bool, // false for the bulk CAR load (aggregates recomputed in one pass after)
+) -> Result<std::collections::HashSet<String>, WintermuteError> {
     use std::time::Instant;
 
     if data.is_empty() {
-        return Ok(());
+        return Ok(std::collections::HashSet::new());
     }
 
     let count = data.len();
@@ -766,39 +868,55 @@ pub async fn copy_insert_reposts(
     sink.close().await?;
     let copy_ms = copy_start.elapsed().as_millis();
 
-    // Phase 3: INSERT...ON CONFLICT
+    // Phase 3: INSERT...ON CONFLICT, returning rows actually inserted so
+    // repostCount increments exactly (dupes/replays add zero).
     let insert_start = Instant::now();
-    client
-        .execute(
+    let inserted = client
+        .query(
             "INSERT INTO repost (uri, cid, creator, subject, \"subjectCid\", \"createdAt\", \"indexedAt\")
              SELECT uri, cid, creator, subject, subject_cid, created_at, indexed_at
              FROM _bulk_repost
-             ON CONFLICT DO NOTHING",
+             ON CONFLICT DO NOTHING
+             RETURNING uri, subject",
             &[],
         )
         .await?;
     let insert_ms = insert_start.elapsed().as_millis();
 
+    let agg_start = Instant::now();
+    let mut applied = std::collections::HashSet::with_capacity(inserted.len());
+    let mut reposts: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    for row in &inserted {
+        applied.insert(row.get::<_, String>(0));
+        *reposts.entry(row.get::<_, String>(1)).or_insert(0) += 1;
+    }
+    if compute_agg {
+        increment_post_agg(client, "repostCount", reposts).await?;
+    }
+    let agg_ms = agg_start.elapsed().as_millis();
+
     // Log if total > 100ms (worth investigating)
-    let total_ms = setup_ms + copy_ms + insert_ms;
+    let total_ms = setup_ms + copy_ms + insert_ms + agg_ms;
     if total_ms > 100 {
         tracing::warn!(
-            "SLOW repost bulk: {}ms total (setup={}ms, copy={}ms, insert={}ms) for {} rows",
+            "SLOW repost bulk: {}ms total (setup={}ms, copy={}ms, insert={}ms, agg={}ms) for {} rows",
             total_ms,
             setup_ms,
             copy_ms,
             insert_ms,
+            agg_ms,
             count
         );
     }
 
-    Ok(())
+    Ok(applied)
 }
 
 /// Bulk insert quotes using `COPY` protocol.
 pub async fn copy_insert_quotes(
     client: &deadpool_postgres::Client,
     data: &[(String, String, String, String, String, String)], // uri, cid, subject, subject_cid, created_at, indexed_at
+    compute_agg: bool, // false for the bulk CAR load (aggregates recomputed in one pass after)
 ) -> Result<(), WintermuteError> {
     use std::time::Instant;
 
@@ -855,25 +973,37 @@ pub async fn copy_insert_quotes(
 
     // sortAt is GENERATED ALWAYS; creator is unread by the appview so neither is written.
     let insert_start = Instant::now();
-    client
-        .execute(
+    let inserted = client
+        .query(
             "INSERT INTO quote (uri, cid, subject, \"subjectCid\", \"createdAt\", \"indexedAt\")
              SELECT uri, cid, subject, subject_cid, created_at, indexed_at
              FROM _bulk_quote
-             ON CONFLICT DO NOTHING",
+             ON CONFLICT DO NOTHING
+             RETURNING subject",
             &[],
         )
         .await?;
     let insert_ms = insert_start.elapsed().as_millis();
 
-    let total_ms = setup_ms + copy_ms + insert_ms;
+    let agg_start = Instant::now();
+    if compute_agg {
+        let mut quotes: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+        for row in &inserted {
+            *quotes.entry(row.get::<_, String>(0)).or_insert(0) += 1;
+        }
+        increment_post_agg(client, "quoteCount", quotes).await?;
+    }
+    let agg_ms = agg_start.elapsed().as_millis();
+
+    let total_ms = setup_ms + copy_ms + insert_ms + agg_ms;
     if total_ms > 100 {
         tracing::warn!(
-            "SLOW quote bulk: {}ms total (setup={}ms, copy={}ms, insert={}ms) for {} rows",
+            "SLOW quote bulk: {}ms total (setup={}ms, copy={}ms, insert={}ms, agg={}ms) for {} rows",
             total_ms,
             setup_ms,
             copy_ms,
             insert_ms,
+            agg_ms,
             count
         );
     }

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -1894,7 +1894,7 @@ impl IndexerManager {
             Self::parallel_copy_posts(pool, &posts, bulk_load),
             Self::parallel_copy_likes(pool, &likes, bulk_load),
             Self::parallel_copy_follows(pool, &follows, bulk_load),
-            Self::parallel_copy_reposts(pool, &reposts),
+            Self::parallel_copy_reposts(pool, &reposts, bulk_load),
             Self::parallel_copy_blocks(pool, &blocks),
             Self::parallel_copy_profiles(pool, &profiles),
         );
@@ -2623,7 +2623,9 @@ impl IndexerManager {
             Ok(c) => c,
             Err(e) => return (0, count, Some(WintermuteError::Pool(e))),
         };
-        let err = Self::copy_batch_insert_likes(&client, jobs).await.err();
+        let err = Self::copy_batch_insert_likes(&client, jobs, !bulk_load)
+            .await
+            .err();
         (start.elapsed().as_millis(), count, err)
     }
 
@@ -2650,6 +2652,7 @@ impl IndexerManager {
     async fn parallel_copy_reposts(
         pool: &Pool,
         jobs: &[&ParsedJob<'_>],
+        bulk_load: bool,
     ) -> (u128, usize, Option<WintermuteError>) {
         let count = jobs.len();
         if count == 0 {
@@ -2660,7 +2663,9 @@ impl IndexerManager {
             Ok(c) => c,
             Err(e) => return (0, count, Some(WintermuteError::Pool(e))),
         };
-        let err = Self::copy_batch_insert_reposts(&client, jobs).await.err();
+        let err = Self::copy_batch_insert_reposts(&client, jobs, !bulk_load)
+            .await
+            .err();
         (start.elapsed().as_millis(), count, err)
     }
 
@@ -2717,6 +2722,9 @@ impl IndexerManager {
         let mut embed_image_data: Vec<(String, String, String, String)> = Vec::new();
         let mut embed_video_data: Vec<(String, String, Option<String>)> = Vec::new();
         let mut quote_data: Vec<(String, String, String, String, String, String)> = Vec::new();
+        let mut notif_rows: Vec<bulk::NotificationRow> = Vec::new();
+        // (did, uri, cid, sort_at) for reply posts; ancestor notifications need queries
+        let mut reply_posts: Vec<(String, String, String, String)> = Vec::new();
 
         for pj in jobs {
             if let Some(record) = &pj.job.record {
@@ -2764,6 +2772,7 @@ impl IndexerManager {
                     .and_then(serde_json::Value::as_array)
                     .map(|items| bulk::pg_text_array_literal(items));
 
+                let is_reply = reply_parent.is_some();
                 post_data.push(bulk::PostCopyRow {
                     uri: uri.clone(),
                     cid: pj.job.cid.clone(),
@@ -2785,8 +2794,44 @@ impl IndexerManager {
                     pj.job.cid.clone(),
                     uri.clone(),
                     pj.did.clone(),
-                    sort_at,
+                    sort_at.clone(),
                 ));
+
+                // Mention notifications from facets
+                if let Some(facets) = record.get("facets").and_then(|f| f.as_array()) {
+                    for facet in facets {
+                        let features = facet.get("features").and_then(|f| f.as_array());
+                        for feature in features.into_iter().flatten() {
+                            let feature_type =
+                                feature.get("$type").and_then(|t| t.as_str()).unwrap_or("");
+                            if feature_type != "app.bsky.richtext.facet#mention" {
+                                continue;
+                            }
+                            if let Some(mention_did) = feature.get("did").and_then(|d| d.as_str()) {
+                                if mention_did != pj.did {
+                                    notif_rows.push(bulk::NotificationRow {
+                                        did: mention_did.to_owned(),
+                                        author: pj.did.clone(),
+                                        record_uri: uri.clone(),
+                                        record_cid: pj.job.cid.clone(),
+                                        reason: "mention",
+                                        reason_subject: None,
+                                        sort_at: sort_at.clone(),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if is_reply {
+                    reply_posts.push((
+                        pj.did.clone(),
+                        uri.clone(),
+                        pj.job.cid.clone(),
+                        sort_at.clone(),
+                    ));
+                }
 
                 // Extract embed data for images and videos
                 if let Some(embed) = record.get("embed") {
@@ -2796,6 +2841,7 @@ impl IndexerManager {
                         &mut embed_image_data,
                         &mut embed_video_data,
                     );
+                    let quotes_before = quote_data.len();
                     Self::extract_quote(
                         embed,
                         &uri,
@@ -2804,6 +2850,23 @@ impl IndexerManager {
                         &pj.job.indexed_at,
                         &mut quote_data,
                     );
+                    // Quote notifications for freshly extracted quote subjects
+                    for (_, _, subject, _, _, _) in &quote_data[quotes_before..] {
+                        if let Ok(subject_uri) = AtUri::new(subject.clone(), None) {
+                            let quoted_author = subject_uri.get_hostname();
+                            if quoted_author != pj.did.as_str() {
+                                notif_rows.push(bulk::NotificationRow {
+                                    did: quoted_author.to_owned(),
+                                    author: pj.did.clone(),
+                                    record_uri: uri.clone(),
+                                    record_cid: pj.job.cid.clone(),
+                                    reason: "quote",
+                                    reason_subject: Some(subject.clone()),
+                                    sort_at: sort_at.clone(),
+                                });
+                            }
+                        }
+                    }
                 }
 
                 metrics::INDEXER_POST_EVENTS_TOTAL.inc();
@@ -2814,7 +2877,17 @@ impl IndexerManager {
         bulk::copy_insert_feed_items(client, &feed_item_data).await?;
         bulk::copy_insert_post_embed_images(client, &embed_image_data).await?;
         bulk::copy_insert_post_embed_videos(client, &embed_video_data).await?;
-        bulk::copy_insert_quotes(client, &quote_data).await?;
+        bulk::copy_insert_quotes(client, &quote_data, compute_agg).await?;
+
+        // Notifications are deliberately not limited to newly applied rows:
+        // gap-heal replays must generate them for rows indexed by older code,
+        // and the (did, recordUri, reason) dedupe keeps replays exact.
+        if compute_agg {
+            bulk::copy_insert_notifications(client, &notif_rows).await?;
+            for (did, uri, cid, sort_at) in &reply_posts {
+                Self::write_reply_notifications(client, did, uri, cid, sort_at).await?;
+            }
+        }
 
         Ok(())
     }
@@ -2939,6 +3012,7 @@ impl IndexerManager {
     async fn copy_batch_insert_likes(
         client: &deadpool_postgres::Client,
         jobs: &[&ParsedJob<'_>],
+        compute_agg: bool,
     ) -> Result<(), WintermuteError> {
         use crate::metrics;
 
@@ -2948,6 +3022,7 @@ impl IndexerManager {
 
         let mut like_data: Vec<(String, String, String, String, String, String, String)> =
             Vec::with_capacity(jobs.len());
+        let mut notif_rows: Vec<bulk::NotificationRow> = Vec::new();
 
         for pj in jobs {
             if let Some(record) = &pj.job.record {
@@ -2966,6 +3041,18 @@ impl IndexerManager {
                     .and_then(|v| v.as_str())
                     .unwrap_or(&pj.job.indexed_at);
 
+                Self::collect_subject_notifications(
+                    &mut notif_rows,
+                    record,
+                    &pj.did,
+                    &uri,
+                    &pj.job.cid,
+                    subject_uri,
+                    &pj.job.indexed_at,
+                    "like",
+                    "like-via-repost",
+                );
+
                 like_data.push((
                     uri,
                     pj.job.cid.clone(),
@@ -2980,7 +3067,65 @@ impl IndexerManager {
             }
         }
 
-        bulk::copy_insert_likes(client, &like_data).await
+        bulk::copy_insert_likes(client, &like_data, compute_agg).await?;
+        if compute_agg {
+            bulk::copy_insert_notifications(client, &notif_rows).await?;
+        }
+        Ok(())
+    }
+
+    /// Collect subject + via notifications for a like or repost record,
+    /// mirroring the per-record path's recipients and self-skips.
+    #[allow(clippy::too_many_arguments)]
+    fn collect_subject_notifications(
+        notif_rows: &mut Vec<bulk::NotificationRow>,
+        record: &serde_json::Value,
+        did: &str,
+        uri: &str,
+        cid: &str,
+        subject_uri: &str,
+        indexed_at: &str,
+        reason: &'static str,
+        via_reason: &'static str,
+    ) {
+        if subject_uri.is_empty() {
+            return;
+        }
+        let Ok(subject) = AtUri::new(subject_uri.to_owned(), None) else {
+            return;
+        };
+        let subject_author = subject.get_hostname();
+        if subject_author != did {
+            notif_rows.push(bulk::NotificationRow {
+                did: subject_author.to_owned(),
+                author: did.to_owned(),
+                record_uri: uri.to_owned(),
+                record_cid: cid.to_owned(),
+                reason,
+                reason_subject: Some(subject_uri.to_owned()),
+                sort_at: indexed_at.to_owned(),
+            });
+        }
+        let via_uri_str = record
+            .get("via")
+            .and_then(|v| v.get("uri"))
+            .and_then(|v| v.as_str());
+        if let Some(via_uri_str) = via_uri_str {
+            if let Ok(via_uri) = AtUri::new(via_uri_str.to_owned(), None) {
+                let reposter = via_uri.get_hostname();
+                if reposter != did {
+                    notif_rows.push(bulk::NotificationRow {
+                        did: reposter.to_owned(),
+                        author: did.to_owned(),
+                        record_uri: uri.to_owned(),
+                        record_cid: cid.to_owned(),
+                        reason: via_reason,
+                        reason_subject: Some(via_uri_str.to_owned()),
+                        sort_at: indexed_at.to_owned(),
+                    });
+                }
+            }
+        }
     }
 
     async fn copy_batch_insert_follows(
@@ -2996,6 +3141,7 @@ impl IndexerManager {
 
         let mut follow_data: Vec<(String, String, String, String, String, String)> =
             Vec::with_capacity(jobs.len());
+        let mut notif_rows: Vec<bulk::NotificationRow> = Vec::new();
 
         for pj in jobs {
             if let Some(record) = &pj.job.record {
@@ -3005,6 +3151,18 @@ impl IndexerManager {
                     .get("createdAt")
                     .and_then(|v| v.as_str())
                     .unwrap_or(&pj.job.indexed_at);
+
+                if !subject.is_empty() {
+                    notif_rows.push(bulk::NotificationRow {
+                        did: subject.to_owned(),
+                        author: pj.did.clone(),
+                        record_uri: uri.clone(),
+                        record_cid: pj.job.cid.clone(),
+                        reason: "follow",
+                        reason_subject: None,
+                        sort_at: pj.job.indexed_at.clone(),
+                    });
+                }
 
                 follow_data.push((
                     uri,
@@ -3019,12 +3177,17 @@ impl IndexerManager {
             }
         }
 
-        bulk::copy_insert_follows(client, &follow_data, compute_agg).await
+        bulk::copy_insert_follows(client, &follow_data, compute_agg).await?;
+        if compute_agg {
+            bulk::copy_insert_notifications(client, &notif_rows).await?;
+        }
+        Ok(())
     }
 
     async fn copy_batch_insert_reposts(
         client: &deadpool_postgres::Client,
         jobs: &[&ParsedJob<'_>],
+        compute_agg: bool,
     ) -> Result<(), WintermuteError> {
         use crate::metrics;
 
@@ -3036,6 +3199,7 @@ impl IndexerManager {
             Vec::with_capacity(jobs.len());
         let mut feed_item_data: Vec<(String, String, String, String, String, String)> =
             Vec::with_capacity(jobs.len());
+        let mut notif_rows: Vec<bulk::NotificationRow> = Vec::new();
 
         for pj in jobs {
             if let Some(record) = &pj.job.record {
@@ -3060,6 +3224,18 @@ impl IndexerManager {
                     created_at.clone()
                 };
 
+                Self::collect_subject_notifications(
+                    &mut notif_rows,
+                    record,
+                    &pj.did,
+                    &uri,
+                    &pj.job.cid,
+                    subject_uri,
+                    &pj.job.indexed_at,
+                    "repost",
+                    "repost-via-repost",
+                );
+
                 repost_data.push((
                     uri.clone(),
                     pj.job.cid.clone(),
@@ -3083,8 +3259,11 @@ impl IndexerManager {
             }
         }
 
-        bulk::copy_insert_reposts(client, &repost_data).await?;
+        bulk::copy_insert_reposts(client, &repost_data, compute_agg).await?;
         bulk::copy_insert_feed_items(client, &feed_item_data).await?;
+        if compute_agg {
+            bulk::copy_insert_notifications(client, &notif_rows).await?;
+        }
 
         Ok(())
     }
@@ -3352,6 +3531,39 @@ impl IndexerManager {
         // Reply notifications: walk ancestor chain up to REPLY_NOTIF_DEPTH
         // Matches official Bluesky behavior from post.ts notifsForInsert
         if let Some(parent_uri_str) = reply_parent {
+            Self::write_reply_notifications(client, did, &uri, cid, sort_at).await?;
+
+            // Update replyCount for parent post
+            client
+                .execute(
+                    "INSERT INTO post_agg (uri, \"replyCount\")
+                     SELECT $1::varchar, COUNT(*) FROM post
+                     WHERE \"replyParent\" = $1
+                       AND (\"violatesThreadGate\" IS NULL OR \"violatesThreadGate\" = false)
+                     ON CONFLICT (uri) DO UPDATE SET \"replyCount\" = EXCLUDED.\"replyCount\"",
+                    &[&parent_uri_str],
+                )
+                .await?;
+        }
+
+        // Handle embed.record (quote posts)
+        if let Some(embed) = record.get("embed") {
+            Self::handle_post_embeds(client, embed, &uri, cid, did, created_at, indexed_at).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Notify ancestor authors of a new reply, including descendant repair for
+    /// out-of-order indexing. Shared by the per-record and batch paths.
+    async fn write_reply_notifications(
+        client: &deadpool_postgres::Client,
+        did: &str,
+        uri: &str,
+        cid: &str,
+        sort_at: &str,
+    ) -> Result<(), WintermuteError> {
+        {
             const REPLY_NOTIF_DEPTH: i32 = 5;
 
             // Query ancestors using recursive CTE
@@ -3466,23 +3678,6 @@ impl IndexerManager {
                     }
                 }
             }
-
-            // Update replyCount for parent post
-            client
-                .execute(
-                    "INSERT INTO post_agg (uri, \"replyCount\")
-                     SELECT $1::varchar, COUNT(*) FROM post
-                     WHERE \"replyParent\" = $1
-                       AND (\"violatesThreadGate\" IS NULL OR \"violatesThreadGate\" = false)
-                     ON CONFLICT (uri) DO UPDATE SET \"replyCount\" = EXCLUDED.\"replyCount\"",
-                    &[&parent_uri_str],
-                )
-                .await?;
-        }
-
-        // Handle embed.record (quote posts)
-        if let Some(embed) = record.get("embed") {
-            Self::handle_post_embeds(client, embed, &uri, cid, did, created_at, indexed_at).await?;
         }
 
         Ok(())

--- a/rsky-wintermute/src/indexer/tests.rs
+++ b/rsky-wintermute/src/indexer/tests.rs
@@ -62,10 +62,24 @@ mod indexer_tests {
             "notification",
         ];
 
+        // post_agg is keyed by post uri, so it must go before the posts do.
+        drop(
+            client
+                .execute(
+                    "DELETE FROM post_agg WHERE uri IN (SELECT uri FROM post WHERE creator = $1)",
+                    &[&did],
+                )
+                .await,
+        );
+
+        // One DELETE per candidate column: a single OR query fails outright on
+        // tables that lack any one of these columns, silently deleting nothing.
+        // Table names are quoted ("like" is a reserved word).
         for table in &tables {
-            let query =
-                format!("DELETE FROM {table} WHERE creator = $1 OR did = $1 OR author = $1");
-            drop(client.execute(&query, &[&did]).await);
+            for column in ["creator", "did", "author"] {
+                let query = format!("DELETE FROM \"{table}\" WHERE {column} = $1");
+                drop(client.execute(&query, &[&did]).await);
+            }
         }
 
         drop(
@@ -76,14 +90,6 @@ mod indexer_tests {
         drop(
             client
                 .execute("DELETE FROM profile_agg WHERE did = $1", &[&did])
-                .await,
-        );
-        drop(
-            client
-                .execute(
-                    "DELETE FROM post_agg WHERE uri IN (SELECT uri FROM post WHERE creator = $1)",
-                    &[&did],
-                )
                 .await,
         );
     }
@@ -2019,6 +2025,256 @@ mod indexer_tests {
         assert_eq!(row.get::<_, i64>(0), 1, "followersCount must be exactly 1");
 
         for did in [creator, subject] {
+            cleanup_test_data(&pool, did).await;
+        }
+    }
+
+    #[test]
+    fn collect_subject_notifications_recipients_and_self_skips() {
+        let record = serde_json::json!({
+            "subject": {"uri": "at://did:plc:subject-author/app.bsky.feed.post/abc"},
+            "via": {"uri": "at://did:plc:reposter/app.bsky.feed.repost/xyz"},
+        });
+        let mut rows = Vec::new();
+        IndexerManager::collect_subject_notifications(
+            &mut rows,
+            &record,
+            "did:plc:liker",
+            "at://did:plc:liker/app.bsky.feed.like/1",
+            "cid1",
+            "at://did:plc:subject-author/app.bsky.feed.post/abc",
+            "2026-07-30T00:00:00.000Z",
+            "like",
+            "like-via-repost",
+        );
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].did, "did:plc:subject-author");
+        assert_eq!(rows[0].reason, "like");
+        assert_eq!(
+            rows[0].reason_subject.as_deref(),
+            Some("at://did:plc:subject-author/app.bsky.feed.post/abc")
+        );
+        assert_eq!(rows[1].did, "did:plc:reposter");
+        assert_eq!(rows[1].reason, "like-via-repost");
+
+        // Self-like and self-via generate nothing
+        let mut rows = Vec::new();
+        IndexerManager::collect_subject_notifications(
+            &mut rows,
+            &serde_json::json!({
+                "subject": {"uri": "at://did:plc:liker/app.bsky.feed.post/own"},
+                "via": {"uri": "at://did:plc:liker/app.bsky.feed.repost/own"},
+            }),
+            "did:plc:liker",
+            "at://did:plc:liker/app.bsky.feed.like/2",
+            "cid2",
+            "at://did:plc:liker/app.bsky.feed.post/own",
+            "2026-07-30T00:00:00.000Z",
+            "like",
+            "like-via-repost",
+        );
+        assert!(rows.is_empty());
+
+        // Empty subject generates nothing
+        let mut rows = Vec::new();
+        IndexerManager::collect_subject_notifications(
+            &mut rows,
+            &serde_json::json!({}),
+            "did:plc:liker",
+            "at://did:plc:liker/app.bsky.feed.like/3",
+            "cid3",
+            "",
+            "2026-07-30T00:00:00.000Z",
+            "like",
+            "like-via-repost",
+        );
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn bulk_notifications_and_post_agg_are_exact_and_replay_safe() {
+        use crate::indexer::bulk::{self, NotificationRow, PostCopyRow};
+
+        let pool = setup_test_pool();
+        let author = "did:plc:wintermute-test-notif-author";
+        let recipient = "did:plc:wintermute-test-notif-recip";
+        for did in [author, recipient] {
+            cleanup_test_data(&pool, did).await;
+        }
+
+        let client = pool.get().await.unwrap();
+        for did in [author, recipient] {
+            client
+                .execute(
+                    "INSERT INTO actor (did, \"indexedAt\") VALUES ($1, NOW()) \
+                     ON CONFLICT (did) DO NOTHING",
+                    &[&did],
+                )
+                .await
+                .unwrap();
+        }
+
+        let parent_uri = format!("at://{recipient}/app.bsky.feed.post/notifparent");
+        let cid = "bafyreihhl5mpvjkrhnnagen2fomozzhnhhdq2jr6cego2nzbvmwewv5rd4".to_owned();
+        let ts = "2026-07-30T00:00:00.000Z".to_owned();
+        client
+            .execute("DELETE FROM post_agg WHERE uri = $1", &[&parent_uri])
+            .await
+            .unwrap();
+        client
+            .execute("DELETE FROM quote WHERE subject = $1", &[&parent_uri])
+            .await
+            .unwrap();
+
+        // Parent post by recipient, then a batch reply by author: replyCount
+        // increments exactly once across a replay.
+        let parent = PostCopyRow {
+            uri: parent_uri.clone(),
+            cid: cid.clone(),
+            creator: recipient.to_owned(),
+            text: "parent".to_owned(),
+            reply_root: None,
+            reply_root_cid: None,
+            reply_parent: None,
+            reply_parent_cid: None,
+            created_at: ts.clone(),
+            indexed_at: ts.clone(),
+            langs: None,
+            tags: None,
+        };
+        let reply = PostCopyRow {
+            uri: format!("at://{author}/app.bsky.feed.post/notifreply"),
+            cid: cid.clone(),
+            creator: author.to_owned(),
+            text: "reply".to_owned(),
+            reply_root: Some(parent_uri.clone()),
+            reply_root_cid: Some(cid.clone()),
+            reply_parent: Some(parent_uri.clone()),
+            reply_parent_cid: Some(cid.clone()),
+            created_at: ts.clone(),
+            indexed_at: ts.clone(),
+            langs: None,
+            tags: None,
+        };
+        let applied = bulk::copy_insert_posts(&client, &[parent, reply], true)
+            .await
+            .unwrap();
+        assert_eq!(applied.len(), 2, "both posts must apply");
+        let replay_row = PostCopyRow {
+            uri: format!("at://{author}/app.bsky.feed.post/notifreply"),
+            cid: cid.clone(),
+            creator: author.to_owned(),
+            text: "reply replay".to_owned(),
+            reply_root: Some(parent_uri.clone()),
+            reply_root_cid: Some(cid.clone()),
+            reply_parent: Some(parent_uri.clone()),
+            reply_parent_cid: Some(cid.clone()),
+            created_at: ts.clone(),
+            indexed_at: ts.clone(),
+            langs: None,
+            tags: None,
+        };
+        let replayed = bulk::copy_insert_posts(&client, &[replay_row], true)
+            .await
+            .unwrap();
+        assert!(replayed.is_empty(), "replayed post must not re-apply");
+
+        // Batch likes and reposts of the parent: likeCount/repostCount exact
+        // across replays.
+        let like = (
+            format!("at://{author}/app.bsky.feed.like/notiflike"),
+            cid.clone(),
+            author.to_owned(),
+            parent_uri.clone(),
+            cid.clone(),
+            ts.clone(),
+            ts.clone(),
+        );
+        let like_applied = bulk::copy_insert_likes(&client, std::slice::from_ref(&like), true)
+            .await
+            .unwrap();
+        assert_eq!(like_applied.len(), 1);
+        let like_replayed = bulk::copy_insert_likes(&client, std::slice::from_ref(&like), true)
+            .await
+            .unwrap();
+        assert!(like_replayed.is_empty());
+
+        let repost = (
+            format!("at://{author}/app.bsky.feed.repost/notifrepost"),
+            cid.clone(),
+            author.to_owned(),
+            parent_uri.clone(),
+            cid.clone(),
+            ts.clone(),
+            ts.clone(),
+        );
+        bulk::copy_insert_reposts(&client, std::slice::from_ref(&repost), true)
+            .await
+            .unwrap();
+        bulk::copy_insert_reposts(&client, std::slice::from_ref(&repost), true)
+            .await
+            .unwrap();
+
+        // Batch quote of the parent: quoteCount exact across replays.
+        let quote = (
+            format!("at://{author}/app.bsky.feed.post/notifquote"),
+            cid.clone(),
+            parent_uri.clone(),
+            cid.clone(),
+            ts.clone(),
+            ts.clone(),
+        );
+        bulk::copy_insert_quotes(&client, std::slice::from_ref(&quote), true)
+            .await
+            .unwrap();
+        bulk::copy_insert_quotes(&client, std::slice::from_ref(&quote), true)
+            .await
+            .unwrap();
+
+        let agg = client
+            .query_one(
+                "SELECT \"replyCount\", \"likeCount\", \"repostCount\", \"quoteCount\" \
+                 FROM post_agg WHERE uri = $1",
+                &[&parent_uri],
+            )
+            .await
+            .unwrap();
+        assert_eq!(agg.get::<_, i64>(0), 1, "replyCount must be exactly 1");
+        assert_eq!(agg.get::<_, i64>(1), 1, "likeCount must be exactly 1");
+        assert_eq!(agg.get::<_, i64>(2), 1, "repostCount must be exactly 1");
+        assert_eq!(agg.get::<_, i64>(3), 1, "quoteCount must be exactly 1");
+
+        // Bulk notifications dedupe on (did, recordUri, reason).
+        let notif = NotificationRow {
+            did: recipient.to_owned(),
+            author: author.to_owned(),
+            record_uri: format!("at://{author}/app.bsky.feed.like/notiflike"),
+            record_cid: cid.clone(),
+            reason: "like",
+            reason_subject: Some(parent_uri.clone()),
+            sort_at: ts.clone(),
+        };
+        bulk::copy_insert_notifications(&client, std::slice::from_ref(&notif))
+            .await
+            .unwrap();
+        bulk::copy_insert_notifications(&client, std::slice::from_ref(&notif))
+            .await
+            .unwrap();
+        let notif_count: i64 = client
+            .query_one(
+                "SELECT COUNT(*) FROM notification WHERE did = $1 AND author = $2",
+                &[&recipient, &author],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(notif_count, 1, "notification must dedupe to exactly 1");
+
+        client
+            .execute("DELETE FROM post_agg WHERE uri = $1", &[&parent_uri])
+            .await
+            .unwrap();
+        for did in [author, recipient] {
             cleanup_test_data(&pool, did).await;
         }
     }


### PR DESCRIPTION
The batch/COPY live-drain path never wrote notification rows or post likeCount/repostCount/quoteCount/replyCount, so standard notifications and engagement counts silently stopped for all live-indexed records (community-post notifications come from the dataplane and were unaffected). Batch inserts now emit the same notifications as the per-record path and increment post_agg by exact replay-safe deltas.