### PR TITLE
fix(rsky-relay): bound relay memory and drain accept backlog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8278,7 +8278,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-relay"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "chrono",

--- a/rsky-relay/Cargo.toml
+++ b/rsky-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-relay"
-version = "0.1.1"
+version = "0.1.2"
 default-run = "rsky-relay"
 edition = "2024"
 

--- a/rsky-relay/src/config.rs
+++ b/rsky-relay/src/config.rs
@@ -21,6 +21,7 @@ pub static METRICS_LISTEN: LazyLock<Option<String>> =
 // Bounds unconsumed intake to capacity * frame_size while the validator lags;
 // crawler backpressure engages when the ring nears full.
 pub const CAPACITY_MSGS: usize = 1 << 13;
+pub const INTAKE_BYTE_BUDGET: usize = 2 * 1024 * 1024 * 1024;
 pub const CAPACITY_REQS: usize = 1 << 12;
 pub const CAPACITY_STATUS: usize = 1 << 10;
 pub const WORKERS_CRAWLERS: usize = 4;

--- a/rsky-relay/src/config.rs
+++ b/rsky-relay/src/config.rs
@@ -22,6 +22,7 @@ pub static METRICS_LISTEN: LazyLock<Option<String>> =
 // crawler backpressure engages when the ring nears full.
 pub const CAPACITY_MSGS: usize = 1 << 13;
 pub const INTAKE_BYTE_BUDGET: usize = 2 * 1024 * 1024 * 1024;
+pub const PUBLISHER_MAX_WRITE_BUFFER: usize = 32 * 1024 * 1024;
 pub const CAPACITY_REQS: usize = 1 << 12;
 pub const CAPACITY_STATUS: usize = 1 << 10;
 pub const WORKERS_CRAWLERS: usize = 4;

--- a/rsky-relay/src/config.rs
+++ b/rsky-relay/src/config.rs
@@ -18,7 +18,9 @@ pub static METRICS_LISTEN: LazyLock<Option<String>> =
     LazyLock::new(|| env::var("RELAY_METRICS_LISTEN").ok().filter(|s| !s.is_empty()));
 
 // main
-pub const CAPACITY_MSGS: usize = 1 << 16;
+// Bounds unconsumed intake to capacity * frame_size while the validator lags;
+// crawler backpressure engages when the ring nears full.
+pub const CAPACITY_MSGS: usize = 1 << 13;
 pub const CAPACITY_REQS: usize = 1 << 12;
 pub const CAPACITY_STATUS: usize = 1 << 10;
 pub const WORKERS_CRAWLERS: usize = 4;

