### PR TITLE
feat(wintermute): sharded live drain, sequence-keyed queue, via capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.4.21"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.4.18"
+version = "0.4.19"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.4.16"
+version = "0.4.17"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.4.14"
+version = "0.4.15"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.4.21"
+version = "0.5.0"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/src/config.rs
+++ b/rsky-wintermute/src/config.rs
@@ -158,6 +158,24 @@ pub static FIREHOSE_LIVE_DRAIN_BATCH: LazyLock<usize> = LazyLock::new(|| {
         .unwrap_or(2000)
 });
 
+/// Concurrent shards a `firehose_live` batch is split into, partitioned by repo
+/// DID so per-repo ordering holds. 1 = single-shard (previous behavior).
+pub static FIREHOSE_LIVE_SHARDS: LazyLock<usize> = LazyLock::new(|| {
+    std::env::var("FIREHOSE_LIVE_SHARDS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|n| *n >= 1)
+        .unwrap_or(1)
+});
+
+/// Serialize live like inserts across shards (the like index is contention-prone).
+/// Set `LIVE_LIKE_SERIALIZE=false` to let shards write likes concurrently.
+pub static LIVE_LIKE_SERIALIZE: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var("LIVE_LIKE_SERIALIZE")
+        .map(|v| v != "false" && v != "0")
+        .unwrap_or(true)
+});
+
 pub static INLINE_CONCURRENCY: LazyLock<usize> = LazyLock::new(|| {
     std::env::var("INLINE_CONCURRENCY")
         .ok()

--- a/rsky-wintermute/src/indexer/bulk.rs
+++ b/rsky-wintermute/src/indexer/bulk.rs
@@ -221,14 +221,15 @@ pub async fn decrement_profile_agg(
     Ok(())
 }
 
-/// Set-based reply notifications for a batch of new reply posts, replacing a
-/// per-reply pair of round-trips with two statements. Seeds are
-/// `(did, uri, cid, sort_at)` of the new replies. Semantics mirror the
-/// per-record walk: ancestors up to depth 4 are notified of each new reply,
-/// and existing descendants (out-of-order indexing) are re-linked to the new
-/// post's ancestor chain, including the new post itself. Inserts are ordered
-/// by conflict key for deadlock-free concurrency and deduped on
-/// (did, "recordUri", reason).
+/// Set-based reply notifications for a batch of new reply posts, replacing
+/// per-reply round-trips with one recursive statement over pkey joins. Seeds
+/// are `(did, uri, cid, sort_at)` of the new replies; ancestors up to depth 4
+/// are notified of each. The per-record path's descendant repair is deliberately
+/// omitted here: descendants of a just-created post only exist when indexing
+/// ran out of order, the backfill path still repairs that case per-record, and
+/// the planner cannot be trusted to bound a descendants recursion over the
+/// post table from unnest seeds. Inserts are ordered by conflict key for
+/// deadlock-free concurrency and deduped on (did, "recordUri", reason).
 pub async fn write_reply_notifications_bulk(
     client: &deadpool_postgres::Client,
     seeds: &[(String, String, String, String)],
@@ -269,40 +270,6 @@ pub async fn write_reply_notifications_bulk(
              ORDER BY 1, 3
              ON CONFLICT (did, \"recordUri\", reason) DO NOTHING",
             &[&dids, &uris, &cids, &sort_ats],
-        )
-        .await?;
-
-    client
-        .execute(
-            "WITH RECURSIVE seeds AS (
-                 SELECT * FROM unnest($1::text[], $2::text[]) AS s(did, uri)
-             ),
-             ancestor(seed_uri, uri, parent, height) AS (
-                 SELECT s.uri, p.uri, p.\"replyParent\", 0
-                 FROM seeds s JOIN post p ON p.uri = s.uri
-               UNION ALL
-                 SELECT a.seed_uri, p.uri, p.\"replyParent\", a.height + 1
-                 FROM ancestor a JOIN post p ON p.uri = a.parent
-                 WHERE a.height < 4
-             ),
-             descendent(seed_uri, uri, depth) AS (
-                 SELECT s.uri, p.uri, 1
-                 FROM seeds s JOIN post p ON p.\"replyParent\" = s.uri
-               UNION ALL
-                 SELECT d.seed_uri, p.uri, d.depth + 1
-                 FROM descendent d JOIN post p ON p.\"replyParent\" = d.uri
-                 WHERE d.depth < 4
-             )
-             INSERT INTO notification (did, author, \"recordUri\", \"recordCid\", reason, \"reasonSubject\", \"sortAt\")
-             SELECT DISTINCT split_part(a.uri, '/', 3), dp.creator, dp.uri, dp.cid, 'reply', a.uri, dp.\"sortAt\"
-             FROM descendent d
-             JOIN post dp ON dp.uri = d.uri
-             JOIN ancestor a ON a.seed_uri = d.seed_uri
-             WHERE d.depth + a.height < 5
-               AND split_part(a.uri, '/', 3) <> dp.creator
-             ORDER BY 1, 3
-             ON CONFLICT (did, \"recordUri\", reason) DO NOTHING",
-            &[&dids, &uris],
         )
         .await?;
 

--- a/rsky-wintermute/src/indexer/bulk.rs
+++ b/rsky-wintermute/src/indexer/bulk.rs
@@ -79,6 +79,32 @@ pub struct PostCopyRow {
     pub tags: Option<String>,
 }
 
+/// A like or repost row for bulk `COPY`: strong-ref subject plus optional
+/// via attribution.
+pub struct SubjectRecordRow {
+    pub uri: String,
+    pub cid: String,
+    pub creator: String,
+    pub subject: String,
+    pub subject_cid: String,
+    pub created_at: String,
+    pub indexed_at: String,
+    pub via: Option<String>,
+    pub via_cid: Option<String>,
+}
+
+/// A follow row for bulk `COPY`: DID subject plus optional via attribution.
+pub struct FollowCopyRow {
+    pub uri: String,
+    pub cid: String,
+    pub creator: String,
+    pub subject_did: String,
+    pub created_at: String,
+    pub indexed_at: String,
+    pub via: Option<String>,
+    pub via_cid: Option<String>,
+}
+
 /// A notification destined for the `notification` table.
 pub struct NotificationRow {
     pub did: String,
@@ -686,7 +712,7 @@ pub async fn copy_insert_feed_items(
 /// Bulk insert likes using `COPY` protocol.
 pub async fn copy_insert_likes(
     client: &deadpool_postgres::Client,
-    data: &[(String, String, String, String, String, String, String)], // uri, cid, creator, subject, subject_cid, created_at, indexed_at
+    data: &[SubjectRecordRow],
     compute_agg: bool, // false for the bulk CAR load (aggregates recomputed in one pass after)
 ) -> Result<std::collections::HashSet<String>, WintermuteError> {
     use std::time::Instant;
@@ -708,7 +734,9 @@ pub async fn copy_insert_likes(
                 subject text NOT NULL,
                 subject_cid text NOT NULL,
                 created_at text NOT NULL,
-                indexed_at text NOT NULL
+                indexed_at text NOT NULL,
+                via text,
+                via_cid text
             );
             TRUNCATE _bulk_like",
         )
@@ -718,24 +746,26 @@ pub async fn copy_insert_likes(
     // Phase 2: COPY data
     let copy_start = Instant::now();
     let copy_stmt = client
-        .copy_in("COPY _bulk_like (uri, cid, creator, subject, subject_cid, created_at, indexed_at) FROM STDIN WITH (FORMAT text, DELIMITER E'\\t', NULL '')")
+        .copy_in("COPY _bulk_like (uri, cid, creator, subject, subject_cid, created_at, indexed_at, via, via_cid) FROM STDIN WITH (FORMAT text, DELIMITER E'\\t', NULL '')")
         .await?;
 
     let sink = copy_stmt;
     pin_mut!(sink);
 
     let mut buffer = Vec::with_capacity(data.len() * 250);
-    for (uri, cid, creator, subject, subject_cid, created_at, indexed_at) in data {
-        let uri = escape_copy_field(uri);
-        let cid = escape_copy_field(cid);
-        let creator = escape_copy_field(creator);
-        let subject = escape_copy_field(subject);
-        let subject_cid = escape_copy_field(subject_cid);
-        let created_at = escape_copy_field(created_at);
-        let indexed_at = escape_copy_field(indexed_at);
+    for row in data {
+        let uri = escape_copy_field(&row.uri);
+        let cid = escape_copy_field(&row.cid);
+        let creator = escape_copy_field(&row.creator);
+        let subject = escape_copy_field(&row.subject);
+        let subject_cid = escape_copy_field(&row.subject_cid);
+        let created_at = escape_copy_field(&row.created_at);
+        let indexed_at = escape_copy_field(&row.indexed_at);
+        let via = escape_copy_field(row.via.as_deref().unwrap_or(""));
+        let via_cid = escape_copy_field(row.via_cid.as_deref().unwrap_or(""));
         writeln!(
             buffer,
-            "{uri}\t{cid}\t{creator}\t{subject}\t{subject_cid}\t{created_at}\t{indexed_at}"
+            "{uri}\t{cid}\t{creator}\t{subject}\t{subject_cid}\t{created_at}\t{indexed_at}\t{via}\t{via_cid}"
         )
         .map_err(|e| WintermuteError::Other(format!("buffer write error: {e}")))?;
     }
@@ -749,8 +779,8 @@ pub async fn copy_insert_likes(
     let insert_start = Instant::now();
     let inserted = client
         .query(
-            "INSERT INTO \"like\" (uri, cid, creator, subject, \"subjectCid\", \"createdAt\", \"indexedAt\")
-             SELECT uri, cid, creator, subject, subject_cid, created_at, indexed_at
+            "INSERT INTO \"like\" (uri, cid, creator, subject, \"subjectCid\", \"createdAt\", \"indexedAt\", via, \"viaCid\")
+             SELECT uri, cid, creator, subject, subject_cid, created_at, indexed_at, via, via_cid
              FROM _bulk_like
              ON CONFLICT DO NOTHING
              RETURNING uri, subject",
@@ -791,7 +821,7 @@ pub async fn copy_insert_likes(
 /// Bulk insert follows using `COPY` protocol.
 pub async fn copy_insert_follows(
     client: &deadpool_postgres::Client,
-    data: &[(String, String, String, String, String, String)], // uri, cid, creator, subject_did, created_at, indexed_at
+    data: &[FollowCopyRow],
     compute_agg: bool, // false for the bulk CAR load (aggregates recomputed in one pass after)
 ) -> Result<std::collections::HashSet<String>, WintermuteError> {
     use std::time::Instant;
@@ -812,7 +842,9 @@ pub async fn copy_insert_follows(
                 creator text NOT NULL,
                 subject_did text NOT NULL,
                 created_at text NOT NULL,
-                indexed_at text NOT NULL
+                indexed_at text NOT NULL,
+                via text,
+                via_cid text
             );
             TRUNCATE _bulk_follow",
         )
@@ -822,23 +854,25 @@ pub async fn copy_insert_follows(
     // Phase 2: COPY data
     let copy_start = Instant::now();
     let copy_stmt = client
-        .copy_in("COPY _bulk_follow (uri, cid, creator, subject_did, created_at, indexed_at) FROM STDIN WITH (FORMAT text, DELIMITER E'\\t')")
+        .copy_in("COPY _bulk_follow (uri, cid, creator, subject_did, created_at, indexed_at, via, via_cid) FROM STDIN WITH (FORMAT text, DELIMITER E'\\t')")
         .await?;
 
     let sink = copy_stmt;
     pin_mut!(sink);
 
     let mut buffer = Vec::with_capacity(data.len() * 200);
-    for (uri, cid, creator, subject_did, created_at, indexed_at) in data {
-        let uri = escape_copy_field(uri);
-        let cid = escape_copy_field(cid);
-        let creator = escape_copy_field(creator);
-        let subject_did = escape_copy_field(subject_did);
-        let created_at = escape_copy_field(created_at);
-        let indexed_at = escape_copy_field(indexed_at);
+    for row in data {
+        let uri = escape_copy_field(&row.uri);
+        let cid = escape_copy_field(&row.cid);
+        let creator = escape_copy_field(&row.creator);
+        let subject_did = escape_copy_field(&row.subject_did);
+        let created_at = escape_copy_field(&row.created_at);
+        let indexed_at = escape_copy_field(&row.indexed_at);
+        let via = escape_copy_opt(row.via.as_deref());
+        let via_cid = escape_copy_opt(row.via_cid.as_deref());
         writeln!(
             buffer,
-            "{uri}\t{cid}\t{creator}\t{subject_did}\t{created_at}\t{indexed_at}"
+            "{uri}\t{cid}\t{creator}\t{subject_did}\t{created_at}\t{indexed_at}\t{via}\t{via_cid}"
         )
         .map_err(|e| WintermuteError::Other(format!("buffer write error: {e}")))?;
     }
@@ -852,8 +886,8 @@ pub async fn copy_insert_follows(
     let insert_start = Instant::now();
     let inserted = client
         .query(
-            "INSERT INTO follow (uri, cid, creator, \"subjectDid\", \"createdAt\", \"indexedAt\")
-             SELECT uri, cid, creator, subject_did, created_at, indexed_at
+            "INSERT INTO follow (uri, cid, creator, \"subjectDid\", \"createdAt\", \"indexedAt\", via, \"viaCid\")
+             SELECT uri, cid, creator, subject_did, created_at, indexed_at, via, via_cid
              FROM _bulk_follow
              ON CONFLICT DO NOTHING
              RETURNING uri, creator, \"subjectDid\"",
@@ -921,7 +955,7 @@ pub async fn copy_insert_follows(
 /// Bulk insert reposts using `COPY` protocol.
 pub async fn copy_insert_reposts(
     client: &deadpool_postgres::Client,
-    data: &[(String, String, String, String, String, String, String)], // uri, cid, creator, subject, subject_cid, created_at, indexed_at
+    data: &[SubjectRecordRow],
     compute_agg: bool, // false for the bulk CAR load (aggregates recomputed in one pass after)
 ) -> Result<std::collections::HashSet<String>, WintermuteError> {
     use std::time::Instant;
@@ -943,7 +977,9 @@ pub async fn copy_insert_reposts(
                 subject text NOT NULL,
                 subject_cid text NOT NULL,
                 created_at text NOT NULL,
-                indexed_at text NOT NULL
+                indexed_at text NOT NULL,
+                via text,
+                via_cid text
             );
             TRUNCATE _bulk_repost",
         )
@@ -953,24 +989,26 @@ pub async fn copy_insert_reposts(
     // Phase 2: COPY data
     let copy_start = Instant::now();
     let copy_stmt = client
-        .copy_in("COPY _bulk_repost (uri, cid, creator, subject, subject_cid, created_at, indexed_at) FROM STDIN WITH (FORMAT text, DELIMITER E'\\t', NULL '')")
+        .copy_in("COPY _bulk_repost (uri, cid, creator, subject, subject_cid, created_at, indexed_at, via, via_cid) FROM STDIN WITH (FORMAT text, DELIMITER E'\\t', NULL '')")
         .await?;
 
     let sink = copy_stmt;
     pin_mut!(sink);
 
     let mut buffer = Vec::with_capacity(data.len() * 250);
-    for (uri, cid, creator, subject, subject_cid, created_at, indexed_at) in data {
-        let uri = escape_copy_field(uri);
-        let cid = escape_copy_field(cid);
-        let creator = escape_copy_field(creator);
-        let subject = escape_copy_field(subject);
-        let subject_cid = escape_copy_field(subject_cid);
-        let created_at = escape_copy_field(created_at);
-        let indexed_at = escape_copy_field(indexed_at);
+    for row in data {
+        let uri = escape_copy_field(&row.uri);
+        let cid = escape_copy_field(&row.cid);
+        let creator = escape_copy_field(&row.creator);
+        let subject = escape_copy_field(&row.subject);
+        let subject_cid = escape_copy_field(&row.subject_cid);
+        let created_at = escape_copy_field(&row.created_at);
+        let indexed_at = escape_copy_field(&row.indexed_at);
+        let via = escape_copy_field(row.via.as_deref().unwrap_or(""));
+        let via_cid = escape_copy_field(row.via_cid.as_deref().unwrap_or(""));
         writeln!(
             buffer,
-            "{uri}\t{cid}\t{creator}\t{subject}\t{subject_cid}\t{created_at}\t{indexed_at}"
+            "{uri}\t{cid}\t{creator}\t{subject}\t{subject_cid}\t{created_at}\t{indexed_at}\t{via}\t{via_cid}"
         )
         .map_err(|e| WintermuteError::Other(format!("buffer write error: {e}")))?;
     }
@@ -984,8 +1022,8 @@ pub async fn copy_insert_reposts(
     let insert_start = Instant::now();
     let inserted = client
         .query(
-            "INSERT INTO repost (uri, cid, creator, subject, \"subjectCid\", \"createdAt\", \"indexedAt\")
-             SELECT uri, cid, creator, subject, subject_cid, created_at, indexed_at
+            "INSERT INTO repost (uri, cid, creator, subject, \"subjectCid\", \"createdAt\", \"indexedAt\", via, \"viaCid\")
+             SELECT uri, cid, creator, subject, subject_cid, created_at, indexed_at, via, via_cid
              FROM _bulk_repost
              ON CONFLICT DO NOTHING
              RETURNING uri, subject",

--- a/rsky-wintermute/src/indexer/bulk.rs
+++ b/rsky-wintermute/src/indexer/bulk.rs
@@ -221,6 +221,94 @@ pub async fn decrement_profile_agg(
     Ok(())
 }
 
+/// Set-based reply notifications for a batch of new reply posts, replacing a
+/// per-reply pair of round-trips with two statements. Seeds are
+/// `(did, uri, cid, sort_at)` of the new replies. Semantics mirror the
+/// per-record walk: ancestors up to depth 4 are notified of each new reply,
+/// and existing descendants (out-of-order indexing) are re-linked to the new
+/// post's ancestor chain, including the new post itself. Inserts are ordered
+/// by conflict key for deadlock-free concurrency and deduped on
+/// (did, "recordUri", reason).
+pub async fn write_reply_notifications_bulk(
+    client: &deadpool_postgres::Client,
+    seeds: &[(String, String, String, String)],
+) -> Result<(), WintermuteError> {
+    if seeds.is_empty() {
+        return Ok(());
+    }
+    let mut dids = Vec::with_capacity(seeds.len());
+    let mut uris = Vec::with_capacity(seeds.len());
+    let mut cids = Vec::with_capacity(seeds.len());
+    let mut sort_ats = Vec::with_capacity(seeds.len());
+    for (did, uri, cid, sort_at) in seeds {
+        dids.push(did.as_str());
+        uris.push(uri.as_str());
+        cids.push(cid.as_str());
+        sort_ats.push(sort_at.as_str());
+    }
+
+    client
+        .execute(
+            "WITH RECURSIVE seeds AS (
+                 SELECT * FROM unnest($1::text[], $2::text[], $3::text[], $4::text[])
+                     AS s(did, uri, cid, sort_at)
+             ),
+             ancestor(seed_uri, uri, parent, height) AS (
+                 SELECT s.uri, p.uri, p.\"replyParent\", 0
+                 FROM seeds s JOIN post p ON p.uri = s.uri
+               UNION ALL
+                 SELECT a.seed_uri, p.uri, p.\"replyParent\", a.height + 1
+                 FROM ancestor a JOIN post p ON p.uri = a.parent
+                 WHERE a.height < 4
+             )
+             INSERT INTO notification (did, author, \"recordUri\", \"recordCid\", reason, \"reasonSubject\", \"sortAt\")
+             SELECT split_part(a.uri, '/', 3), s.did, s.uri, s.cid, 'reply', a.uri, s.sort_at
+             FROM ancestor a
+             JOIN seeds s ON s.uri = a.seed_uri
+             WHERE a.height >= 1 AND split_part(a.uri, '/', 3) <> s.did
+             ORDER BY 1, 3
+             ON CONFLICT (did, \"recordUri\", reason) DO NOTHING",
+            &[&dids, &uris, &cids, &sort_ats],
+        )
+        .await?;
+
+    client
+        .execute(
+            "WITH RECURSIVE seeds AS (
+                 SELECT * FROM unnest($1::text[], $2::text[]) AS s(did, uri)
+             ),
+             ancestor(seed_uri, uri, parent, height) AS (
+                 SELECT s.uri, p.uri, p.\"replyParent\", 0
+                 FROM seeds s JOIN post p ON p.uri = s.uri
+               UNION ALL
+                 SELECT a.seed_uri, p.uri, p.\"replyParent\", a.height + 1
+                 FROM ancestor a JOIN post p ON p.uri = a.parent
+                 WHERE a.height < 4
+             ),
+             descendent(seed_uri, uri, depth) AS (
+                 SELECT s.uri, p.uri, 1
+                 FROM seeds s JOIN post p ON p.\"replyParent\" = s.uri
+               UNION ALL
+                 SELECT d.seed_uri, p.uri, d.depth + 1
+                 FROM descendent d JOIN post p ON p.\"replyParent\" = d.uri
+                 WHERE d.depth < 4
+             )
+             INSERT INTO notification (did, author, \"recordUri\", \"recordCid\", reason, \"reasonSubject\", \"sortAt\")
+             SELECT DISTINCT split_part(a.uri, '/', 3), dp.creator, dp.uri, dp.cid, 'reply', a.uri, dp.\"sortAt\"
+             FROM descendent d
+             JOIN post dp ON dp.uri = d.uri
+             JOIN ancestor a ON a.seed_uri = d.seed_uri
+             WHERE d.depth + a.height < 5
+               AND split_part(a.uri, '/', 3) <> dp.creator
+             ORDER BY 1, 3
+             ON CONFLICT (did, \"recordUri\", reason) DO NOTHING",
+            &[&dids, &uris],
+        )
+        .await?;
+
+    Ok(())
+}
+
 /// Bulk insert records using `COPY` protocol.
 /// Returns vector of booleans indicating which records were applied (not stale).
 pub async fn copy_insert_records(

--- a/rsky-wintermute/src/indexer/bulk.rs
+++ b/rsky-wintermute/src/indexer/bulk.rs
@@ -293,7 +293,7 @@ pub async fn copy_insert_records(
     // Phase 1: Table setup
     let setup_start = Instant::now();
     client
-        .execute(
+        .batch_execute(
             "CREATE TEMP TABLE IF NOT EXISTS _bulk_record (
                 uri text NOT NULL,
                 cid text NOT NULL,
@@ -301,13 +301,10 @@ pub async fn copy_insert_records(
                 json text,
                 rev text NOT NULL,
                 indexed_at text NOT NULL
-            )",
-            &[],
+            );
+            TRUNCATE _bulk_record",
         )
         .await?;
-
-    // Truncate in case of reuse
-    client.execute("TRUNCATE _bulk_record", &[]).await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     // Phase 2: COPY data into temp table
@@ -405,15 +402,13 @@ pub async fn copy_ensure_actors(
     // Phase 1: Table setup
     let setup_start = Instant::now();
     client
-        .execute(
+        .batch_execute(
             "CREATE TEMP TABLE IF NOT EXISTS _bulk_actor (
                 did text NOT NULL
-            )",
-            &[],
+            );
+            TRUNCATE _bulk_actor",
         )
         .await?;
-
-    client.execute("TRUNCATE _bulk_actor", &[]).await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     // Phase 2: COPY dids
@@ -482,7 +477,7 @@ pub async fn copy_insert_posts(
     // Phase 1: Table setup
     let setup_start = Instant::now();
     client
-        .execute(
+        .batch_execute(
             "CREATE TEMP TABLE IF NOT EXISTS _bulk_post (
                 uri text NOT NULL,
                 cid text NOT NULL,
@@ -496,12 +491,10 @@ pub async fn copy_insert_posts(
                 indexed_at text NOT NULL,
                 langs text[],
                 tags text[]
-            )",
-            &[],
+            );
+            TRUNCATE _bulk_post",
         )
         .await?;
-
-    client.execute("TRUNCATE _bulk_post", &[]).await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     // Phase 2: COPY data. text is NOT NULL so empty string is preserved; reply_*/langs/tags
@@ -619,7 +612,7 @@ pub async fn copy_insert_feed_items(
     // Phase 1: Table setup
     let setup_start = Instant::now();
     client
-        .execute(
+        .batch_execute(
             "CREATE TEMP TABLE IF NOT EXISTS _bulk_feed_item (
                 type text NOT NULL,
                 uri text NOT NULL,
@@ -627,12 +620,10 @@ pub async fn copy_insert_feed_items(
                 post_uri text NOT NULL,
                 originator_did text NOT NULL,
                 sort_at text NOT NULL
-            )",
-            &[],
+            );
+            TRUNCATE _bulk_feed_item",
         )
         .await?;
-
-    client.execute("TRUNCATE _bulk_feed_item", &[]).await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     // Phase 2: COPY data
@@ -709,7 +700,7 @@ pub async fn copy_insert_likes(
     // Phase 1: Table setup
     let setup_start = Instant::now();
     client
-        .execute(
+        .batch_execute(
             "CREATE TEMP TABLE IF NOT EXISTS _bulk_like (
                 uri text NOT NULL,
                 cid text NOT NULL,
@@ -718,12 +709,10 @@ pub async fn copy_insert_likes(
                 subject_cid text NOT NULL,
                 created_at text NOT NULL,
                 indexed_at text NOT NULL
-            )",
-            &[],
+            );
+            TRUNCATE _bulk_like",
         )
         .await?;
-
-    client.execute("TRUNCATE _bulk_like", &[]).await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     // Phase 2: COPY data
@@ -816,7 +805,7 @@ pub async fn copy_insert_follows(
     // Phase 1: Table setup
     let setup_start = Instant::now();
     client
-        .execute(
+        .batch_execute(
             "CREATE TEMP TABLE IF NOT EXISTS _bulk_follow (
                 uri text NOT NULL,
                 cid text NOT NULL,
@@ -824,12 +813,10 @@ pub async fn copy_insert_follows(
                 subject_did text NOT NULL,
                 created_at text NOT NULL,
                 indexed_at text NOT NULL
-            )",
-            &[],
+            );
+            TRUNCATE _bulk_follow",
         )
         .await?;
-
-    client.execute("TRUNCATE _bulk_follow", &[]).await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     // Phase 2: COPY data
@@ -948,7 +935,7 @@ pub async fn copy_insert_reposts(
     // Phase 1: Table setup
     let setup_start = Instant::now();
     client
-        .execute(
+        .batch_execute(
             "CREATE TEMP TABLE IF NOT EXISTS _bulk_repost (
                 uri text NOT NULL,
                 cid text NOT NULL,
@@ -957,12 +944,10 @@ pub async fn copy_insert_reposts(
                 subject_cid text NOT NULL,
                 created_at text NOT NULL,
                 indexed_at text NOT NULL
-            )",
-            &[],
+            );
+            TRUNCATE _bulk_repost",
         )
         .await?;
-
-    client.execute("TRUNCATE _bulk_repost", &[]).await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     // Phase 2: COPY data
@@ -1054,7 +1039,7 @@ pub async fn copy_insert_quotes(
 
     let setup_start = Instant::now();
     client
-        .execute(
+        .batch_execute(
             "CREATE TEMP TABLE IF NOT EXISTS _bulk_quote (
                 uri text NOT NULL,
                 cid text NOT NULL,
@@ -1062,12 +1047,10 @@ pub async fn copy_insert_quotes(
                 subject_cid text NOT NULL,
                 created_at text NOT NULL,
                 indexed_at text NOT NULL
-            )",
-            &[],
+            );
+            TRUNCATE _bulk_quote",
         )
         .await?;
-
-    client.execute("TRUNCATE _bulk_quote", &[]).await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     let copy_start = Instant::now();
@@ -1153,7 +1136,7 @@ pub async fn copy_insert_blocks(
     // Phase 1: Table setup
     let setup_start = Instant::now();
     client
-        .execute(
+        .batch_execute(
             "CREATE TEMP TABLE IF NOT EXISTS _bulk_block (
                 uri text NOT NULL,
                 cid text NOT NULL,
@@ -1161,12 +1144,10 @@ pub async fn copy_insert_blocks(
                 subject text NOT NULL,
                 created_at text NOT NULL,
                 indexed_at text NOT NULL
-            )",
-            &[],
+            );
+            TRUNCATE _bulk_block",
         )
         .await?;
-
-    client.execute("TRUNCATE _bulk_block", &[]).await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     // Phase 2: COPY data
@@ -1242,19 +1223,15 @@ pub async fn copy_insert_post_embed_images(
     // Phase 1: Table setup
     let setup_start = Instant::now();
     client
-        .execute(
+        .batch_execute(
             "CREATE TEMP TABLE IF NOT EXISTS _bulk_post_embed_image (
                 post_uri text NOT NULL,
                 position text NOT NULL,
                 image_cid text NOT NULL,
                 alt text NOT NULL
-            )",
-            &[],
+            );
+            TRUNCATE _bulk_post_embed_image",
         )
-        .await?;
-
-    client
-        .execute("TRUNCATE _bulk_post_embed_image", &[])
         .await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
@@ -1326,18 +1303,14 @@ pub async fn copy_insert_post_embed_videos(
     // Phase 1: Table setup
     let setup_start = Instant::now();
     client
-        .execute(
+        .batch_execute(
             "CREATE TEMP TABLE IF NOT EXISTS _bulk_post_embed_video (
                 post_uri text NOT NULL,
                 video_cid text NOT NULL,
                 alt text
-            )",
-            &[],
+            );
+            TRUNCATE _bulk_post_embed_video",
         )
-        .await?;
-
-    client
-        .execute("TRUNCATE _bulk_post_embed_video", &[])
         .await?;
     let setup_ms = setup_start.elapsed().as_millis();
 

--- a/rsky-wintermute/src/indexer/bulk.rs
+++ b/rsky-wintermute/src/indexer/bulk.rs
@@ -99,6 +99,12 @@ pub async fn copy_insert_notifications(
     if rows.is_empty() {
         return Ok(());
     }
+    // Sorted by conflict key so concurrent notification writers acquire
+    // unique-index locks in one global order.
+    let mut ordered: Vec<&NotificationRow> = rows.iter().collect();
+    ordered.sort_unstable_by(|a, b| {
+        (&a.did, &a.record_uri, a.reason).cmp(&(&b.did, &b.record_uri, b.reason))
+    });
     let mut dids = Vec::with_capacity(rows.len());
     let mut authors = Vec::with_capacity(rows.len());
     let mut uris = Vec::with_capacity(rows.len());
@@ -106,7 +112,7 @@ pub async fn copy_insert_notifications(
     let mut reasons = Vec::with_capacity(rows.len());
     let mut subjects: Vec<Option<&str>> = Vec::with_capacity(rows.len());
     let mut sort_ats = Vec::with_capacity(rows.len());
-    for row in rows {
+    for row in ordered {
         dids.push(row.did.as_str());
         authors.push(row.author.as_str());
         uris.push(row.record_uri.as_str());
@@ -126,6 +132,14 @@ pub async fn copy_insert_notifications(
     Ok(())
 }
 
+/// Sort delta keys so every concurrent aggregate upsert visits rows in one
+/// global order; unordered multi-row upserts on shared rows deadlock.
+pub fn sorted_deltas(counts: std::collections::HashMap<String, i64>) -> (Vec<String>, Vec<i64>) {
+    let mut pairs: Vec<(String, i64)> = counts.into_iter().collect();
+    pairs.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    pairs.into_iter().unzip()
+}
+
 /// Increment a `post_agg` count column by exact per-uri deltas.
 async fn increment_post_agg(
     client: &deadpool_postgres::Client,
@@ -135,7 +149,7 @@ async fn increment_post_agg(
     if counts.is_empty() {
         return Ok(());
     }
-    let (uris, deltas): (Vec<String>, Vec<i64>) = counts.into_iter().unzip();
+    let (uris, deltas) = sorted_deltas(counts);
     client
         .execute(
             &format!(
@@ -145,6 +159,63 @@ async fn increment_post_agg(
                    SET \"{column}\" = COALESCE(post_agg.\"{column}\", 0) + EXCLUDED.\"{column}\""
             ),
             &[&uris, &deltas],
+        )
+        .await?;
+    Ok(())
+}
+
+/// Decrement a `post_agg` count column by exact per-uri deltas, floored at 0.
+/// Rows are locked in sorted uri order first so concurrent aggregate writers
+/// cannot deadlock; absent rows hydrate as 0 and need no decrement.
+pub async fn decrement_post_agg(
+    client: &deadpool_postgres::Client,
+    column: &str,
+    counts: std::collections::HashMap<String, i64>,
+) -> Result<(), WintermuteError> {
+    if counts.is_empty() {
+        return Ok(());
+    }
+    let (uris, deltas) = sorted_deltas(counts);
+    client
+        .execute(
+            &format!(
+                "WITH locked AS (
+                     SELECT uri FROM post_agg WHERE uri = ANY($1) ORDER BY uri FOR UPDATE
+                 )
+                 UPDATE post_agg p
+                 SET \"{column}\" = GREATEST(COALESCE(p.\"{column}\", 0) - d.c, 0)
+                 FROM unnest($1::text[], $2::int8[]) AS d(u, c)
+                 WHERE p.uri = d.u AND p.uri IN (SELECT uri FROM locked)"
+            ),
+            &[&uris, &deltas],
+        )
+        .await?;
+    Ok(())
+}
+
+/// Decrement a `profile_agg` count column by exact per-did deltas, floored at
+/// 0, with the same sorted lock acquisition as [`decrement_post_agg`].
+pub async fn decrement_profile_agg(
+    client: &deadpool_postgres::Client,
+    column: &str,
+    counts: std::collections::HashMap<String, i64>,
+) -> Result<(), WintermuteError> {
+    if counts.is_empty() {
+        return Ok(());
+    }
+    let (dids, deltas) = sorted_deltas(counts);
+    client
+        .execute(
+            &format!(
+                "WITH locked AS (
+                     SELECT did FROM profile_agg WHERE did = ANY($1) ORDER BY did FOR UPDATE
+                 )
+                 UPDATE profile_agg p
+                 SET \"{column}\" = GREATEST(COALESCE(p.\"{column}\", 0) - d.c, 0)
+                 FROM unnest($1::text[], $2::int8[]) AS d(u, c)
+                 WHERE p.did = d.u AND p.did IN (SELECT did FROM locked)"
+            ),
+            &[&dids, &deltas],
         )
         .await?;
     Ok(())
@@ -445,7 +516,7 @@ pub async fn copy_insert_posts(
             }
         }
         if compute_agg {
-            let (dids, deltas): (Vec<String>, Vec<i64>) = counts.into_iter().unzip();
+            let (dids, deltas) = sorted_deltas(counts);
             client
                 .execute(
                     "INSERT INTO profile_agg (did, \"postsCount\")
@@ -765,7 +836,7 @@ pub async fn copy_insert_follows(
             *follows.entry(row.get::<_, String>(1)).or_insert(0) += 1;
             *followers.entry(row.get::<_, String>(2)).or_insert(0) += 1;
         }
-        let (f_dids, f_deltas): (Vec<String>, Vec<i64>) = follows.into_iter().unzip();
+        let (f_dids, f_deltas) = sorted_deltas(follows);
         client
             .execute(
                 "INSERT INTO profile_agg (did, \"followsCount\")
@@ -775,7 +846,7 @@ pub async fn copy_insert_follows(
                 &[&f_dids, &f_deltas],
             )
             .await?;
-        let (s_dids, s_deltas): (Vec<String>, Vec<i64>) = followers.into_iter().unzip();
+        let (s_dids, s_deltas) = sorted_deltas(followers);
         client
             .execute(
                 "INSERT INTO profile_agg (did, \"followersCount\")

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -1625,26 +1625,21 @@ impl IndexerManager {
             let group_result: Result<(), WintermuteError> = async {
                 match collection {
                     "app.bsky.feed.like" => {
-                        let subjects: Vec<String> = client
+                        let mut subjects: std::collections::HashMap<String, i64> =
+                            std::collections::HashMap::new();
+                        for r in client
                             .query(
                                 "DELETE FROM \"like\" WHERE uri = ANY($1) RETURNING subject",
                                 &[&group_uris],
                             )
                             .await?
-                            .iter()
-                            .filter_map(|r| r.get::<_, Option<String>>(0))
-                            .collect();
-                        if !bulk_load && !subjects.is_empty() {
-                            client
-                                .execute(
-                                    "UPDATE post_agg p
-                                     SET \"likeCount\" = GREATEST(p.\"likeCount\" - d.c, 0)
-                                     FROM (SELECT uri, count(*)::int8 AS c
-                                           FROM unnest($1::text[]) AS u(uri) GROUP BY uri) d
-                                     WHERE p.uri = d.uri",
-                                    &[&subjects],
-                                )
-                                .await?;
+                        {
+                            if let Some(subject) = r.get::<_, Option<String>>(0) {
+                                *subjects.entry(subject).or_insert(0) += 1;
+                            }
+                        }
+                        if !bulk_load {
+                            bulk::decrement_post_agg(&client, "likeCount", subjects).await?;
                         }
                     }
                     "app.bsky.graph.block" => {
@@ -1656,29 +1651,24 @@ impl IndexerManager {
                             .await?;
                     }
                     "app.bsky.feed.repost" => {
-                        let subjects: Vec<String> = client
+                        let mut subjects: std::collections::HashMap<String, i64> =
+                            std::collections::HashMap::new();
+                        for r in client
                             .query(
                                 "DELETE FROM repost WHERE uri = ANY($1) RETURNING subject",
                                 &[&group_uris],
                             )
                             .await?
-                            .iter()
-                            .filter_map(|r| r.get::<_, Option<String>>(0))
-                            .collect();
+                        {
+                            if let Some(subject) = r.get::<_, Option<String>>(0) {
+                                *subjects.entry(subject).or_insert(0) += 1;
+                            }
+                        }
                         client
                             .execute("DELETE FROM feed_item WHERE uri = ANY($1)", &[&group_uris])
                             .await?;
-                        if !bulk_load && !subjects.is_empty() {
-                            client
-                                .execute(
-                                    "UPDATE post_agg p
-                                     SET \"repostCount\" = GREATEST(p.\"repostCount\" - d.c, 0)
-                                     FROM (SELECT uri, count(*)::int8 AS c
-                                           FROM unnest($1::text[]) AS u(uri) GROUP BY uri) d
-                                     WHERE p.uri = d.uri",
-                                    &[&subjects],
-                                )
-                                .await?;
+                        if !bulk_load {
+                            bulk::decrement_post_agg(&client, "repostCount", subjects).await?;
                         }
                     }
                     "app.bsky.feed.post" => {
@@ -1688,42 +1678,24 @@ impl IndexerManager {
                                 &[&group_uris],
                             )
                             .await?;
-                        let mut creators: Vec<String> = Vec::with_capacity(deleted.len());
-                        let mut parents: Vec<String> = Vec::new();
+                        let mut creators: std::collections::HashMap<String, i64> =
+                            std::collections::HashMap::new();
+                        let mut parents: std::collections::HashMap<String, i64> =
+                            std::collections::HashMap::new();
                         for r in &deleted {
                             if let Some(creator) = r.get::<_, Option<String>>(0) {
-                                creators.push(creator);
+                                *creators.entry(creator).or_insert(0) += 1;
                             }
                             if let Some(parent) = r.get::<_, Option<String>>(1) {
-                                parents.push(parent);
+                                *parents.entry(parent).or_insert(0) += 1;
                             }
                         }
                         client
                             .execute("DELETE FROM feed_item WHERE uri = ANY($1)", &[&group_uris])
                             .await?;
-                        if !bulk_load && !creators.is_empty() {
-                            client
-                                .execute(
-                                    "UPDATE profile_agg p
-                                     SET \"postsCount\" = GREATEST(p.\"postsCount\" - d.c, 0)
-                                     FROM (SELECT did, count(*)::int AS c
-                                           FROM unnest($1::text[]) AS u(did) GROUP BY did) d
-                                     WHERE p.did = d.did",
-                                    &[&creators],
-                                )
-                                .await?;
-                        }
-                        if !bulk_load && !parents.is_empty() {
-                            client
-                                .execute(
-                                    "UPDATE post_agg p
-                                     SET \"replyCount\" = GREATEST(p.\"replyCount\" - d.c, 0)
-                                     FROM (SELECT uri, count(*)::int8 AS c
-                                           FROM unnest($1::text[]) AS u(uri) GROUP BY uri) d
-                                     WHERE p.uri = d.uri",
-                                    &[&parents],
-                                )
-                                .await?;
+                        if !bulk_load {
+                            bulk::decrement_profile_agg(&client, "postsCount", creators).await?;
+                            bulk::decrement_post_agg(&client, "replyCount", parents).await?;
                         }
                     }
                     "app.bsky.graph.follow" => {
@@ -1738,29 +1710,16 @@ impl IndexerManager {
                             .map(|r| (r.get(0), r.get(1)))
                             .collect();
                         if !bulk_load && !pairs.is_empty() {
-                            let creators: Vec<String> =
-                                pairs.iter().map(|(c, _)| c.clone()).collect();
-                            let subjects: Vec<String> =
-                                pairs.iter().map(|(_, s)| s.clone()).collect();
-                            client
-                                .execute(
-                                    "UPDATE profile_agg p
-                                     SET \"followsCount\" = GREATEST(p.\"followsCount\" - d.c, 0)
-                                     FROM (SELECT did, count(*)::int AS c
-                                           FROM unnest($1::text[]) AS u(did) GROUP BY did) d
-                                     WHERE p.did = d.did",
-                                    &[&creators],
-                                )
-                                .await?;
-                            client
-                                .execute(
-                                    "UPDATE profile_agg p
-                                     SET \"followersCount\" = GREATEST(p.\"followersCount\" - d.c, 0)
-                                     FROM (SELECT did, count(*)::int AS c
-                                           FROM unnest($1::text[]) AS u(did) GROUP BY did) d
-                                     WHERE p.did = d.did",
-                                    &[&subjects],
-                                )
+                            let mut creators: std::collections::HashMap<String, i64> =
+                                std::collections::HashMap::new();
+                            let mut subjects: std::collections::HashMap<String, i64> =
+                                std::collections::HashMap::new();
+                            for (c, s) in &pairs {
+                                *creators.entry(c.clone()).or_insert(0) += 1;
+                                *subjects.entry(s.clone()).or_insert(0) += 1;
+                            }
+                            bulk::decrement_profile_agg(&client, "followsCount", creators).await?;
+                            bulk::decrement_profile_agg(&client, "followersCount", subjects)
                                 .await?;
                         }
                     }

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -1426,11 +1426,45 @@ impl IndexerManager {
         let mut results: Vec<(Vec<u8>, Result<(), WintermuteError>)> =
             Vec::with_capacity(jobs.len());
 
-        // Separate creates/updates from deletes
+        // The batch phases run all creates before all deletes, which reorders a
+        // user's rapid create/delete/create sequences within one drain batch
+        // (e.g. like, unlike, re-like: the re-like collides with the not-yet
+        // deleted first like and is silently dropped). Any (did, collection)
+        // pair with both creates and deletes in this batch is processed
+        // per-record in queue order instead.
+        let mut create_pairs: std::collections::HashSet<(String, String)> =
+            std::collections::HashSet::new();
+        let mut delete_pairs: std::collections::HashSet<(String, String)> =
+            std::collections::HashSet::new();
+        for (_, job) in jobs {
+            if let Ok(uri) = AtUri::new(job.uri.clone(), None) {
+                let pair = (uri.get_hostname().clone(), uri.get_collection());
+                match job.action {
+                    WriteAction::Create | WriteAction::Update => {
+                        create_pairs.insert(pair);
+                    }
+                    WriteAction::Delete => {
+                        delete_pairs.insert(pair);
+                    }
+                }
+            }
+        }
+        let conflicted: std::collections::HashSet<(String, String)> =
+            create_pairs.intersection(&delete_pairs).cloned().collect();
+
+        // Separate creates/updates from deletes; conflicted pairs go sequential
         let mut creates: Vec<&(Vec<u8>, IndexJob)> = Vec::new();
         let mut deletes: Vec<&(Vec<u8>, IndexJob)> = Vec::new();
+        let mut sequential: Vec<&(Vec<u8>, IndexJob)> = Vec::new();
 
         for job_tuple in jobs {
+            let is_conflicted = AtUri::new(job_tuple.1.uri.clone(), None)
+                .map(|uri| conflicted.contains(&(uri.get_hostname().clone(), uri.get_collection())))
+                .unwrap_or(false);
+            if is_conflicted && !bulk_load {
+                sequential.push(job_tuple);
+                continue;
+            }
             match job_tuple.1.action {
                 WriteAction::Create | WriteAction::Update => creates.push(job_tuple),
                 WriteAction::Delete => deletes.push(job_tuple),
@@ -1448,6 +1482,14 @@ impl IndexerManager {
             let (delete_results, bf) = Self::batch_delete_records(pool, &deletes, bulk_load).await;
             batch_failed |= bf;
             results.extend(delete_results);
+        }
+
+        for (key, job) in sequential {
+            let result = Self::process_job(pool, job).await;
+            if result.is_err() {
+                batch_failed = true;
+            }
+            results.push((key.clone(), result));
         }
 
         (results, batch_failed)
@@ -1570,9 +1612,27 @@ impl IndexerManager {
             let group_result: Result<(), WintermuteError> = async {
                 match collection {
                     "app.bsky.feed.like" => {
-                        client
-                            .execute("DELETE FROM \"like\" WHERE uri = ANY($1)", &[&group_uris])
-                            .await?;
+                        let subjects: Vec<String> = client
+                            .query(
+                                "DELETE FROM \"like\" WHERE uri = ANY($1) RETURNING subject",
+                                &[&group_uris],
+                            )
+                            .await?
+                            .iter()
+                            .filter_map(|r| r.get::<_, Option<String>>(0))
+                            .collect();
+                        if !bulk_load && !subjects.is_empty() {
+                            client
+                                .execute(
+                                    "UPDATE post_agg p
+                                     SET \"likeCount\" = GREATEST(p.\"likeCount\" - d.c, 0)
+                                     FROM (SELECT uri, count(*)::int8 AS c
+                                           FROM unnest($1::text[]) AS u(uri) GROUP BY uri) d
+                                     WHERE p.uri = d.uri",
+                                    &[&subjects],
+                                )
+                                .await?;
+                        }
                     }
                     "app.bsky.graph.block" => {
                         client
@@ -1583,23 +1643,48 @@ impl IndexerManager {
                             .await?;
                     }
                     "app.bsky.feed.repost" => {
-                        client
-                            .execute("DELETE FROM repost WHERE uri = ANY($1)", &[&group_uris])
-                            .await?;
-                        client
-                            .execute("DELETE FROM feed_item WHERE uri = ANY($1)", &[&group_uris])
-                            .await?;
-                    }
-                    "app.bsky.feed.post" => {
-                        let creators: Vec<String> = client
+                        let subjects: Vec<String> = client
                             .query(
-                                "DELETE FROM post WHERE uri = ANY($1) RETURNING creator",
+                                "DELETE FROM repost WHERE uri = ANY($1) RETURNING subject",
                                 &[&group_uris],
                             )
                             .await?
                             .iter()
                             .filter_map(|r| r.get::<_, Option<String>>(0))
                             .collect();
+                        client
+                            .execute("DELETE FROM feed_item WHERE uri = ANY($1)", &[&group_uris])
+                            .await?;
+                        if !bulk_load && !subjects.is_empty() {
+                            client
+                                .execute(
+                                    "UPDATE post_agg p
+                                     SET \"repostCount\" = GREATEST(p.\"repostCount\" - d.c, 0)
+                                     FROM (SELECT uri, count(*)::int8 AS c
+                                           FROM unnest($1::text[]) AS u(uri) GROUP BY uri) d
+                                     WHERE p.uri = d.uri",
+                                    &[&subjects],
+                                )
+                                .await?;
+                        }
+                    }
+                    "app.bsky.feed.post" => {
+                        let deleted = client
+                            .query(
+                                "DELETE FROM post WHERE uri = ANY($1) RETURNING creator, \"replyParent\"",
+                                &[&group_uris],
+                            )
+                            .await?;
+                        let mut creators: Vec<String> = Vec::with_capacity(deleted.len());
+                        let mut parents: Vec<String> = Vec::new();
+                        for r in &deleted {
+                            if let Some(creator) = r.get::<_, Option<String>>(0) {
+                                creators.push(creator);
+                            }
+                            if let Some(parent) = r.get::<_, Option<String>>(1) {
+                                parents.push(parent);
+                            }
+                        }
                         client
                             .execute("DELETE FROM feed_item WHERE uri = ANY($1)", &[&group_uris])
                             .await?;
@@ -1612,6 +1697,18 @@ impl IndexerManager {
                                            FROM unnest($1::text[]) AS u(did) GROUP BY did) d
                                      WHERE p.did = d.did",
                                     &[&creators],
+                                )
+                                .await?;
+                        }
+                        if !bulk_load && !parents.is_empty() {
+                            client
+                                .execute(
+                                    "UPDATE post_agg p
+                                     SET \"replyCount\" = GREATEST(p.\"replyCount\" - d.c, 0)
+                                     FROM (SELECT uri, count(*)::int8 AS c
+                                           FROM unnest($1::text[]) AS u(uri) GROUP BY uri) d
+                                     WHERE p.uri = d.uri",
+                                    &[&parents],
                                 )
                                 .await?;
                         }
@@ -2594,7 +2691,7 @@ impl IndexerManager {
             Ok(c) => c,
             Err(e) => return (0, count, Some(WintermuteError::Pool(e))),
         };
-        let err = Self::copy_batch_insert_posts(&client, jobs, !bulk_load)
+        let err = Self::copy_batch_insert_posts(pool, &client, jobs, !bulk_load)
             .await
             .err();
         (start.elapsed().as_millis(), count, err)
@@ -2706,6 +2803,7 @@ impl IndexerManager {
     // COPY-based batch insert wrappers that extract data and call bulk functions
 
     async fn copy_batch_insert_posts(
+        pool: &Pool,
         client: &deadpool_postgres::Client,
         jobs: &[&ParsedJob<'_>],
         compute_agg: bool,
@@ -2884,8 +2982,17 @@ impl IndexerManager {
         // and the (did, recordUri, reason) dedupe keeps replays exact.
         if compute_agg {
             bulk::copy_insert_notifications(client, &notif_rows).await?;
-            for (did, uri, cid, sort_at) in &reply_posts {
-                Self::write_reply_notifications(client, did, uri, cid, sort_at).await?;
+            // The per-reply ancestor walk is two queries per reply; run a few
+            // concurrently on their own pooled connections or it dominates the
+            // post worker's cycle and caps drain throughput.
+            for chunk in reply_posts.chunks(3) {
+                let walks = chunk.iter().map(|(did, uri, cid, sort_at)| async move {
+                    let conn = pool.get().await.map_err(WintermuteError::Pool)?;
+                    Self::write_reply_notifications(&conn, did, uri, cid, sort_at).await
+                });
+                for result in futures::future::join_all(walks).await {
+                    result?;
+                }
             }
         }
 

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -3198,8 +3198,7 @@ impl IndexerManager {
             return Ok(());
         }
 
-        let mut like_data: Vec<(String, String, String, String, String, String, String)> =
-            Vec::with_capacity(jobs.len());
+        let mut like_data: Vec<bulk::SubjectRecordRow> = Vec::with_capacity(jobs.len());
         let mut notif_rows: Vec<bulk::NotificationRow> = Vec::new();
 
         for pj in jobs {
@@ -3218,6 +3217,7 @@ impl IndexerManager {
                     .get("createdAt")
                     .and_then(|v| v.as_str())
                     .unwrap_or(&pj.job.indexed_at);
+                let (via, via_cid) = Self::extract_via(record);
 
                 Self::collect_subject_notifications(
                     &mut notif_rows,
@@ -3231,15 +3231,17 @@ impl IndexerManager {
                     "like-via-repost",
                 );
 
-                like_data.push((
+                like_data.push(bulk::SubjectRecordRow {
                     uri,
-                    pj.job.cid.clone(),
-                    pj.did.clone(),
-                    subject_uri.to_owned(),
-                    subject_cid.to_owned(),
-                    created_at.to_owned(),
-                    pj.job.indexed_at.clone(),
-                ));
+                    cid: pj.job.cid.clone(),
+                    creator: pj.did.clone(),
+                    subject: subject_uri.to_owned(),
+                    subject_cid: subject_cid.to_owned(),
+                    created_at: created_at.to_owned(),
+                    indexed_at: pj.job.indexed_at.clone(),
+                    via,
+                    via_cid,
+                });
 
                 metrics::INDEXER_LIKE_EVENTS_TOTAL.inc();
             }
@@ -3266,6 +3268,19 @@ impl IndexerManager {
         }
         let conn = pool.get().await.map_err(WintermuteError::Pool)?;
         bulk::copy_insert_notifications(&conn, notif_rows).await
+    }
+
+    /// Extract via attribution `{uri, cid}` from a like/repost/follow record.
+    fn extract_via(record: &serde_json::Value) -> (Option<String>, Option<String>) {
+        let via = record.get("via");
+        (
+            via.and_then(|v| v.get("uri"))
+                .and_then(|v| v.as_str())
+                .map(str::to_owned),
+            via.and_then(|v| v.get("cid"))
+                .and_then(|v| v.as_str())
+                .map(str::to_owned),
+        )
     }
 
     /// Collect subject + via notifications for a like or repost record,
@@ -3334,8 +3349,7 @@ impl IndexerManager {
             return Ok(());
         }
 
-        let mut follow_data: Vec<(String, String, String, String, String, String)> =
-            Vec::with_capacity(jobs.len());
+        let mut follow_data: Vec<bulk::FollowCopyRow> = Vec::with_capacity(jobs.len());
         let mut notif_rows: Vec<bulk::NotificationRow> = Vec::new();
 
         for pj in jobs {
@@ -3346,6 +3360,7 @@ impl IndexerManager {
                     .get("createdAt")
                     .and_then(|v| v.as_str())
                     .unwrap_or(&pj.job.indexed_at);
+                let (via, via_cid) = Self::extract_via(record);
 
                 if !subject.is_empty() {
                     notif_rows.push(bulk::NotificationRow {
@@ -3359,14 +3374,16 @@ impl IndexerManager {
                     });
                 }
 
-                follow_data.push((
+                follow_data.push(bulk::FollowCopyRow {
                     uri,
-                    pj.job.cid.clone(),
-                    pj.did.clone(),
-                    subject.to_owned(),
-                    created_at.to_owned(),
-                    pj.job.indexed_at.clone(),
-                ));
+                    cid: pj.job.cid.clone(),
+                    creator: pj.did.clone(),
+                    subject_did: subject.to_owned(),
+                    created_at: created_at.to_owned(),
+                    indexed_at: pj.job.indexed_at.clone(),
+                    via,
+                    via_cid,
+                });
 
                 metrics::INDEXER_FOLLOW_EVENTS_TOTAL.inc();
             }
@@ -3392,8 +3409,7 @@ impl IndexerManager {
             return Ok(());
         }
 
-        let mut repost_data: Vec<(String, String, String, String, String, String, String)> =
-            Vec::with_capacity(jobs.len());
+        let mut repost_data: Vec<bulk::SubjectRecordRow> = Vec::with_capacity(jobs.len());
         let mut feed_item_data: Vec<(String, String, String, String, String, String)> =
             Vec::with_capacity(jobs.len());
         let mut notif_rows: Vec<bulk::NotificationRow> = Vec::new();
@@ -3420,6 +3436,7 @@ impl IndexerManager {
                 } else {
                     created_at.clone()
                 };
+                let (via, via_cid) = Self::extract_via(record);
 
                 Self::collect_subject_notifications(
                     &mut notif_rows,
@@ -3433,15 +3450,17 @@ impl IndexerManager {
                     "repost-via-repost",
                 );
 
-                repost_data.push((
-                    uri.clone(),
-                    pj.job.cid.clone(),
-                    pj.did.clone(),
-                    subject_uri.to_owned(),
-                    subject_cid.to_owned(),
+                repost_data.push(bulk::SubjectRecordRow {
+                    uri: uri.clone(),
+                    cid: pj.job.cid.clone(),
+                    creator: pj.did.clone(),
+                    subject: subject_uri.to_owned(),
+                    subject_cid: subject_cid.to_owned(),
                     created_at,
-                    pj.job.indexed_at.clone(),
-                ));
+                    indexed_at: pj.job.indexed_at.clone(),
+                    via,
+                    via_cid,
+                });
 
                 feed_item_data.push((
                     "repost".to_owned(),
@@ -4290,6 +4309,7 @@ impl IndexerManager {
             .get("createdAt")
             .and_then(|v| v.as_str())
             .unwrap_or(indexed_at);
+        let (via, via_cid) = Self::extract_via(record);
 
         // Ensure the follow subject also has an actor row (cached)
         if !subject.is_empty() && !ACTOR_CACHE.contains_key(subject) {
@@ -4301,10 +4321,10 @@ impl IndexerManager {
 
         let row_count = client
             .execute(
-                "INSERT INTO follow (uri, cid, creator, \"subjectDid\", \"createdAt\", \"indexedAt\")
-                 VALUES ($1, $2, $3, $4, $5, $6)
+                "INSERT INTO follow (uri, cid, creator, \"subjectDid\", \"createdAt\", \"indexedAt\", via, \"viaCid\")
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
                  ON CONFLICT DO NOTHING",
-                &[&uri, &cid, &did, &subject, &created_at, &indexed_at],
+                &[&uri, &cid, &did, &subject, &created_at, &indexed_at, &via, &via_cid],
             )
             .await?;
 

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -1539,12 +1539,51 @@ impl IndexerManager {
             }
         }
 
-        for (key, job) in sequential {
-            let result = Box::pin(Self::process_job(pool, job)).await;
-            if result.is_err() {
-                batch_failed = true;
+        // Distinct conflicted uris are independent rows, so their groups run
+        // concurrently; jobs within one uri keep strict queue order.
+        if !sequential.is_empty() {
+            let prepass_start = std::time::Instant::now();
+            let mut uri_groups: Vec<Vec<&(Vec<u8>, IndexJob)>> = Vec::new();
+            let mut group_index: std::collections::HashMap<&str, usize> =
+                std::collections::HashMap::new();
+            for job_tuple in sequential {
+                let uri = job_tuple.1.uri.as_str();
+                if let Some(&idx) = group_index.get(uri) {
+                    uri_groups[idx].push(job_tuple);
+                } else {
+                    group_index.insert(uri, uri_groups.len());
+                    uri_groups.push(vec![job_tuple]);
+                }
             }
-            results.push((key.clone(), result));
+            let group_count = uri_groups.len();
+            let group_futures: Vec<_> = uri_groups
+                .into_iter()
+                .map(|group| {
+                    Box::pin(async move {
+                        let mut out = Vec::with_capacity(group.len());
+                        for (key, job) in group {
+                            out.push((key.clone(), Box::pin(Self::process_job(pool, job)).await));
+                        }
+                        out
+                    })
+                })
+                .collect();
+            let group_results: Vec<_> = futures::stream::iter(group_futures)
+                .buffer_unordered(4)
+                .collect()
+                .await;
+            for group in group_results {
+                for (key, result) in group {
+                    if result.is_err() {
+                        batch_failed = true;
+                    }
+                    results.push((key, result));
+                }
+            }
+            let prepass_ms = prepass_start.elapsed().as_millis();
+            if prepass_ms > 500 {
+                tracing::warn!("SLOW conflicted pre-pass: {prepass_ms}ms for {group_count} uris");
+            }
         }
 
         // Deletes run before creates: a user's unlike-then-relike spanning the

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -1426,42 +1426,30 @@ impl IndexerManager {
         let mut results: Vec<(Vec<u8>, Result<(), WintermuteError>)> =
             Vec::with_capacity(jobs.len());
 
-        // The batch phases run all creates before all deletes, which reorders a
-        // user's rapid create/delete/create sequences within one drain batch
-        // (e.g. like, unlike, re-like: the re-like collides with the not-yet
-        // deleted first like and is silently dropped). Any (did, collection)
-        // pair with both creates and deletes in this batch is processed
-        // per-record in queue order instead.
-        let mut create_pairs: std::collections::HashSet<(String, String)> =
-            std::collections::HashSet::new();
-        let mut delete_pairs: std::collections::HashSet<(String, String)> =
-            std::collections::HashSet::new();
+        // A record created AND deleted within one drain batch cannot be
+        // phase-split at all; those rare same-uri pairs process per-record in
+        // queue order first.
+        let mut create_uris: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        let mut delete_uris: std::collections::HashSet<&str> = std::collections::HashSet::new();
         for (_, job) in jobs {
-            if let Ok(uri) = AtUri::new(job.uri.clone(), None) {
-                let pair = (uri.get_hostname().clone(), uri.get_collection());
-                match job.action {
-                    WriteAction::Create | WriteAction::Update => {
-                        create_pairs.insert(pair);
-                    }
-                    WriteAction::Delete => {
-                        delete_pairs.insert(pair);
-                    }
+            match job.action {
+                WriteAction::Create | WriteAction::Update => {
+                    create_uris.insert(job.uri.as_str());
+                }
+                WriteAction::Delete => {
+                    delete_uris.insert(job.uri.as_str());
                 }
             }
         }
-        let conflicted: std::collections::HashSet<(String, String)> =
-            create_pairs.intersection(&delete_pairs).cloned().collect();
+        let conflicted: std::collections::HashSet<&str> =
+            create_uris.intersection(&delete_uris).copied().collect();
 
-        // Separate creates/updates from deletes; conflicted pairs go sequential
         let mut creates: Vec<&(Vec<u8>, IndexJob)> = Vec::new();
         let mut deletes: Vec<&(Vec<u8>, IndexJob)> = Vec::new();
         let mut sequential: Vec<&(Vec<u8>, IndexJob)> = Vec::new();
 
         for job_tuple in jobs {
-            let is_conflicted = AtUri::new(job_tuple.1.uri.clone(), None)
-                .map(|uri| conflicted.contains(&(uri.get_hostname().clone(), uri.get_collection())))
-                .unwrap_or(false);
-            if is_conflicted && !bulk_load {
+            if !bulk_load && conflicted.contains(job_tuple.1.uri.as_str()) {
                 sequential.push(job_tuple);
                 continue;
             }
@@ -1471,25 +1459,28 @@ impl IndexerManager {
             }
         }
 
-        // Process creates in batch (uses parallel COPY for different collection types)
-        if !creates.is_empty() {
-            let (batch_results, bf) = Self::batch_insert_records(pool, &creates, bulk_load).await;
-            batch_failed |= bf;
-            results.extend(batch_results);
-        }
-
-        if !deletes.is_empty() {
-            let (delete_results, bf) = Self::batch_delete_records(pool, &deletes, bulk_load).await;
-            batch_failed |= bf;
-            results.extend(delete_results);
-        }
-
         for (key, job) in sequential {
             let result = Self::process_job(pool, job).await;
             if result.is_err() {
                 batch_failed = true;
             }
             results.push((key.clone(), result));
+        }
+
+        // Deletes run before creates: a user's unlike-then-relike spanning the
+        // phase split must clear the old row first, or the new record is
+        // silently dropped on its (subject, creator)-style unique conflict.
+        if !deletes.is_empty() {
+            let (delete_results, bf) = Self::batch_delete_records(pool, &deletes, bulk_load).await;
+            batch_failed |= bf;
+            results.extend(delete_results);
+        }
+
+        // Process creates in batch (uses parallel COPY for different collection types)
+        if !creates.is_empty() {
+            let (batch_results, bf) = Self::batch_insert_records(pool, &creates, bulk_load).await;
+            batch_failed |= bf;
+            results.extend(batch_results);
         }
 
         (results, batch_failed)
@@ -3976,25 +3967,34 @@ impl IndexerManager {
             .map_err(|e| WintermuteError::Other(format!("invalid uri: {e}")))?;
         let uri = uri_obj.to_string();
 
-        // Fetch creator before deleting so we can decrement postsCount
-        let row = client
-            .query_opt("SELECT creator FROM post WHERE uri = $1", &[&uri])
-            .await?;
-
-        client
-            .execute("DELETE FROM post WHERE uri = $1", &[&uri])
+        let deleted = client
+            .query(
+                "DELETE FROM post WHERE uri = $1 RETURNING creator, \"replyParent\"",
+                &[&uri],
+            )
             .await?;
         client
             .execute("DELETE FROM feed_item WHERE uri = $1", &[&uri])
             .await?;
 
-        if let Some(row) = row {
-            let creator: Option<String> = row.get("creator");
-            if let Some(creator) = creator {
+        if let Some(row) = deleted.first() {
+            if let Some(creator) = row.get::<_, Option<String>>(0) {
                 client
                     .execute(
                         "UPDATE profile_agg SET \"postsCount\" = GREATEST(\"postsCount\" - 1, 0) WHERE did = $1",
                         &[&creator],
+                    )
+                    .await?;
+            }
+            if let Some(parent) = row.get::<_, Option<String>>(1) {
+                client
+                    .execute(
+                        "INSERT INTO post_agg (uri, \"replyCount\")
+                         SELECT $1::varchar, COUNT(*) FROM post
+                         WHERE \"replyParent\" = $1
+                           AND (\"violatesThreadGate\" IS NULL OR \"violatesThreadGate\" = false)
+                         ON CONFLICT (uri) DO UPDATE SET \"replyCount\" = EXCLUDED.\"replyCount\"",
+                        &[&parent],
                     )
                     .await?;
             }
@@ -4152,9 +4152,23 @@ impl IndexerManager {
             .map_err(|e| WintermuteError::Other(format!("invalid uri: {e}")))?;
         let uri = uri_obj.to_string();
 
-        client
-            .execute("DELETE FROM \"like\" WHERE uri = $1", &[&uri])
+        let deleted = client
+            .query(
+                "DELETE FROM \"like\" WHERE uri = $1 RETURNING subject",
+                &[&uri],
+            )
             .await?;
+
+        if let Some(subject) = deleted.first().and_then(|r| r.get::<_, Option<String>>(0)) {
+            client
+                .execute(
+                    "INSERT INTO post_agg (uri, \"likeCount\")
+                     SELECT $1::varchar, COUNT(*) FROM \"like\" WHERE subject = $1
+                     ON CONFLICT (uri) DO UPDATE SET \"likeCount\" = EXCLUDED.\"likeCount\"",
+                    &[&subject],
+                )
+                .await?;
+        }
 
         Ok(())
     }
@@ -4393,12 +4407,26 @@ impl IndexerManager {
             .map_err(|e| WintermuteError::Other(format!("invalid uri: {e}")))?;
         let uri = uri_obj.to_string();
 
-        client
-            .execute("DELETE FROM repost WHERE uri = $1", &[&uri])
+        let deleted = client
+            .query(
+                "DELETE FROM repost WHERE uri = $1 RETURNING subject",
+                &[&uri],
+            )
             .await?;
         client
             .execute("DELETE FROM feed_item WHERE uri = $1", &[&uri])
             .await?;
+
+        if let Some(subject) = deleted.first().and_then(|r| r.get::<_, Option<String>>(0)) {
+            client
+                .execute(
+                    "INSERT INTO post_agg (uri, \"repostCount\")
+                     SELECT $1::varchar, COUNT(*) FROM repost WHERE subject = $1
+                     ON CONFLICT (uri) DO UPDATE SET \"repostCount\" = EXCLUDED.\"repostCount\"",
+                    &[&subject],
+                )
+                .await?;
+        }
 
         Ok(())
     }

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -348,29 +348,46 @@ impl IndexerManager {
             Self::update_queue_metrics_for(&metrics_storage);
         }));
 
+        // The dequeue walks and removes thousands of Fjall entries per batch;
+        // it runs on a blocking thread and is prefetched while the previous
+        // batch's database work is in flight, so neither cost serializes
+        // behind the other.
+        let dequeue = |storage: Arc<Storage>| {
+            tokio::task::spawn_blocking(move || {
+                storage
+                    .dequeue_firehose_live_batch(batch_size)
+                    .map_err(|e| {
+                        tracing::error!("failed to dequeue firehose_live batch: {e}");
+                    })
+            })
+        };
+        let mut prefetched: Option<Vec<(Vec<u8>, IndexJob)>> = None;
+
         loop {
             if SHUTDOWN.load(Ordering::Relaxed) {
                 tracing::info!("shutdown requested for firehose_live processor");
                 break;
             }
 
-            let batch: Vec<(Vec<u8>, IndexJob)> =
-                match self.storage.dequeue_firehose_live_batch(batch_size) {
-                    Ok(jobs) => jobs,
-                    Err(e) => {
-                        tracing::error!("failed to dequeue firehose_live batch: {e}");
-                        Vec::new()
-                    }
-                };
+            let batch: Vec<(Vec<u8>, IndexJob)> = match prefetched.take() {
+                Some(jobs) => jobs,
+                None => dequeue(Arc::clone(&self.storage))
+                    .await
+                    .ok()
+                    .and_then(Result::ok)
+                    .unwrap_or_default(),
+            };
 
             if batch.is_empty() {
                 tokio::time::sleep(Duration::from_millis(50)).await;
                 continue;
             }
 
+            let prefetch = dequeue(Arc::clone(&self.storage));
             let bulk_mode = !*crate::config::LIVE_AGGREGATES;
             let (results, _batch_failed) =
                 Box::pin(Self::process_jobs_batch(&self.pool_live, &batch, bulk_mode)).await;
+            prefetched = prefetch.await.ok().and_then(Result::ok);
             let jobs_by_key: std::collections::HashMap<&[u8], &IndexJob> =
                 batch.iter().map(|(k, j)| (k.as_slice(), j)).collect();
             for (key, result) in results {
@@ -432,7 +449,10 @@ impl IndexerManager {
             let processed = Arc::clone(&processed_total);
 
             let handle = tokio::spawn(async move {
-                Self::backfill_worker_loop(worker_id, storage, pool, batch_size, processed).await;
+                Box::pin(Self::backfill_worker_loop(
+                    worker_id, storage, pool, batch_size, processed,
+                ))
+                .await;
             });
             worker_handles.push(handle);
         }
@@ -1460,7 +1480,7 @@ impl IndexerManager {
         }
 
         for (key, job) in sequential {
-            let result = Self::process_job(pool, job).await;
+            let result = Box::pin(Self::process_job(pool, job)).await;
             if result.is_err() {
                 batch_failed = true;
             }
@@ -1471,14 +1491,16 @@ impl IndexerManager {
         // phase split must clear the old row first, or the new record is
         // silently dropped on its (subject, creator)-style unique conflict.
         if !deletes.is_empty() {
-            let (delete_results, bf) = Self::batch_delete_records(pool, &deletes, bulk_load).await;
+            let (delete_results, bf) =
+                Box::pin(Self::batch_delete_records(pool, &deletes, bulk_load)).await;
             batch_failed |= bf;
             results.extend(delete_results);
         }
 
         // Process creates in batch (uses parallel COPY for different collection types)
         if !creates.is_empty() {
-            let (batch_results, bf) = Self::batch_insert_records(pool, &creates, bulk_load).await;
+            let (batch_results, bf) =
+                Box::pin(Self::batch_insert_records(pool, &creates, bulk_load)).await;
             batch_failed |= bf;
             results.extend(batch_results);
         }

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -2945,30 +2945,29 @@ impl IndexerManager {
 
         bulk::copy_insert_posts(client, &post_data, compute_agg).await?;
         bulk::copy_insert_feed_items(client, &feed_item_data).await?;
-        bulk::copy_insert_post_embed_images(client, &embed_image_data).await?;
-        bulk::copy_insert_post_embed_videos(client, &embed_video_data).await?;
-        bulk::copy_insert_quotes(client, &quote_data, compute_agg).await?;
 
         // Notifications are deliberately not limited to newly applied rows:
         // gap-heal replays must generate them for rows indexed by older code,
-        // and the (did, recordUri, reason) dedupe keeps replays exact.
-        if compute_agg {
-            bulk::copy_insert_notifications(client, &notif_rows).await?;
-            // The per-reply ancestor walk is two queries per reply; run a few
-            // concurrently on their own pooled connections or it dominates the
-            // post worker's cycle and caps drain throughput.
-            for chunk in reply_posts.chunks(3) {
-                let walks = chunk.iter().map(|(did, uri, cid, sort_at)| async move {
-                    let conn = pool.get().await.map_err(WintermuteError::Pool)?;
-                    Self::write_reply_notifications(&conn, did, uri, cid, sort_at).await
-                });
-                for result in futures::future::join_all(walks).await {
-                    result?;
+        // and the (did, recordUri, reason) dedupe keeps replays exact. The
+        // notification work runs on its own connection concurrently with the
+        // embed/quote inserts.
+        let (embed_result, notif_result) = futures::join!(
+            async {
+                bulk::copy_insert_post_embed_images(client, &embed_image_data).await?;
+                bulk::copy_insert_post_embed_videos(client, &embed_video_data).await?;
+                bulk::copy_insert_quotes(client, &quote_data, compute_agg).await
+            },
+            async {
+                if !compute_agg {
+                    return Ok(());
                 }
+                let conn = pool.get().await.map_err(WintermuteError::Pool)?;
+                bulk::copy_insert_notifications(&conn, &notif_rows).await?;
+                bulk::write_reply_notifications_bulk(&conn, &reply_posts).await
             }
-        }
-
-        Ok(())
+        );
+        embed_result?;
+        notif_result
     }
 
     /// Extract a quote subject (uri, cid) from a post's embed, mirroring the live path.

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -7,7 +7,10 @@ use crate::config::{
     HANDLE_REINDEX_INTERVAL_VALID, HANDLE_RESOLUTION_BATCH_SIZE, HANDLE_RESOLUTION_CONCURRENCY,
     IDENTITY_RESOLVER_TIMEOUT, INLINE_CONCURRENCY, WORKERS_INDEXER,
 };
-use crate::config::{FIREHOSE_LIVE_DRAIN_BATCH, INDEXER_BATCH_SIZE, INDEXER_BATCH_WORKERS};
+use crate::config::{
+    FIREHOSE_LIVE_DRAIN_BATCH, FIREHOSE_LIVE_SHARDS, INDEXER_BATCH_SIZE, INDEXER_BATCH_WORKERS,
+    LIVE_LIKE_SERIALIZE,
+};
 use crate::storage::Storage;
 #[cfg(test)]
 use crate::types::LabelEvent;
@@ -91,12 +94,20 @@ impl IndexerManager {
         // Create separate pools for each stream to prevent starvation
         // Backfill gets 50% of connections since it's the main bottleneck
         let backfill_pool_size = pool_size / 2;
-        let live_pool_size = pool_size / 4;
+        // Each live shard can hold up to 8 connections at once and deadpool has
+        // no acquire timeout, so the pool must always cover every shard fully.
+        let live_shards = *FIREHOSE_LIVE_SHARDS;
+        let live_pool_size = if live_shards > 1 {
+            (pool_size / 4).max(live_shards * 8)
+        } else {
+            pool_size / 4
+        };
         let labels_pool_size = pool_size / 4;
 
         tracing::info!(
-            "indexer DB pools: live={}, backfill={}, labels={}",
+            "indexer DB pools: live={} (shards={}), backfill={}, labels={}",
             live_pool_size,
+            live_shards,
             backfill_pool_size,
             labels_pool_size
         );
@@ -379,17 +390,23 @@ impl IndexerManager {
             };
 
             if batch.is_empty() {
-                tokio::time::sleep(Duration::from_millis(50)).await;
+                self.storage
+                    .wait_for_live_enqueue(Duration::from_millis(50))
+                    .await;
                 continue;
             }
 
             let prefetch = dequeue(Arc::clone(&self.storage));
             let bulk_mode = !*crate::config::LIVE_AGGREGATES;
-            let (results, _batch_failed) =
-                Box::pin(Self::process_jobs_batch(&self.pool_live, &batch, bulk_mode)).await;
+            let shard_batches = Self::shard_live_jobs(batch, *FIREHOSE_LIVE_SHARDS);
+            let results =
+                Self::process_live_shards(&self.pool_live, &shard_batches, bulk_mode).await;
             prefetched = prefetch.await.ok().and_then(Result::ok);
-            let jobs_by_key: std::collections::HashMap<&[u8], &IndexJob> =
-                batch.iter().map(|(k, j)| (k.as_slice(), j)).collect();
+            let jobs_by_key: std::collections::HashMap<&[u8], &IndexJob> = shard_batches
+                .iter()
+                .flatten()
+                .map(|(k, j)| (k.as_slice(), j))
+                .collect();
             for (key, result) in results {
                 processed_count += 1;
                 if let Err(e) = result {
@@ -424,6 +441,49 @@ impl IndexerManager {
                 last_log = std::time::Instant::now();
             }
         }
+    }
+
+    /// Partition a live batch by repo DID so each shard owns every job for its
+    /// repos: per-repo ordering and same-URI pairing survive concurrent shards.
+    fn shard_live_jobs(
+        batch: Vec<(Vec<u8>, IndexJob)>,
+        shards: usize,
+    ) -> Vec<Vec<(Vec<u8>, IndexJob)>> {
+        if shards <= 1 {
+            return vec![batch];
+        }
+        let mut out: Vec<Vec<(Vec<u8>, IndexJob)>> = (0..shards).map(|_| Vec::new()).collect();
+        let shard_count = shards as u64;
+        for entry in batch {
+            let shard = {
+                let did = entry.1.uri.split('/').nth(2).unwrap_or(&entry.1.uri);
+                let mut hasher = std::hash::DefaultHasher::new();
+                std::hash::Hash::hash(did, &mut hasher);
+                usize::try_from(std::hash::Hasher::finish(&hasher) % shard_count).unwrap_or(0)
+            };
+            out[shard].push(entry);
+        }
+        out
+    }
+
+    /// Run `process_jobs_batch` for every non-empty shard concurrently and
+    /// merge the per-job results. Awaiting all shards before the next dequeue
+    /// keeps per-repo ordering intact across batches.
+    async fn process_live_shards(
+        pool: &Pool,
+        shard_batches: &[Vec<(Vec<u8>, IndexJob)>],
+        bulk_mode: bool,
+    ) -> Vec<(Vec<u8>, Result<(), WintermuteError>)> {
+        futures::future::join_all(
+            shard_batches
+                .iter()
+                .filter(|shard| !shard.is_empty())
+                .map(|shard| Box::pin(Self::process_jobs_batch(pool, shard, bulk_mode))),
+        )
+        .await
+        .into_iter()
+        .flat_map(|(results, _batch_failed)| results)
+        .collect()
     }
 
     async fn process_firehose_backfill_loop(&self) {
@@ -2682,7 +2742,7 @@ impl IndexerManager {
 
         // Serialize live like inserts across workers (the like index causes contention).
         // The bulk CAR load runs with indexes dropped, so the semaphore would only throttle it.
-        let _permit = if bulk_load {
+        let _permit = if bulk_load || !*LIVE_LIKE_SERIALIZE {
             None
         } else {
             Some(LIKE_INSERT_SEMAPHORE.acquire().await)
@@ -2958,7 +3018,7 @@ impl IndexerManager {
                 bulk::copy_insert_quotes(client, &quote_data, compute_agg).await
             },
             async {
-                if !compute_agg {
+                if !compute_agg || (notif_rows.is_empty() && reply_posts.is_empty()) {
                     return Ok(());
                 }
                 let conn = pool.get().await.map_err(WintermuteError::Pool)?;

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -154,7 +154,7 @@ impl IndexerManager {
             // Spawn each processor as independent task for true parallelism
             let live_handle = {
                 let mgr = manager.clone();
-                tokio::spawn(async move { mgr.process_firehose_live_loop().await })
+                tokio::spawn(async move { Box::pin(mgr.process_firehose_live_loop()).await })
             };
 
             let backfill_handle = {
@@ -370,7 +370,7 @@ impl IndexerManager {
 
             let bulk_mode = !*crate::config::LIVE_AGGREGATES;
             let (results, _batch_failed) =
-                Self::process_jobs_batch(&self.pool_live, &batch, bulk_mode).await;
+                Box::pin(Self::process_jobs_batch(&self.pool_live, &batch, bulk_mode)).await;
             let jobs_by_key: std::collections::HashMap<&[u8], &IndexJob> =
                 batch.iter().map(|(k, j)| (k.as_slice(), j)).collect();
             for (key, result) in results {
@@ -2711,7 +2711,7 @@ impl IndexerManager {
             Ok(c) => c,
             Err(e) => return (0, count, Some(WintermuteError::Pool(e))),
         };
-        let err = Self::copy_batch_insert_likes(&client, jobs, !bulk_load)
+        let err = Self::copy_batch_insert_likes(pool, &client, jobs, !bulk_load)
             .await
             .err();
         (start.elapsed().as_millis(), count, err)
@@ -2731,7 +2731,7 @@ impl IndexerManager {
             Ok(c) => c,
             Err(e) => return (0, count, Some(WintermuteError::Pool(e))),
         };
-        let err = Self::copy_batch_insert_follows(&client, jobs, !bulk_load)
+        let err = Self::copy_batch_insert_follows(pool, &client, jobs, !bulk_load)
             .await
             .err();
         (start.elapsed().as_millis(), count, err)
@@ -2751,7 +2751,7 @@ impl IndexerManager {
             Ok(c) => c,
             Err(e) => return (0, count, Some(WintermuteError::Pool(e))),
         };
-        let err = Self::copy_batch_insert_reposts(&client, jobs, !bulk_load)
+        let err = Self::copy_batch_insert_reposts(pool, &client, jobs, !bulk_load)
             .await
             .err();
         (start.elapsed().as_millis(), count, err)
@@ -3108,6 +3108,7 @@ impl IndexerManager {
     }
 
     async fn copy_batch_insert_likes(
+        pool: &Pool,
         client: &deadpool_postgres::Client,
         jobs: &[&ParsedJob<'_>],
         compute_agg: bool,
@@ -3165,11 +3166,27 @@ impl IndexerManager {
             }
         }
 
-        bulk::copy_insert_likes(client, &like_data, compute_agg).await?;
-        if compute_agg {
-            bulk::copy_insert_notifications(client, &notif_rows).await?;
+        // The notification insert is independent of the like rows (ungated,
+        // deduped), so it runs on its own connection concurrently with the
+        // bulk insert instead of serially extending the worker's cycle.
+        let (insert_result, notif_result) = futures::join!(
+            bulk::copy_insert_likes(client, &like_data, compute_agg),
+            Self::insert_notifications_pooled(pool, &notif_rows, compute_agg)
+        );
+        insert_result?;
+        notif_result
+    }
+
+    async fn insert_notifications_pooled(
+        pool: &Pool,
+        notif_rows: &[bulk::NotificationRow],
+        compute_agg: bool,
+    ) -> Result<(), WintermuteError> {
+        if !compute_agg || notif_rows.is_empty() {
+            return Ok(());
         }
-        Ok(())
+        let conn = pool.get().await.map_err(WintermuteError::Pool)?;
+        bulk::copy_insert_notifications(&conn, notif_rows).await
     }
 
     /// Collect subject + via notifications for a like or repost record,
@@ -3227,6 +3244,7 @@ impl IndexerManager {
     }
 
     async fn copy_batch_insert_follows(
+        pool: &Pool,
         client: &deadpool_postgres::Client,
         jobs: &[&ParsedJob<'_>],
         compute_agg: bool,
@@ -3275,14 +3293,16 @@ impl IndexerManager {
             }
         }
 
-        bulk::copy_insert_follows(client, &follow_data, compute_agg).await?;
-        if compute_agg {
-            bulk::copy_insert_notifications(client, &notif_rows).await?;
-        }
-        Ok(())
+        let (insert_result, notif_result) = futures::join!(
+            bulk::copy_insert_follows(client, &follow_data, compute_agg),
+            Self::insert_notifications_pooled(pool, &notif_rows, compute_agg)
+        );
+        insert_result?;
+        notif_result
     }
 
     async fn copy_batch_insert_reposts(
+        pool: &Pool,
         client: &deadpool_postgres::Client,
         jobs: &[&ParsedJob<'_>],
         compute_agg: bool,
@@ -3357,13 +3377,15 @@ impl IndexerManager {
             }
         }
 
-        bulk::copy_insert_reposts(client, &repost_data, compute_agg).await?;
-        bulk::copy_insert_feed_items(client, &feed_item_data).await?;
-        if compute_agg {
-            bulk::copy_insert_notifications(client, &notif_rows).await?;
-        }
-
-        Ok(())
+        let (insert_result, notif_result) = futures::join!(
+            async {
+                bulk::copy_insert_reposts(client, &repost_data, compute_agg).await?;
+                bulk::copy_insert_feed_items(client, &feed_item_data).await
+            },
+            Self::insert_notifications_pooled(pool, &notif_rows, compute_agg)
+        );
+        insert_result?;
+        notif_result
     }
 
     async fn copy_batch_insert_blocks(

--- a/rsky-wintermute/src/indexer/tests.rs
+++ b/rsky-wintermute/src/indexer/tests.rs
@@ -2278,4 +2278,155 @@ mod indexer_tests {
             cleanup_test_data(&pool, did).await;
         }
     }
+
+    #[tokio::test]
+    async fn batch_toggle_sequence_keeps_final_like_and_exact_counts() {
+        use crate::indexer::bulk::PostCopyRow;
+        use crate::types::{IndexJob, WriteAction};
+
+        let pool = setup_test_pool();
+        let liker = "did:plc:wintermute-test-toggle-liker";
+        let author = "did:plc:wintermute-test-toggle-author";
+        for did in [liker, author] {
+            cleanup_test_data(&pool, did).await;
+        }
+
+        let client = pool.get().await.unwrap();
+        for did in [liker, author] {
+            client
+                .execute(
+                    "INSERT INTO actor (did, \"indexedAt\") VALUES ($1, NOW()) \
+                     ON CONFLICT (did) DO NOTHING",
+                    &[&did],
+                )
+                .await
+                .unwrap();
+        }
+
+        let post_uri = format!("at://{author}/app.bsky.feed.post/togglepost");
+        let cid = "bafyreihhl5mpvjkrhnnagen2fomozzhnhhdq2jr6cego2nzbvmwewv5rd4".to_owned();
+        let ts = "2026-07-31T00:00:00.000Z".to_owned();
+        client
+            .execute("DELETE FROM post_agg WHERE uri = $1", &[&post_uri])
+            .await
+            .unwrap();
+        crate::indexer::bulk::copy_insert_posts(
+            &client,
+            &[PostCopyRow {
+                uri: post_uri.clone(),
+                cid: cid.clone(),
+                creator: author.to_owned(),
+                text: "toggle target".to_owned(),
+                reply_root: None,
+                reply_root_cid: None,
+                reply_parent: None,
+                reply_parent_cid: None,
+                created_at: ts.clone(),
+                indexed_at: ts.clone(),
+                langs: None,
+                tags: None,
+            }],
+            true,
+        )
+        .await
+        .unwrap();
+
+        let like_record = serde_json::json!({
+            "$type": "app.bsky.feed.like",
+            "subject": {"uri": post_uri, "cid": cid},
+            "createdAt": ts,
+        });
+        let like_uri = |rkey: &str| format!("at://{liker}/app.bsky.feed.like/{rkey}");
+        let job = |rkey: &str, action: WriteAction, rev: &str, with_record: bool| IndexJob {
+            uri: like_uri(rkey),
+            cid: cid.clone(),
+            action,
+            record: with_record.then(|| like_record.clone()),
+            indexed_at: ts.clone(),
+            rev: rev.to_owned(),
+        };
+
+        // like, unlike, re-like within ONE drain batch: the phase split
+        // (creates before deletes) must not eat the final like.
+        let jobs = vec![
+            (
+                b"k1".to_vec(),
+                job("toggle1", WriteAction::Create, "3a", true),
+            ),
+            (
+                b"k2".to_vec(),
+                job("toggle1", WriteAction::Delete, "3b", false),
+            ),
+            (
+                b"k3".to_vec(),
+                job("toggle2", WriteAction::Create, "3c", true),
+            ),
+        ];
+        let (results, batch_failed) = IndexerManager::process_jobs_batch(&pool, &jobs, false).await;
+        assert!(!batch_failed);
+        assert_eq!(results.len(), 3);
+        for (_, r) in &results {
+            assert!(r.is_ok(), "job failed: {r:?}");
+        }
+
+        let final_like: Option<String> = client
+            .query_opt(
+                "SELECT uri FROM \"like\" WHERE creator = $1 AND subject = $2",
+                &[&liker, &post_uri],
+            )
+            .await
+            .unwrap()
+            .map(|r| r.get(0));
+        assert_eq!(
+            final_like.as_deref(),
+            Some(like_uri("toggle2").as_str()),
+            "the re-like must survive the toggle sequence"
+        );
+        let agg: i64 = client
+            .query_one(
+                "SELECT \"likeCount\" FROM post_agg WHERE uri = $1",
+                &[&post_uri],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(agg, 1, "likeCount must be exactly 1 after toggle");
+
+        // Unlike in a LATER batch: the batch delete path must decrement.
+        let delete_jobs = vec![(
+            b"k4".to_vec(),
+            job("toggle2", WriteAction::Delete, "3d", false),
+        )];
+        let (results, batch_failed) =
+            IndexerManager::process_jobs_batch(&pool, &delete_jobs, false).await;
+        assert!(!batch_failed);
+        assert!(results.iter().all(|(_, r)| r.is_ok()));
+
+        let remaining: i64 = client
+            .query_one(
+                "SELECT COUNT(*) FROM \"like\" WHERE creator = $1 AND subject = $2",
+                &[&liker, &post_uri],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(remaining, 0, "unlike must delete the like row");
+        let agg: i64 = client
+            .query_one(
+                "SELECT \"likeCount\" FROM post_agg WHERE uri = $1",
+                &[&post_uri],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(agg, 0, "likeCount must return to exactly 0 after unlike");
+
+        client
+            .execute("DELETE FROM post_agg WHERE uri = $1", &[&post_uri])
+            .await
+            .unwrap();
+        for did in [liker, author] {
+            cleanup_test_data(&pool, did).await;
+        }
+    }
 }

--- a/rsky-wintermute/src/indexer/tests.rs
+++ b/rsky-wintermute/src/indexer/tests.rs
@@ -2739,25 +2739,25 @@ mod indexer_tests {
                 );
             }
         }
-        let toggle_record = serde_json::json!({
-            "$type": "app.bsky.feed.like",
-            "subject": {"uri": post_uris[0], "cid": cid},
-            "createdAt": ts,
-        });
-        push(
-            &mut jobs,
-            toggle_uri.clone(),
-            WriteAction::Create,
-            Some(toggle_record),
-            "3a",
-        );
-        push(
-            &mut jobs,
-            toggle_uri.clone(),
-            WriteAction::Delete,
-            None,
-            "3b",
-        );
+        let second_toggle_uri = format!("at://{}/app.bsky.feed.like/shardtoggle2", likers[1]);
+        for (uri, subject) in [
+            (&toggle_uri, &post_uris[0]),
+            (&second_toggle_uri, &post_uris[1]),
+        ] {
+            let record = serde_json::json!({
+                "$type": "app.bsky.feed.like",
+                "subject": {"uri": subject, "cid": cid},
+                "createdAt": ts,
+            });
+            push(
+                &mut jobs,
+                uri.clone(),
+                WriteAction::Create,
+                Some(record),
+                "3a",
+            );
+            push(&mut jobs, uri.clone(), WriteAction::Delete, None, "3b");
+        }
 
         let mut snapshots = Vec::new();
         for shards in [1usize, 3] {
@@ -2784,15 +2784,14 @@ mod indexer_tests {
             assert_eq!(snap.0, vec![3, 3, 3], "like rows wrong at shards={shards}");
             assert_eq!(snap.1, vec![3, 3, 3], "likeCount wrong at shards={shards}");
             let client = pool.get().await.unwrap();
-            let toggle_left: i64 = client
-                .query_one(
-                    "SELECT COUNT(*) FROM \"like\" WHERE uri = $1",
-                    &[&toggle_uri],
-                )
-                .await
-                .unwrap()
-                .get(0);
-            assert_eq!(toggle_left, 0, "toggled like survived at shards={shards}");
+            for uri in [&toggle_uri, &second_toggle_uri] {
+                let toggle_left: i64 = client
+                    .query_one("SELECT COUNT(*) FROM \"like\" WHERE uri = $1", &[uri])
+                    .await
+                    .unwrap()
+                    .get(0);
+                assert_eq!(toggle_left, 0, "toggled like survived at shards={shards}");
+            }
             snapshots.push(snap);
         }
         assert_eq!(

--- a/rsky-wintermute/src/indexer/tests.rs
+++ b/rsky-wintermute/src/indexer/tests.rs
@@ -1990,14 +1990,16 @@ mod indexer_tests {
             .await
             .unwrap();
 
-        let follow = (
-            format!("at://{creator}/app.bsky.graph.follow/aggfollow1"),
-            "bafyreihhl5mpvjkrhnnagen2fomozzhnhhdq2jr6cego2nzbvmwewv5rd4".to_owned(),
-            creator.to_owned(),
-            subject.to_owned(),
-            "2026-07-30T00:00:00.000Z".to_owned(),
-            "2026-07-30T00:00:00.000Z".to_owned(),
-        );
+        let follow = bulk::FollowCopyRow {
+            uri: format!("at://{creator}/app.bsky.graph.follow/aggfollow1"),
+            cid: "bafyreihhl5mpvjkrhnnagen2fomozzhnhhdq2jr6cego2nzbvmwewv5rd4".to_owned(),
+            creator: creator.to_owned(),
+            subject_did: subject.to_owned(),
+            created_at: "2026-07-30T00:00:00.000Z".to_owned(),
+            indexed_at: "2026-07-30T00:00:00.000Z".to_owned(),
+            via: None,
+            via_cid: None,
+        };
         bulk::copy_insert_follows(&client, std::slice::from_ref(&follow), true)
             .await
             .unwrap();
@@ -2181,15 +2183,17 @@ mod indexer_tests {
 
         // Batch likes and reposts of the parent: likeCount/repostCount exact
         // across replays.
-        let like = (
-            format!("at://{author}/app.bsky.feed.like/notiflike"),
-            cid.clone(),
-            author.to_owned(),
-            parent_uri.clone(),
-            cid.clone(),
-            ts.clone(),
-            ts.clone(),
-        );
+        let like = bulk::SubjectRecordRow {
+            uri: format!("at://{author}/app.bsky.feed.like/notiflike"),
+            cid: cid.clone(),
+            creator: author.to_owned(),
+            subject: parent_uri.clone(),
+            subject_cid: cid.clone(),
+            created_at: ts.clone(),
+            indexed_at: ts.clone(),
+            via: None,
+            via_cid: None,
+        };
         let like_applied = bulk::copy_insert_likes(&client, std::slice::from_ref(&like), true)
             .await
             .unwrap();
@@ -2199,15 +2203,17 @@ mod indexer_tests {
             .unwrap();
         assert!(like_replayed.is_empty());
 
-        let repost = (
-            format!("at://{author}/app.bsky.feed.repost/notifrepost"),
-            cid.clone(),
-            author.to_owned(),
-            parent_uri.clone(),
-            cid.clone(),
-            ts.clone(),
-            ts.clone(),
-        );
+        let repost = bulk::SubjectRecordRow {
+            uri: format!("at://{author}/app.bsky.feed.repost/notifrepost"),
+            cid: cid.clone(),
+            creator: author.to_owned(),
+            subject: parent_uri.clone(),
+            subject_cid: cid.clone(),
+            created_at: ts.clone(),
+            indexed_at: ts.clone(),
+            via: None,
+            via_cid: None,
+        };
         bulk::copy_insert_reposts(&client, std::slice::from_ref(&repost), true)
             .await
             .unwrap();
@@ -2800,6 +2806,115 @@ mod indexer_tests {
         );
 
         for did in &all_dids {
+            cleanup_test_data(&pool, did).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn via_attribution_persists_from_batch_path() {
+        use crate::types::{IndexJob, WriteAction};
+
+        let pool = setup_test_pool();
+        let author = "did:plc:wintermute-test-via-author";
+        let actor = "did:plc:wintermute-test-via-actor";
+        for did in [author, actor] {
+            cleanup_test_data(&pool, did).await;
+        }
+        let client = pool.get().await.unwrap();
+        for did in [author, actor] {
+            client
+                .execute(
+                    "INSERT INTO actor (did, \"indexedAt\") VALUES ($1, NOW()) \
+                     ON CONFLICT (did) DO NOTHING",
+                    &[&did],
+                )
+                .await
+                .unwrap();
+        }
+        drop(client);
+
+        let cid = "bafyreihhl5mpvjkrhnnagen2fomozzhnhhdq2jr6cego2nzbvmwewv5rd4";
+        let ts = "2026-08-03T00:00:00.000Z";
+        let post_uri = format!("at://{author}/app.bsky.feed.post/viapost");
+        let via_uri = format!("at://{author}/app.bsky.feed.repost/viasource");
+        let subject = serde_json::json!({"uri": post_uri, "cid": cid});
+        let via = serde_json::json!({"uri": via_uri, "cid": cid});
+
+        let job = |coll: &str, rkey: &str, record: serde_json::Value| IndexJob {
+            uri: format!("at://{actor}/{coll}/{rkey}"),
+            cid: cid.to_owned(),
+            action: WriteAction::Create,
+            record: Some(record),
+            indexed_at: ts.to_owned(),
+            rev: "3a".to_owned(),
+        };
+        let jobs = vec![
+            (
+                b"v1".to_vec(),
+                job(
+                    "app.bsky.feed.like",
+                    "withvia",
+                    serde_json::json!({"$type": "app.bsky.feed.like", "subject": subject, "via": via, "createdAt": ts}),
+                ),
+            ),
+            (
+                b"v2".to_vec(),
+                job(
+                    "app.bsky.feed.like",
+                    "novia",
+                    serde_json::json!({"$type": "app.bsky.feed.like", "subject": {"uri": format!("at://{author}/app.bsky.feed.post/viapost2"), "cid": cid}, "createdAt": ts}),
+                ),
+            ),
+            (
+                b"v3".to_vec(),
+                job(
+                    "app.bsky.feed.repost",
+                    "withvia",
+                    serde_json::json!({"$type": "app.bsky.feed.repost", "subject": subject, "via": via, "createdAt": ts}),
+                ),
+            ),
+            (
+                b"v4".to_vec(),
+                job(
+                    "app.bsky.graph.follow",
+                    "withvia",
+                    serde_json::json!({"$type": "app.bsky.graph.follow", "subject": author, "via": via, "createdAt": ts}),
+                ),
+            ),
+        ];
+        let (results, batch_failed) = IndexerManager::process_jobs_batch(&pool, &jobs, false).await;
+        assert!(!batch_failed);
+        for (_, r) in &results {
+            assert!(r.is_ok(), "job failed: {r:?}");
+        }
+
+        let client = pool.get().await.unwrap();
+        for (table, coll, rkey, expect_via) in [
+            ("\"like\"", "app.bsky.feed.like", "withvia", true),
+            ("\"like\"", "app.bsky.feed.like", "novia", false),
+            ("repost", "app.bsky.feed.repost", "withvia", true),
+            ("follow", "app.bsky.graph.follow", "withvia", true),
+        ] {
+            let uri = format!("at://{actor}/{coll}/{rkey}");
+            let row = client
+                .query_one(
+                    &format!("SELECT via, \"viaCid\" FROM {table} WHERE uri = $1"),
+                    &[&uri],
+                )
+                .await
+                .unwrap();
+            let got_via: Option<String> = row.get(0);
+            let got_via_cid: Option<String> = row.get(1);
+            if expect_via {
+                assert_eq!(got_via.as_deref(), Some(via_uri.as_str()), "{uri}");
+                assert_eq!(got_via_cid.as_deref(), Some(cid), "{uri}");
+            } else {
+                assert!(got_via.is_none() && got_via_cid.is_none(), "{uri}");
+            }
+        }
+        drop(client);
+
+        for did in [author, actor] {
             cleanup_test_data(&pool, did).await;
         }
     }

--- a/rsky-wintermute/src/indexer/tests.rs
+++ b/rsky-wintermute/src/indexer/tests.rs
@@ -2392,10 +2392,55 @@ mod indexer_tests {
             .get(0);
         assert_eq!(agg, 1, "likeCount must be exactly 1 after toggle");
 
-        // Unlike in a LATER batch: the batch delete path must decrement.
+        // Cross-batch toggle: unlike toggle2 and re-like as toggle3 in ONE
+        // batch (the create of toggle2 was a prior batch). Deletes must run
+        // before creates or toggle3 dies on the (subject, creator) conflict
+        // with toggle2's still-present row.
+        let cross_jobs = vec![
+            (
+                b"k4".to_vec(),
+                job("toggle2", WriteAction::Delete, "3d", false),
+            ),
+            (
+                b"k5".to_vec(),
+                job("toggle3", WriteAction::Create, "3e", true),
+            ),
+        ];
+        let (results, batch_failed) =
+            IndexerManager::process_jobs_batch(&pool, &cross_jobs, false).await;
+        assert!(!batch_failed);
+        assert!(results.iter().all(|(_, r)| r.is_ok()));
+
+        let final_like: Option<String> = client
+            .query_opt(
+                "SELECT uri FROM \"like\" WHERE creator = $1 AND subject = $2",
+                &[&liker, &post_uri],
+            )
+            .await
+            .unwrap()
+            .map(|r| r.get(0));
+        assert_eq!(
+            final_like.as_deref(),
+            Some(like_uri("toggle3").as_str()),
+            "the cross-batch re-like must survive the phase split"
+        );
+        let agg: i64 = client
+            .query_one(
+                "SELECT \"likeCount\" FROM post_agg WHERE uri = $1",
+                &[&post_uri],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(
+            agg, 1,
+            "likeCount must be exactly 1 after cross-batch toggle"
+        );
+
+        // Final unlike in its own batch: the batch delete path must decrement.
         let delete_jobs = vec![(
-            b"k4".to_vec(),
-            job("toggle2", WriteAction::Delete, "3d", false),
+            b"k6".to_vec(),
+            job("toggle3", WriteAction::Delete, "3f", false),
         )];
         let (results, batch_failed) =
             IndexerManager::process_jobs_batch(&pool, &delete_jobs, false).await;

--- a/rsky-wintermute/src/indexer/tests.rs
+++ b/rsky-wintermute/src/indexer/tests.rs
@@ -2466,6 +2466,47 @@ mod indexer_tests {
             .get(0);
         assert_eq!(agg, 0, "likeCount must return to exactly 0 after unlike");
 
+        // A batch reply must notify the parent author via the set-based walk.
+        let reply_uri = format!("at://{liker}/app.bsky.feed.post/togglereply");
+        let reply_record = serde_json::json!({
+            "$type": "app.bsky.feed.post",
+            "text": "reply via batch",
+            "reply": {
+                "root": {"uri": post_uri, "cid": cid},
+                "parent": {"uri": post_uri, "cid": cid},
+            },
+            "createdAt": ts,
+        });
+        let reply_jobs = vec![(
+            b"k7".to_vec(),
+            IndexJob {
+                uri: reply_uri.clone(),
+                cid: cid.clone(),
+                action: WriteAction::Create,
+                record: Some(reply_record),
+                indexed_at: ts.clone(),
+                rev: "3g".to_owned(),
+            },
+        )];
+        let (results, batch_failed) =
+            IndexerManager::process_jobs_batch(&pool, &reply_jobs, false).await;
+        assert!(!batch_failed);
+        assert!(results.iter().all(|(_, r)| r.is_ok()));
+
+        let reply_notif: i64 = client
+            .query_one(
+                "SELECT COUNT(*) FROM notification \
+                 WHERE did = $1 AND \"recordUri\" = $2 AND reason = 'reply'",
+                &[&author, &reply_uri],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(
+            reply_notif, 1,
+            "parent author must get a reply notification"
+        );
+
         client
             .execute("DELETE FROM post_agg WHERE uri = $1", &[&post_uri])
             .await

--- a/rsky-wintermute/src/indexer/tests.rs
+++ b/rsky-wintermute/src/indexer/tests.rs
@@ -2515,4 +2515,293 @@ mod indexer_tests {
             cleanup_test_data(&pool, did).await;
         }
     }
+
+    #[test]
+    fn shard_live_jobs_is_deterministic_and_did_sticky() {
+        use crate::types::{IndexJob, WriteAction};
+
+        let job = |did: &str, rkey: &str| IndexJob {
+            uri: format!("at://{did}/app.bsky.feed.post/{rkey}"),
+            cid: "cid".to_owned(),
+            action: WriteAction::Create,
+            record: None,
+            indexed_at: "2026-08-01T00:00:00.000Z".to_owned(),
+            rev: "3a".to_owned(),
+        };
+        let batch: Vec<(Vec<u8>, IndexJob)> = (0u8..40)
+            .map(|i| {
+                let did = format!("did:plc:sharddid{}", i % 7);
+                (vec![i], job(&did, &format!("r{i}")))
+            })
+            .collect();
+
+        let single = IndexerManager::shard_live_jobs(batch.clone(), 1);
+        assert_eq!(single.len(), 1);
+        assert_eq!(single[0].len(), 40);
+
+        let shards = IndexerManager::shard_live_jobs(batch.clone(), 4);
+        assert_eq!(shards.len(), 4);
+        assert_eq!(shards.iter().map(Vec::len).sum::<usize>(), 40);
+
+        let mut did_to_shard = std::collections::HashMap::new();
+        for (idx, shard) in shards.iter().enumerate() {
+            for (_, j) in shard {
+                let did = j.uri.split('/').nth(2).unwrap().to_owned();
+                if let Some(prev) = did_to_shard.insert(did, idx) {
+                    assert_eq!(prev, idx, "did split across shards");
+                }
+            }
+        }
+        assert!(
+            did_to_shard
+                .values()
+                .collect::<std::collections::HashSet<_>>()
+                .len()
+                > 1,
+            "test dids all hashed to one shard"
+        );
+
+        let again = IndexerManager::shard_live_jobs(batch, 4);
+        for (a, b) in shards.iter().zip(again.iter()) {
+            assert!(
+                a.iter().map(|(k, _)| k).eq(b.iter().map(|(k, _)| k)),
+                "shard assignment not deterministic"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn live_enqueue_wakes_waiting_drain() {
+        use crate::types::{IndexJob, WriteAction};
+
+        let (storage, _dir) = setup_test_storage();
+        let storage = Arc::new(storage);
+        let job = IndexJob {
+            uri: "at://did:plc:wintermute-test-wakeup/app.bsky.feed.post/r1".to_owned(),
+            cid: "cid".to_owned(),
+            action: WriteAction::Create,
+            record: None,
+            indexed_at: "2026-08-01T00:00:00.000Z".to_owned(),
+            rev: "3a".to_owned(),
+        };
+
+        // An enqueue from a plain thread stores a permit even with no waiter,
+        // so the subsequent wait completes without consuming the timeout.
+        let enqueuer = {
+            let storage = Arc::clone(&storage);
+            let job = job.clone();
+            std::thread::spawn(move || storage.enqueue_firehose_live(&job).unwrap())
+        };
+        enqueuer.join().unwrap();
+
+        let start = std::time::Instant::now();
+        storage
+            .wait_for_live_enqueue(std::time::Duration::from_secs(5))
+            .await;
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(1),
+            "stored notify permit did not wake the waiter"
+        );
+
+        let start = std::time::Instant::now();
+        storage
+            .wait_for_live_enqueue(std::time::Duration::from_millis(20))
+            .await;
+        assert!(start.elapsed() >= std::time::Duration::from_millis(20));
+    }
+
+    async fn shard_pass_snapshot(
+        pool: &Pool,
+        post_uris: &[String],
+        authors: &[String],
+    ) -> (Vec<i64>, Vec<i64>, Vec<i64>) {
+        let client = pool.get().await.unwrap();
+        let mut like_rows = Vec::new();
+        let mut like_counts = Vec::new();
+        for uri in post_uris {
+            let rows: i64 = client
+                .query_one("SELECT COUNT(*) FROM \"like\" WHERE subject = $1", &[&uri])
+                .await
+                .unwrap()
+                .get(0);
+            like_rows.push(rows);
+            let agg: i64 = client
+                .query_one(
+                    "SELECT COALESCE((SELECT \"likeCount\" FROM post_agg WHERE uri = $1), 0)",
+                    &[&uri],
+                )
+                .await
+                .unwrap()
+                .get(0);
+            like_counts.push(agg);
+        }
+        let mut notif_counts = Vec::new();
+        for did in authors {
+            let n: i64 = client
+                .query_one(
+                    "SELECT COUNT(*) FROM notification WHERE did = $1 AND reason = 'like'",
+                    &[&did],
+                )
+                .await
+                .unwrap()
+                .get(0);
+            notif_counts.push(n);
+        }
+        (like_rows, like_counts, notif_counts)
+    }
+
+    async fn run_shard_pass(
+        pool: &Pool,
+        jobs: &[(Vec<u8>, crate::types::IndexJob)],
+        shards: usize,
+    ) {
+        let shard_batches = IndexerManager::shard_live_jobs(jobs.to_vec(), shards);
+        let results = IndexerManager::process_live_shards(pool, &shard_batches, false).await;
+        assert_eq!(results.len(), jobs.len());
+        for (_, r) in &results {
+            assert!(r.is_ok(), "job failed: {r:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn sharded_live_drain_matches_single_shard_results() {
+        use crate::types::{IndexJob, WriteAction};
+
+        let pool = setup_test_pool();
+        let authors: Vec<String> = (0..3)
+            .map(|i| format!("did:plc:wintermute-test-shard-author{i}"))
+            .collect();
+        let likers: Vec<String> = (0..3)
+            .map(|i| format!("did:plc:wintermute-test-shard-liker{i}"))
+            .collect();
+        let all_dids: Vec<&str> = authors
+            .iter()
+            .chain(likers.iter())
+            .map(String::as_str)
+            .collect();
+
+        let cid = "bafyreihhl5mpvjkrhnnagen2fomozzhnhhdq2jr6cego2nzbvmwewv5rd4".to_owned();
+        let ts = "2026-08-01T00:00:00.000Z".to_owned();
+        let post_uris: Vec<String> = authors
+            .iter()
+            .enumerate()
+            .map(|(i, a)| format!("at://{a}/app.bsky.feed.post/shardpost{i}"))
+            .collect();
+        let toggle_uri = format!("at://{}/app.bsky.feed.like/shardtoggle", likers[0]);
+
+        let mut jobs: Vec<(Vec<u8>, IndexJob)> = Vec::new();
+        let mut key = 0u8;
+        let mut push = |jobs: &mut Vec<(Vec<u8>, IndexJob)>,
+                        uri: String,
+                        action: WriteAction,
+                        record: Option<serde_json::Value>,
+                        rev: &str| {
+            key += 1;
+            jobs.push((
+                vec![key],
+                IndexJob {
+                    uri,
+                    cid: cid.clone(),
+                    action,
+                    record,
+                    indexed_at: ts.clone(),
+                    rev: rev.to_owned(),
+                },
+            ));
+        };
+        for (i, uri) in post_uris.iter().enumerate() {
+            let record = serde_json::json!({
+                "$type": "app.bsky.feed.post",
+                "text": format!("shard post {i}"),
+                "createdAt": ts,
+            });
+            push(
+                &mut jobs,
+                uri.clone(),
+                WriteAction::Create,
+                Some(record),
+                "3a",
+            );
+        }
+        for (i, post_uri) in post_uris.iter().enumerate() {
+            for (j, liker) in likers.iter().enumerate() {
+                let record = serde_json::json!({
+                    "$type": "app.bsky.feed.like",
+                    "subject": {"uri": post_uri, "cid": cid},
+                    "createdAt": ts,
+                });
+                push(
+                    &mut jobs,
+                    format!("at://{liker}/app.bsky.feed.like/sl{i}{j}"),
+                    WriteAction::Create,
+                    Some(record),
+                    "3a",
+                );
+            }
+        }
+        let toggle_record = serde_json::json!({
+            "$type": "app.bsky.feed.like",
+            "subject": {"uri": post_uris[0], "cid": cid},
+            "createdAt": ts,
+        });
+        push(
+            &mut jobs,
+            toggle_uri.clone(),
+            WriteAction::Create,
+            Some(toggle_record),
+            "3a",
+        );
+        push(
+            &mut jobs,
+            toggle_uri.clone(),
+            WriteAction::Delete,
+            None,
+            "3b",
+        );
+
+        let mut snapshots = Vec::new();
+        for shards in [1usize, 3] {
+            for did in &all_dids {
+                cleanup_test_data(&pool, did).await;
+            }
+            let client = pool.get().await.unwrap();
+            for did in &all_dids {
+                client
+                    .execute(
+                        "INSERT INTO actor (did, \"indexedAt\") VALUES ($1, NOW()) \
+                         ON CONFLICT (did) DO NOTHING",
+                        &[&did],
+                    )
+                    .await
+                    .unwrap();
+            }
+            drop(client);
+
+            run_shard_pass(&pool, &jobs, shards).await;
+
+            let snap = shard_pass_snapshot(&pool, &post_uris, &authors).await;
+            // Exact counts: 3 likes per post; the toggled like must be gone.
+            assert_eq!(snap.0, vec![3, 3, 3], "like rows wrong at shards={shards}");
+            assert_eq!(snap.1, vec![3, 3, 3], "likeCount wrong at shards={shards}");
+            let client = pool.get().await.unwrap();
+            let toggle_left: i64 = client
+                .query_one(
+                    "SELECT COUNT(*) FROM \"like\" WHERE uri = $1",
+                    &[&toggle_uri],
+                )
+                .await
+                .unwrap()
+                .get(0);
+            assert_eq!(toggle_left, 0, "toggled like survived at shards={shards}");
+            snapshots.push(snap);
+        }
+        assert_eq!(
+            snapshots[0], snapshots[1],
+            "sharded results diverge from single-shard results"
+        );
+
+        for did in &all_dids {
+            cleanup_test_data(&pool, did).await;
+        }
+    }
 }

--- a/rsky-wintermute/src/ingester/mod.rs
+++ b/rsky-wintermute/src/ingester/mod.rs
@@ -757,6 +757,15 @@ impl IngesterManager {
                 }
             };
 
+            // Drop disallowed collections before they occupy the queue: junk
+            // record storms otherwise create crest lag for real events even
+            // though the indexer would discard them at parse.
+            let collection = op.path.split('/').next().unwrap_or("");
+            if !crate::config::record_collection_allowed(collection) {
+                crate::metrics::INGESTER_OPS_FILTERED_TOTAL.inc();
+                continue;
+            }
+
             // Build AT-URI from repo DID + record path
             let uri = format!("at://{}/{}", event.did, op.path);
 
@@ -851,6 +860,15 @@ impl IngesterManager {
                     continue;
                 }
             };
+
+            // Drop disallowed collections before they occupy the queue: junk
+            // record storms otherwise create crest lag for real events even
+            // though the indexer would discard them at parse.
+            let collection = op.path.split('/').next().unwrap_or("");
+            if !crate::config::record_collection_allowed(collection) {
+                crate::metrics::INGESTER_OPS_FILTERED_TOTAL.inc();
+                continue;
+            }
 
             // Build AT-URI from repo DID + record path
             let uri = format!("at://{}/{}", event.did, op.path);

--- a/rsky-wintermute/src/metrics.rs
+++ b/rsky-wintermute/src/metrics.rs
@@ -135,6 +135,14 @@ pub static INGESTER_EVENTS_IN_MEMORY: LazyLock<IntGauge> = LazyLock::new(|| {
     .unwrap()
 });
 
+pub static INGESTER_OPS_FILTERED_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "ingester_ops_filtered_total",
+        "Total firehose ops dropped by the collection allowlist before enqueue"
+    )
+    .unwrap()
+});
+
 /// Errors
 pub static INGESTER_ERRORS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     register_int_counter_vec!(

--- a/rsky-wintermute/src/storage.rs
+++ b/rsky-wintermute/src/storage.rs
@@ -30,6 +30,7 @@ pub struct Storage {
     // head and tombstones pile up there; scanning from the last dequeued key
     // (wrapping when exhausted) avoids re-walking them every batch.
     firehose_live_cursor: std::sync::Mutex<Option<Vec<u8>>>,
+    live_notify: tokio::sync::Notify,
 }
 
 impl Storage {
@@ -149,6 +150,7 @@ impl Storage {
             lmdb_env,
             firehose_backfill_db,
             firehose_live_cursor: std::sync::Mutex::new(None),
+            live_notify: tokio::sync::Notify::new(),
         })
     }
 
@@ -289,7 +291,14 @@ impl Storage {
         self.firehose_live
             .insert(key.as_bytes(), value.as_slice())?;
         crate::metrics::INGESTER_FIREHOSE_LIVE_LENGTH.inc();
+        self.live_notify.notify_one();
         Ok(())
+    }
+
+    /// Block until an enqueue signals the live queue, or `timeout` elapses.
+    /// A permit stored by a `notify_one` that raced ahead completes immediately.
+    pub async fn wait_for_live_enqueue(&self, timeout: std::time::Duration) {
+        drop(tokio::time::timeout(timeout, self.live_notify.notified()).await);
     }
 
     pub fn dequeue_firehose_live(&self) -> Result<Option<(Vec<u8>, IndexJob)>, WintermuteError> {

--- a/rsky-wintermute/src/storage.rs
+++ b/rsky-wintermute/src/storage.rs
@@ -6,6 +6,7 @@ use heed::{Database as HeedDatabase, Env, EnvOpenOptions};
 use std::ops::Bound;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 /// LMDB max map size: 4TB for `firehose_backfill` queue.
 /// Tests use 1GB: repeated 4TB reservations exhaust macOS address space.
@@ -21,6 +22,10 @@ pub struct Storage {
     firehose_events: PartitionHandle,
     repo_backfill: PartitionHandle,
     firehose_live: PartitionHandle,
+    // Sequence-keyed successor to `firehose_live`: monotonic u64 keys mean the
+    // read cursor only moves forward and dequeue tombstones are never
+    // re-scanned. The legacy uri-keyed partition drains first, then this one.
+    firehose_live_seq: PartitionHandle,
     label_live: PartitionHandle,
     cursors: PartitionHandle,
     // LMDB for firehose_backfill - eliminates L0 compaction stalls
@@ -30,6 +35,9 @@ pub struct Storage {
     // head and tombstones pile up there; scanning from the last dequeued key
     // (wrapping when exhausted) avoids re-walking them every batch.
     firehose_live_cursor: std::sync::Mutex<Option<Vec<u8>>>,
+    firehose_live_seq_cursor: std::sync::Mutex<Option<Vec<u8>>>,
+    live_seq_next: AtomicU64,
+    legacy_live_drained: AtomicBool,
     live_notify: tokio::sync::Notify,
 }
 
@@ -103,6 +111,18 @@ impl Storage {
                 .block_size(BLOCK_SIZE),
         )?;
 
+        let firehose_live_seq = db.open_partition(
+            "firehose_live_seq",
+            PartitionCreateOptions::default()
+                .max_memtable_size(MEMTABLE_SIZE)
+                .block_size(BLOCK_SIZE),
+        )?;
+        let live_seq_start = firehose_live_seq.last_key_value()?.map_or(0, |(k, _)| {
+            k.as_ref()
+                .try_into()
+                .map_or(0, |b: [u8; 8]| u64::from_be_bytes(b).saturating_add(1))
+        });
+
         let label_live = db.open_partition(
             "label_live",
             PartitionCreateOptions::default()
@@ -145,11 +165,15 @@ impl Storage {
             firehose_events,
             repo_backfill,
             firehose_live,
+            firehose_live_seq,
             label_live,
             cursors,
             lmdb_env,
             firehose_backfill_db,
             firehose_live_cursor: std::sync::Mutex::new(None),
+            firehose_live_seq_cursor: std::sync::Mutex::new(None),
+            live_seq_next: AtomicU64::new(live_seq_start),
+            legacy_live_drained: AtomicBool::new(false),
             live_notify: tokio::sync::Notify::new(),
         })
     }
@@ -278,18 +302,15 @@ impl Storage {
         Ok(())
     }
 
-    // Firehose live queue (from ingester)
+    // Firehose live queue (from ingester); keys are monotonic so dequeue order
+    // is arrival order and the read cursor never revisits tombstones.
     pub fn enqueue_firehose_live(&self, job: &IndexJob) -> Result<(), WintermuteError> {
-        let key = format!(
-            "{}:{}",
-            job.uri,
-            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
-        );
+        let seq = self.live_seq_next.fetch_add(1, Ordering::Relaxed);
         let mut value = Vec::new();
         ciborium::into_writer(job, &mut value)
             .map_err(|e| WintermuteError::Serialization(format!("failed to serialize job: {e}")))?;
-        self.firehose_live
-            .insert(key.as_bytes(), value.as_slice())?;
+        self.firehose_live_seq
+            .insert(seq.to_be_bytes(), value.as_slice())?;
         crate::metrics::INGESTER_FIREHOSE_LIVE_LENGTH.inc();
         self.live_notify.notify_one();
         Ok(())
@@ -302,18 +323,12 @@ impl Storage {
     }
 
     pub fn dequeue_firehose_live(&self) -> Result<Option<(Vec<u8>, IndexJob)>, WintermuteError> {
-        let mut iter = self.firehose_live.iter();
-        let Some(entry) = iter.next() else {
-            return Ok(None);
-        };
-        let (key, value) = entry?;
-        let key_vec = key.to_vec();
-        let job = ciborium::from_reader(value.as_ref())
-            .map_err(|e| WintermuteError::Serialization(format!("failed to deserialize: {e}")))?;
-        // Remove immediately to prevent re-dequeue race condition
-        self.firehose_live.remove(&key_vec)?;
-        crate::metrics::INGESTER_FIREHOSE_LIVE_LENGTH.dec();
-        Ok(Some((key_vec, job)))
+        let mut batch = self.dequeue_firehose_live_batch(1)?;
+        if batch.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(batch.remove(0)))
+        }
     }
 
     #[allow(clippy::missing_const_for_fn)]
@@ -341,14 +356,93 @@ impl Storage {
         Ok(())
     }
 
-    /// Dequeue up to `limit` `firehose_live` jobs with a single sweep-cursor
-    /// range scan. Scanning resumes after the last dequeued key and wraps to
-    /// the partition start when exhausted, so each batch walks fresh keyspace
-    /// instead of re-skipping the tombstones of every prior batch. Per-record
-    /// ordering holds because keys are uri-first with a timestamp suffix.
+    /// Dequeue up to `limit` live jobs in arrival order. The legacy uri-keyed
+    /// partition drains completely first (existing entries predate the
+    /// sequence keys); afterwards the forward-only sequence scan starts after
+    /// the last dequeued key, so removal tombstones are never revisited.
+    pub fn dequeue_firehose_live_batch(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<(Vec<u8>, IndexJob)>, WintermuteError> {
+        let start = std::time::Instant::now();
+        let mut legacy = false;
+        let results = if self.legacy_live_drained.load(Ordering::Relaxed) {
+            self.dequeue_live_seq_batch(limit)?
+        } else {
+            let legacy_results = self.dequeue_live_legacy_batch(limit)?;
+            if legacy_results.is_empty() {
+                self.legacy_live_drained.store(true, Ordering::Relaxed);
+                tracing::info!("legacy firehose_live partition drained, switching to seq keys");
+                self.dequeue_live_seq_batch(limit)?
+            } else {
+                legacy = true;
+                legacy_results
+            }
+        };
+        let elapsed_ms = start.elapsed().as_millis();
+        if elapsed_ms > 1000 {
+            tracing::warn!(
+                "SLOW live dequeue: {elapsed_ms}ms for {} jobs (legacy={legacy})",
+                results.len()
+            );
+        }
+        Ok(results)
+    }
+
+    /// Forward-only scan of the sequence-keyed partition.
+    fn dequeue_live_seq_batch(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<(Vec<u8>, IndexJob)>, WintermuteError> {
+        let cursor = self
+            .firehose_live_seq_cursor
+            .lock()
+            .map_or(None, |c| c.clone());
+
+        let mut results = Vec::with_capacity(limit);
+        let mut poisoned: Vec<Vec<u8>> = Vec::new();
+        if let Some(after) = cursor {
+            let range = (Bound::Excluded(after), Bound::<Vec<u8>>::Unbounded);
+            Self::collect_live_entries(
+                self.firehose_live_seq.range(range),
+                limit,
+                &mut results,
+                &mut poisoned,
+            )?;
+        } else {
+            Self::collect_live_entries(
+                self.firehose_live_seq.iter(),
+                limit,
+                &mut results,
+                &mut poisoned,
+            )?;
+        }
+
+        let last_key = results
+            .last()
+            .map(|(k, _)| k.clone())
+            .or_else(|| poisoned.last().cloned());
+        if let (Some(key), Ok(mut guard)) = (last_key, self.firehose_live_seq_cursor.lock()) {
+            *guard = Some(key);
+        }
+
+        for (key, _) in &results {
+            self.firehose_live_seq.remove(key.as_slice())?;
+        }
+        for key in &poisoned {
+            self.firehose_live_seq.remove(key.as_slice())?;
+        }
+
+        #[allow(clippy::cast_possible_wrap)]
+        crate::metrics::INGESTER_FIREHOSE_LIVE_LENGTH.sub((results.len() + poisoned.len()) as i64);
+        Ok(results)
+    }
+
+    /// Sweep-cursor scan of the legacy uri-keyed partition: resumes after the
+    /// last dequeued key and wraps to the partition start when exhausted.
     /// Undeserializable entries are removed and skipped so a poison entry
     /// cannot wedge the sweep.
-    pub fn dequeue_firehose_live_batch(
+    fn dequeue_live_legacy_batch(
         &self,
         limit: usize,
     ) -> Result<Vec<(Vec<u8>, IndexJob)>, WintermuteError> {
@@ -870,7 +964,7 @@ impl Storage {
     }
 
     pub fn firehose_live_len(&self) -> Result<usize, WintermuteError> {
-        Ok(self.firehose_live.len()?)
+        Ok(self.firehose_live.len()? + self.firehose_live_seq.len()?)
     }
 
     pub fn firehose_backfill_len(&self) -> Result<usize, WintermuteError> {
@@ -1525,5 +1619,90 @@ mod tests {
         assert_eq!(storage.repo_backfill_len().unwrap(), 0);
         storage.clear_repo_backfill().unwrap();
         assert_eq!(storage.repo_backfill_len().unwrap(), 0);
+    }
+
+    fn live_job(uri: &str) -> IndexJob {
+        IndexJob {
+            uri: uri.to_owned(),
+            cid: "cid".to_owned(),
+            action: WriteAction::Create,
+            record: None,
+            indexed_at: "2026-08-01T00:00:00.000Z".to_owned(),
+            rev: "3a".to_owned(),
+        }
+    }
+
+    #[test]
+    fn live_queue_dequeues_in_arrival_order() {
+        let (storage, _dir) = setup_test_storage();
+        for i in 0..5 {
+            storage
+                .enqueue_firehose_live(&live_job(&format!(
+                    "at://did:plc:a/app.bsky.feed.post/r{i}"
+                )))
+                .unwrap();
+        }
+        let batch = storage.dequeue_firehose_live_batch(10).unwrap();
+        assert_eq!(batch.len(), 5);
+        for (i, (key, job)) in batch.iter().enumerate() {
+            assert_eq!(job.uri, format!("at://did:plc:a/app.bsky.feed.post/r{i}"));
+            assert_eq!(key.len(), 8);
+        }
+        storage
+            .enqueue_firehose_live(&live_job("at://did:plc:a/app.bsky.feed.post/r5"))
+            .unwrap();
+        let next = storage.dequeue_firehose_live_batch(10).unwrap();
+        assert_eq!(next.len(), 1);
+        assert_eq!(next[0].1.uri, "at://did:plc:a/app.bsky.feed.post/r5");
+        assert!(storage.dequeue_firehose_live_batch(10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn live_queue_drains_legacy_partition_first() {
+        let (storage, _dir) = setup_test_storage();
+        for i in 0..3 {
+            let job = live_job(&format!("at://did:plc:legacy/app.bsky.feed.post/l{i}"));
+            let mut value = Vec::new();
+            ciborium::into_writer(&job, &mut value).unwrap();
+            storage
+                .firehose_live
+                .insert(format!("{}:{i}", job.uri).as_bytes(), value.as_slice())
+                .unwrap();
+        }
+        storage
+            .enqueue_firehose_live(&live_job("at://did:plc:new/app.bsky.feed.post/n0"))
+            .unwrap();
+        assert_eq!(storage.firehose_live_len().unwrap(), 4);
+
+        let first = storage.dequeue_firehose_live_batch(10).unwrap();
+        assert_eq!(first.len(), 3);
+        assert!(first.iter().all(|(_, j)| j.uri.contains("did:plc:legacy")));
+
+        let second = storage.dequeue_firehose_live_batch(10).unwrap();
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0].1.uri, "at://did:plc:new/app.bsky.feed.post/n0");
+        assert!(storage.legacy_live_drained.load(Ordering::Relaxed));
+        assert_eq!(storage.firehose_live_len().unwrap(), 0);
+    }
+
+    #[test]
+    fn live_queue_keys_stay_monotonic_across_reopen() {
+        let temp_dir = TempDir::with_prefix("wintermute_test_").unwrap();
+        let db_path = temp_dir.path().join("test_db");
+        {
+            let storage = Storage::new(Some(db_path.clone())).unwrap();
+            storage
+                .enqueue_firehose_live(&live_job("at://did:plc:a/app.bsky.feed.post/first"))
+                .unwrap();
+        }
+        let storage = Storage::new(Some(db_path)).unwrap();
+        storage
+            .enqueue_firehose_live(&live_job("at://did:plc:a/app.bsky.feed.post/second"))
+            .unwrap();
+        let batch = storage.dequeue_firehose_live_batch(10).unwrap();
+        assert_eq!(batch.len(), 2);
+        assert_eq!(batch[0].1.uri, "at://did:plc:a/app.bsky.feed.post/first");
+        assert_eq!(batch[1].1.uri, "at://did:plc:a/app.bsky.feed.post/second");
+        assert!(batch[0].0 < batch[1].0);
     }
 }


### PR DESCRIPTION
Parallel DID-sharded live batch processing with enqueue wakeup, a sequence-keyed FIFO live queue replacing the tombstone-swept uri keyspace, and via-attribution capture into the typed tables. Deployed as v0.5.0-0.7.0.