--- a/rsky-relay/src/crawler/connection.rs
+++ b/rsky-relay/src/crawler/connection.rs
@@ -70,7 +70,9 @@ impl Connection {
     // true: polled
     pub fn poll(&mut self) -> Result<bool, ConnectionError> {
         for _ in 0..128 {
-            if self.message_tx.remaining() < 16 {
+            if self.message_tx.remaining() < 16
+                || crate::types::intake_bytes() > crate::config::INTAKE_BYTE_BUDGET
+            {
                 return Ok(false);
             }
 
@@ -98,6 +100,7 @@ impl Connection {
             };
 
             let mut slot = self.message_tx.send_ref()?;
+            crate::types::intake_bytes_add(bytes.len());
             slot.data = bytes;
             slot.hostname.clone_from(&self.hostname);
         }

--- a/rsky-relay/src/publisher/connection.rs
+++ b/rsky-relay/src/publisher/connection.rs
@@ -51,7 +51,12 @@ impl Connection {
     pub fn connect(
         addr: SocketAddr, stream: MaybeTlsStream<TcpStream>, cursor: Cursor,
     ) -> Result<Self, ConnectionError> {
-        let client = tungstenite::accept(stream)?;
+        // Without a cap the write buffer default is unbounded, so one
+        // subscriber catching up from an old cursor queues its whole backlog
+        // in memory; WriteBufferFull backpressure only exists below a cap.
+        let config = tungstenite::protocol::WebSocketConfig::default()
+            .max_write_buffer_size(crate::config::PUBLISHER_MAX_WRITE_BUFFER);
+        let client = tungstenite::accept_with_config(stream, Some(config))?;
         match client.get_ref() {
             MaybeTlsStream::Rustls(stream) => {
                 stream.get_ref().set_nonblocking(true)?;

--- a/rsky-relay/src/server/server.rs
+++ b/rsky-relay/src/server/server.rs
@@ -79,6 +79,7 @@ pub fn fetch_page_with_retry<F: HostListFetcher + ?Sized>(
 }
 
 const SLEEP: Duration = Duration::from_millis(10);
+const ACCEPTS_PER_TICK: usize = 64;
 
 #[cfg(not(feature = "labeler"))]
 const PATH_LIST_HOSTS: &str = "/xrpc/com.atproto.sync.listHosts";
@@ -261,27 +262,35 @@ impl Server {
             self.last = Instant::now();
         }
 
-        match self.listener.accept() {
-            Ok((mut stream, addr)) => {
-                tracing::trace!(%addr, "received request");
-                let stream = if let Some(tls_config) = self.tls_config.clone() {
-                    let mut conn = ServerConnection::new(tls_config)?;
-                    if let Err(err) = conn.complete_io(&mut stream) {
-                        tracing::info!(%addr, %err, "tls handshake error");
+        // Drain the accept backlog each tick: one accept per sleep caps intake
+        // at ~100/s, which overflows the listen queue whenever every
+        // subscriber reconnects at once.
+        let mut accepted = 0;
+        loop {
+            match self.listener.accept() {
+                Ok((mut stream, addr)) => {
+                    tracing::trace!(%addr, "received request");
+                    let stream = if let Some(tls_config) = self.tls_config.clone() {
+                        let mut conn = ServerConnection::new(tls_config)?;
+                        if let Err(err) = conn.complete_io(&mut stream) {
+                            tracing::info!(%addr, %err, "tls handshake error");
+                        }
+                        let stream = StreamOwned::new(conn, stream);
+                        MaybeTlsStream::Rustls(stream)
+                    } else {
+                        MaybeTlsStream::Plain(stream)
+                    };
+                    if let Err(err) = self.handle_stream(ErrorOnDropTcpStream(Some(stream)), addr) {
+                        tracing::info!(%addr, %err, "invalid request");
                     }
-                    let stream = StreamOwned::new(conn, stream);
-                    MaybeTlsStream::Rustls(stream)
-                } else {
-                    MaybeTlsStream::Plain(stream)
-                };
-                if let Err(err) = self.handle_stream(ErrorOnDropTcpStream(Some(stream)), addr) {
-                    tracing::info!(%addr, %err, "invalid request");
+                    accepted += 1;
+                    if accepted >= ACCEPTS_PER_TICK {
+                        break;
+                    }
                 }
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
+                Err(e) => Err(e)?,
             }
-            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
-                return Ok(true);
-            }
-            Err(e) => Err(e)?,
         }
 
         Ok(true)

--- a/rsky-relay/src/types.rs
+++ b/rsky-relay/src/types.rs
@@ -67,10 +67,36 @@ impl Recycle<Message> for MessageRecycle {
     // A released slot must drop its frame: retaining the Bytes turns the ring
     // into a frame cache of capacity * frame_size, which reaches tens of GiB
     // during large-commit floods.
-    fn recycle(&self, msg: &mut Message) {
-        msg.data = Bytes::new();
-        msg.hostname.clear();
+    fn recycle(&self, element: &mut Message) {
+        element.data = Bytes::new();
+        element.hostname.clear();
     }
+}
+
+// Unconsumed intake bytes across the ring. Slot count alone cannot bound
+// memory because commit frames vary from bytes to many megabytes; crawlers
+// pause reading once this passes the budget.
+static INFLIGHT_INTAKE_BYTES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+pub fn intake_bytes_add(len: usize) {
+    INFLIGHT_INTAKE_BYTES.fetch_add(len, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub fn intake_bytes_sub(len: usize) {
+    #[expect(clippy::unwrap_used)]
+    INFLIGHT_INTAKE_BYTES
+        .fetch_update(
+            std::sync::atomic::Ordering::Relaxed,
+            std::sync::atomic::Ordering::Relaxed,
+            |v| Some(v.saturating_sub(len)),
+        )
+        .unwrap();
+}
+
+#[must_use]
+pub fn intake_bytes() -> usize {
+    INFLIGHT_INTAKE_BYTES.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
@@ -271,6 +297,18 @@ mod tests {
         recycler.recycle(&mut msg);
         assert!(msg.data.is_empty());
         assert!(msg.hostname.is_empty());
+    }
+
+    #[test]
+    fn intake_byte_accounting_saturates_at_zero() {
+        let before = intake_bytes();
+        intake_bytes_add(10);
+        assert_eq!(intake_bytes(), before + 10);
+        intake_bytes_sub(before + 25);
+        assert_eq!(intake_bytes(), 0);
+        intake_bytes_add(7);
+        intake_bytes_sub(7);
+        assert_eq!(intake_bytes(), 0);
     }
 
     #[test]

--- a/rsky-relay/src/types.rs
+++ b/rsky-relay/src/types.rs
@@ -64,7 +64,13 @@ impl Recycle<Message> for MessageRecycle {
         Message { data: Bytes::new(), hostname: String::new() }
     }
 
-    fn recycle(&self, _: &mut Message) {}
+    // A released slot must drop its frame: retaining the Bytes turns the ring
+    // into a frame cache of capacity * frame_size, which reaches tens of GiB
+    // during large-commit floods.
+    fn recycle(&self, msg: &mut Message) {
+        msg.data = Bytes::new();
+        msg.hostname.clear();
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Default)]

--- a/rsky-relay/src/types.rs
+++ b/rsky-relay/src/types.rs
@@ -262,15 +262,15 @@ mod tests {
     }
 
     #[test]
-    fn message_recycle_no_op() {
+    fn message_recycle_clears_slot() {
         let recycler = MessageRecycle;
         let mut msg = recycler.new_element();
         msg.data = Bytes::from_static(b"x");
         msg.hostname = "h".to_owned();
-        // recycle is a no-op; message must be untouched.
+        // recycle must drop the frame so released ring slots hold no data
         recycler.recycle(&mut msg);
-        assert_eq!(msg.data, Bytes::from_static(b"x"));
-        assert_eq!(msg.hostname, "h");
+        assert!(msg.data.is_empty());
+        assert!(msg.hostname.is_empty());
     }
 
     #[test]

--- a/rsky-relay/src/validator/manager.rs
+++ b/rsky-relay/src/validator/manager.rs
@@ -292,7 +292,9 @@ impl<R: IdentityResolver> Manager<R> {
                         continue;
                     }
                     self.resolver.request_direct(did);
-                    tracing::warn!(%did, "resolver pending; publishing under lenient mode");
+                    // debug: floods of pending DIDs otherwise churn the whole
+                    // journal in minutes; the metrics counter is the signal
+                    tracing::debug!(%did, "resolver pending; publishing under lenient mode");
                     metrics::record_validator_passed_with_warning("resolver_pending");
                     (None, None)
                 };

--- a/rsky-relay/src/validator/manager.rs
+++ b/rsky-relay/src/validator/manager.rs
@@ -203,6 +203,7 @@ impl<R: IdentityResolver> Manager<R> {
             };
 
             let host = &msg.hostname;
+            crate::types::intake_bytes_sub(msg.data.len());
             let span = tracing::info_span!("msg_recv", %host, len = %msg.data.len());
             let _enter = span.enter();
             let event = match SubscribeReposEvent::parse(&msg.data) {

--- a/rsky-relay/src/validator/resolver.rs
+++ b/rsky-relay/src/validator/resolver.rs
@@ -38,6 +38,10 @@ pub trait IdentityResolver: Send {
 const POLL_TIMEOUT: Duration = Duration::from_micros(10);
 const REQ_TIMEOUT: Duration = Duration::from_secs(30);
 const TCP_KEEPALIVE: Duration = Duration::from_secs(300);
+// Hard ceiling on concurrent DID fetches: event floods from never-before-seen
+// DIDs must not grow the future set without bound. Skipped DIDs retry on
+// their next event once capacity frees.
+const MAX_INFLIGHT_FETCHES: usize = 4096;
 
 const PLC_URL: &str = "https://plc.directory";
 const PLC_EXPORT: &str = "export?count=1000&after";
@@ -73,6 +77,10 @@ pub struct Resolver {
 
 impl Resolver {
     pub fn new() -> Result<Self, ResolverError> {
+        Self::with_db_path("plc_directory.db")
+    }
+
+    fn with_db_path(db_path: &str) -> Result<Self, ResolverError> {
         #[expect(clippy::unwrap_used)]
         let cache = LruCache::new(NonZeroUsize::new(CAPACITY_CACHE).unwrap());
         let flag = if *DO_PLC_EXPORT {
@@ -80,8 +88,7 @@ impl Resolver {
         } else {
             OpenFlags::SQLITE_OPEN_READ_ONLY
         };
-        let conn =
-            Connection::open_with_flags("plc_directory.db", flag | OpenFlags::SQLITE_OPEN_CREATE)?;
+        let conn = Connection::open_with_flags(db_path, flag | OpenFlags::SQLITE_OPEN_CREATE)?;
         conn.busy_timeout(std::time::Duration::from_secs(5))?;
         conn.execute_batch("PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 1000;")?;
         if *DO_PLC_EXPORT {
@@ -169,29 +176,34 @@ impl Resolver {
     }
 
     fn request_inner(&mut self, did: &str, force_direct: bool) {
-        self.inflight.insert(did.to_owned());
+        // One fetch per DID at a time, bounded overall: repeat events for a
+        // pending DID must not stack additional futures.
+        if self.inflight.contains(did) || self.futures.len() >= MAX_INFLIGHT_FETCHES {
+            return;
+        }
         if let Some(plc) = did.strip_prefix("did:plc:") {
             let plc = if *DO_PLC_EXPORT && !force_direct { None } else { Some(plc) };
-            self.send_req(None, plc);
+            self.inflight.insert(did.to_owned());
+            self.send_req(Some(did), None, plc);
         } else if let Some(web) = did.strip_prefix("did:web:") {
             let Ok(web) = urlencoding::decode(web) else {
                 tracing::debug!(%did, "invalid did");
                 return;
             };
-            self.send_req(Some(&web), None);
+            self.inflight.insert(did.to_owned());
+            self.send_req(Some(did), Some(&web), None);
         } else {
             tracing::debug!(%did, "invalid did");
-            self.inflight.remove(did);
         }
     }
 
-    fn send_req(&mut self, web: Option<&str>, plc: Option<&str>) {
-        let (req, query) = if let Some(web) = web {
+    fn send_req(&mut self, did: Option<&str>, web: Option<&str>, plc: Option<&str>) {
+        let (req, query) = if let (Some(did), Some(web)) = (did, web) {
             tracing::trace!("fetching did");
-            (self.client.get(format!("https://{web}/{DOC_PATH}")), Query::Did(web.to_owned()))
-        } else if let Some(plc) = plc {
+            (self.client.get(format!("https://{web}/{DOC_PATH}")), Query::Did(did.to_owned()))
+        } else if let (Some(did), Some(plc)) = (did, plc) {
             tracing::trace!("fetching did");
-            (self.client.get(format!("{PLC_URL}/did:plc:{plc}")), Query::Did(plc.to_owned()))
+            (self.client.get(format!("{PLC_URL}/did:plc:{plc}")), Query::Did(did.to_owned()))
         } else if let Some(after) = self.after.take() {
             tracing::trace!(%after, "fetching after");
             self.last = Instant::now();
@@ -215,12 +227,14 @@ impl Resolver {
             match res {
                 Ok(bytes) => match query {
                     Query::Did(query) => {
+                        // Clear inflight on every fetch outcome so the DID can
+                        // be retried; a stuck entry would pin it unresolved.
+                        self.inflight.remove(&query);
                         if let Some((did, (pds, key))) = parse_did_doc(&bytes) {
-                            if query != did[8..] {
-                                tracing::warn!(%query, found = %&did[8..], "did query mismatch");
+                            if query != did {
+                                tracing::warn!(%query, %did, "did query mismatch");
                                 return Ok(Vec::new());
                             }
-                            self.inflight.remove(&did);
                             self.cache.put(did.clone(), (pds, key));
                             return Ok(vec![did]);
                         }
@@ -250,7 +264,7 @@ impl Resolver {
                         drop(stmt);
                         tx.commit()?;
                         if count == 1000 {
-                            self.send_req(None, None);
+                            self.send_req(None, None, None);
                         } else {
                             // no more plc operations, drain inflight dids
                             dids.extend(
@@ -262,14 +276,20 @@ impl Resolver {
                 },
                 Err(err) => {
                     tracing::debug!(%err, "fetch error");
-                    // Restore the after cursor on export failure so exports can be retried
-                    if let Query::Export(after) = query {
-                        self.after = Some(after);
+                    match query {
+                        // Restore the after cursor on export failure so exports can be retried
+                        Query::Export(after) => {
+                            self.after = Some(after);
+                        }
+                        // Clear inflight on failed DID fetches so they can be retried
+                        Query::Did(query) => {
+                            self.inflight.remove(&query);
+                        }
                     }
                 }
             }
         } else if *DO_PLC_EXPORT && self.last.elapsed() > PLC_EXPORT_INTERVAL {
-            self.send_req(None, None);
+            self.send_req(None, None, None);
         }
         Ok(Vec::new())
     }
@@ -475,5 +495,57 @@ mod tests {
             Some((Some(pds), _key)) => assert_eq!(pds.as_ref(), "pds.example.com"),
             other => panic!("expected Some endpoint, got {other:?}"),
         }
+    }
+
+    fn test_resolver(dir: &tempfile::TempDir) -> Resolver {
+        let db_path = dir.path().join("plc_directory.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             CREATE TABLE plc_operations (cid TEXT, did TEXT, created_at TEXT, nullified INT, operation BLOB);
+             CREATE TABLE plc_keys (did TEXT PRIMARY KEY, pds_endpoint TEXT, pds_key TEXT, labeler_endpoint TEXT, labeler_key TEXT);
+             INSERT INTO plc_operations (cid, did, created_at, nullified, operation)
+             VALUES ('cid', 'did:plc:seed', '2026-01-01T00:00:00Z', 0, x'7b7d');",
+        )
+        .unwrap();
+        drop(conn);
+        Resolver::with_db_path(db_path.to_str().unwrap()).unwrap()
+    }
+
+    #[test]
+    fn repeat_requests_for_pending_did_do_not_stack_futures() {
+        let dir = tempfile::TempDir::with_prefix("resolver_test_").unwrap();
+        let mut resolver = test_resolver(&dir);
+        for _ in 0..5 {
+            resolver.request_direct("did:web:pds.example.com");
+        }
+        assert_eq!(resolver.futures.len(), 1);
+        assert_eq!(resolver.inflight.len(), 1);
+        for _ in 0..5 {
+            resolver.request_direct("did:plc:aaaabbbbccccdddd");
+        }
+        assert_eq!(resolver.futures.len(), 2);
+        assert_eq!(resolver.inflight.len(), 2);
+    }
+
+    #[test]
+    fn distinct_did_fetches_are_capped() {
+        let dir = tempfile::TempDir::with_prefix("resolver_test_").unwrap();
+        let mut resolver = test_resolver(&dir);
+        for i in 0..(MAX_INFLIGHT_FETCHES + 10) {
+            resolver.request_direct(&format!("did:web:host{i}.example.com"));
+        }
+        assert_eq!(resolver.futures.len(), MAX_INFLIGHT_FETCHES);
+        assert_eq!(resolver.inflight.len(), MAX_INFLIGHT_FETCHES);
+    }
+
+    #[test]
+    fn invalid_did_leaves_no_inflight_entry() {
+        let dir = tempfile::TempDir::with_prefix("resolver_test_").unwrap();
+        let mut resolver = test_resolver(&dir);
+        resolver.request_direct("did:example:nonsense");
+        resolver.request_direct("not-a-did");
+        assert_eq!(resolver.futures.len(), 0);
+        assert_eq!(resolver.inflight.len(), 0);
     }
 }


### PR DESCRIPTION
Clears intake ring slots on recycle, bounds unconsumed intake by bytes, caps the publisher per-subscriber write buffer, dedups and caps resolver DID fetches, and drains up to 64 accepts per server tick. Fixes the OOM crash loop behind the atproto.africa 502 alerts.