### PR TITLE
feat(wintermute): flag-gated record-table skip for boilerplate collections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/src/bin/car_loader.rs
+++ b/rsky-wintermute/src/bin/car_loader.rs
@@ -444,7 +444,13 @@ async fn write_batch(
 
     let n = batch_jobs.len() as u64;
     // bulk_load = true: skip inline aggregates + the like-insert semaphore.
-    let (_results, batch_failed) = IndexerManager::process_jobs_batch(pool, batch_jobs, true).await;
+    let (_results, batch_failed) = IndexerManager::process_jobs_batch(
+        pool,
+        batch_jobs,
+        true,
+        *rsky_wintermute::config::RECORD_SKIP_BOILERPLATE,
+    )
+    .await;
     batch_jobs.clear();
 
     if batch_failed {
@@ -812,7 +818,13 @@ async fn load_single_repo(args: &Args, pool: &Pool, did: &str) -> Result<()> {
         .into_iter()
         .map(|j| (j.uri.clone().into_bytes(), j))
         .collect();
-    let (results, batch_failed) = IndexerManager::process_jobs_batch(pool, &jobs, true).await;
+    let (results, batch_failed) = IndexerManager::process_jobs_batch(
+        pool,
+        &jobs,
+        true,
+        *rsky_wintermute::config::RECORD_SKIP_BOILERPLATE,
+    )
+    .await;
     let errs = results.iter().filter(|(_, r)| r.is_err()).count();
     jobs.clear();
     tracing::info!(

--- a/rsky-wintermute/src/bin/direct_index.rs
+++ b/rsky-wintermute/src/bin/direct_index.rs
@@ -217,7 +217,13 @@ async fn process_did(
             };
 
             // Index directly to PostgreSQL
-            if let Err(e) = IndexerManager::process_job(pool, &job).await {
+            if let Err(e) = IndexerManager::process_job(
+                pool,
+                &job,
+                *rsky_wintermute::config::RECORD_SKIP_BOILERPLATE,
+            )
+            .await
+            {
                 eprintln!("  Warning: failed to index {}: {}", job.uri, e);
             } else {
                 indexed_count += 1;

--- a/rsky-wintermute/src/bin/firehose_catchup.rs
+++ b/rsky-wintermute/src/bin/firehose_catchup.rs
@@ -171,7 +171,13 @@ async fn main() -> Result<()> {
                         let pool_clone = Arc::clone(&pool);
                         let processed_clone = Arc::clone(&processed);
                         tokio::spawn(async move {
-                            if let Err(e) = IndexerManager::process_job(&pool_clone, &job).await {
+                            if let Err(e) = IndexerManager::process_job(
+                                &pool_clone,
+                                &job,
+                                *rsky_wintermute::config::RECORD_SKIP_BOILERPLATE,
+                            )
+                            .await
+                            {
                                 tracing::debug!("indexing failed for {}: {e}", job.uri);
                             }
                             processed_clone.fetch_add(1, Ordering::Relaxed);

--- a/rsky-wintermute/src/config.rs
+++ b/rsky-wintermute/src/config.rs
@@ -208,6 +208,25 @@ pub static BACKFILLER_DB_POOL_SIZE: LazyLock<usize> = LazyLock::new(|| {
         .unwrap_or(32) // Default: 32 connections for backfiller (matches worker count)
 });
 
+/// Stop writing like/follow/repost/block rows to the record table once the
+/// dataplane synthesizes those records from the typed tables.
+pub static RECORD_SKIP_BOILERPLATE: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var("RECORD_SKIP_BOILERPLATE")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false)
+});
+
+#[must_use]
+pub fn boilerplate_collection(collection: &str) -> bool {
+    matches!(
+        collection,
+        "app.bsky.feed.like"
+            | "app.bsky.feed.repost"
+            | "app.bsky.graph.follow"
+            | "app.bsky.graph.block"
+    )
+}
+
 // Comma-separated NSID prefixes (e.g. "app.bsky.,chat.bsky.,site.standard.") allowed in the record store. Empty = unset.
 pub static RECORD_COLLECTION_ALLOWLIST: LazyLock<Vec<String>> = LazyLock::new(|| {
     std::env::var("RECORD_COLLECTION_ALLOWLIST")

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -474,12 +474,17 @@ impl IndexerManager {
         shard_batches: &[Vec<(Vec<u8>, IndexJob)>],
         bulk_mode: bool,
     ) -> Vec<(Vec<u8>, Result<(), WintermuteError>)> {
-        futures::future::join_all(
-            shard_batches
-                .iter()
-                .filter(|shard| !shard.is_empty())
-                .map(|shard| Box::pin(Self::process_jobs_batch(pool, shard, bulk_mode))),
-        )
+        let skip_boilerplate = *crate::config::RECORD_SKIP_BOILERPLATE;
+        futures::future::join_all(shard_batches.iter().filter(|shard| !shard.is_empty()).map(
+            |shard| {
+                Box::pin(Self::process_jobs_batch(
+                    pool,
+                    shard,
+                    bulk_mode,
+                    skip_boilerplate,
+                ))
+            },
+        ))
         .await
         .into_iter()
         .flat_map(|(results, _batch_failed)| results)
@@ -618,7 +623,13 @@ impl IndexerManager {
             // Process the entire batch with batch INSERT statements
             let process_start = Instant::now();
             let bulk_mode = !*crate::config::LIVE_AGGREGATES;
-            let (results, _batch_failed) = Self::process_jobs_batch(&pool, &jobs, bulk_mode).await;
+            let (results, _batch_failed) = Self::process_jobs_batch(
+                &pool,
+                &jobs,
+                bulk_mode,
+                *crate::config::RECORD_SKIP_BOILERPLATE,
+            )
+            .await;
             let process_ms = process_start.elapsed().as_millis();
 
             // Handle results - remove jobs from queue
@@ -863,7 +874,8 @@ impl IndexerManager {
             let pool = self.pool_backfill.clone();
 
             let task = tokio::spawn(async move {
-                let result = Self::process_job(&pool, &job).await;
+                let result =
+                    Self::process_job(&pool, &job, *crate::config::RECORD_SKIP_BOILERPLATE).await;
                 drop(permit);
                 (key, source, result)
             });
@@ -1131,7 +1143,11 @@ impl IndexerManager {
         Ok(result.is_some())
     }
 
-    pub async fn process_job(pool: &Pool, job: &IndexJob) -> Result<(), WintermuteError> {
+    pub async fn process_job(
+        pool: &Pool,
+        job: &IndexJob,
+        skip_boilerplate: bool,
+    ) -> Result<(), WintermuteError> {
         use crate::metrics;
 
         tracing::debug!(
@@ -1177,16 +1193,23 @@ impl IndexerManager {
                     WintermuteError::Other("missing record for create/update".into())
                 })?;
 
-                let applied = Self::insert_generic_record(
-                    &client,
-                    &job.uri,
-                    &job.cid,
-                    did.as_str(),
-                    record_json,
-                    &job.rev,
-                    &job.indexed_at,
-                )
-                .await?;
+                // Boilerplate collections skip the record table once the
+                // dataplane synthesizes them; typed ON CONFLICT absorbs replays.
+                let applied =
+                    if skip_boilerplate && crate::config::boilerplate_collection(&collection) {
+                        true
+                    } else {
+                        Self::insert_generic_record(
+                            &client,
+                            &job.uri,
+                            &job.cid,
+                            did.as_str(),
+                            record_json,
+                            &job.rev,
+                            &job.indexed_at,
+                        )
+                        .await?
+                    };
 
                 if !applied {
                     metrics::INDEXER_STALE_WRITES_SKIPPED_TOTAL.inc();
@@ -1417,7 +1440,15 @@ impl IndexerManager {
                 }
             }
             WriteAction::Delete => {
-                let applied = Self::delete_generic_record(&client, &job.uri, &job.rev).await?;
+                // Boilerplate deletes bypass the record gate: the typed
+                // delete is idempotent when the row is already absent.
+                let applied =
+                    if skip_boilerplate && crate::config::boilerplate_collection(&collection) {
+                        drop(Self::delete_generic_record(&client, &job.uri, &job.rev).await);
+                        true
+                    } else {
+                        Self::delete_generic_record(&client, &job.uri, &job.rev).await?
+                    };
 
                 if !applied {
                     return Ok(());
@@ -1497,6 +1528,7 @@ impl IndexerManager {
         pool: &Pool,
         jobs: &[(Vec<u8>, IndexJob)],
         bulk_load: bool,
+        skip_boilerplate: bool,
     ) -> (Vec<(Vec<u8>, Result<(), WintermuteError>)>, bool) {
         if jobs.is_empty() {
             return (Vec::new(), false);
@@ -1562,7 +1594,10 @@ impl IndexerManager {
                     Box::pin(async move {
                         let mut out = Vec::with_capacity(group.len());
                         for (key, job) in group {
-                            out.push((key.clone(), Box::pin(Self::process_job(pool, job)).await));
+                            out.push((
+                                key.clone(),
+                                Box::pin(Self::process_job(pool, job, skip_boilerplate)).await,
+                            ));
                         }
                         out
                     })
@@ -1590,16 +1625,26 @@ impl IndexerManager {
         // phase split must clear the old row first, or the new record is
         // silently dropped on its (subject, creator)-style unique conflict.
         if !deletes.is_empty() {
-            let (delete_results, bf) =
-                Box::pin(Self::batch_delete_records(pool, &deletes, bulk_load)).await;
+            let (delete_results, bf) = Box::pin(Self::batch_delete_records(
+                pool,
+                &deletes,
+                bulk_load,
+                skip_boilerplate,
+            ))
+            .await;
             batch_failed |= bf;
             results.extend(delete_results);
         }
 
         // Process creates in batch (uses parallel COPY for different collection types)
         if !creates.is_empty() {
-            let (batch_results, bf) =
-                Box::pin(Self::batch_insert_records(pool, &creates, bulk_load)).await;
+            let (batch_results, bf) = Box::pin(Self::batch_insert_records(
+                pool,
+                &creates,
+                bulk_load,
+                skip_boilerplate,
+            ))
+            .await;
             batch_failed |= bf;
             results.extend(batch_results);
         }
@@ -1613,6 +1658,7 @@ impl IndexerManager {
         pool: &Pool,
         jobs: &[&(Vec<u8>, IndexJob)],
         bulk_load: bool,
+        skip_boilerplate: bool,
     ) -> (Vec<(Vec<u8>, Result<(), WintermuteError>)>, bool) {
         use crate::metrics;
         use std::collections::{BTreeMap, HashSet};
@@ -1679,7 +1725,7 @@ impl IndexerManager {
         let revs: Vec<String> = parsed.iter().map(|p| p.job.rev.clone()).collect();
 
         // Rev-gated generic record delete; only applied uris get collection cleanup
-        let applied: HashSet<String> = match client
+        let mut applied: HashSet<String> = match client
             .query(
                 "DELETE FROM record r
                  USING unnest($1::text[], $2::text[]) AS d(uri, rev)
@@ -1699,6 +1745,15 @@ impl IndexerManager {
                 return (results, false);
             }
         };
+        // Boilerplate deletes bypass the record gate once their rows stop
+        // being written there: the typed DELETE is idempotent on absent rows.
+        if skip_boilerplate {
+            for p in &parsed {
+                if crate::config::boilerplate_collection(&p.collection) {
+                    applied.insert(p.uri.clone());
+                }
+            }
+        }
 
         if let Err(e) = client
             .execute("DELETE FROM duplicate_record WHERE uri = ANY($1)", &[&uris])
@@ -1898,6 +1953,7 @@ impl IndexerManager {
         pool: &Pool,
         jobs: &[&(Vec<u8>, IndexJob)],
         bulk_load: bool,
+        skip_boilerplate: bool,
     ) -> (Vec<(Vec<u8>, Result<(), WintermuteError>)>, bool) {
         use crate::metrics;
         use std::time::Instant;
@@ -1978,11 +2034,20 @@ impl IndexerManager {
         }
         let actors_ms = actors_start.elapsed().as_millis();
 
-        // Batch 2: Insert all records into the record table using COPY
+        // Batch 2: Insert records into the record table using COPY. When the
+        // boilerplate skip is on, like/follow/repost/block jobs bypass the
+        // record table entirely: their typed inserts' ON CONFLICT DO NOTHING
+        // absorbs replays, so they count as applied unconditionally.
         let records_start = Instant::now();
+        let record_gated: Vec<bool> = parsed_jobs
+            .iter()
+            .map(|pj| !(skip_boilerplate && crate::config::boilerplate_collection(&pj.collection)))
+            .collect();
         let record_data: Vec<_> = parsed_jobs
             .iter()
-            .map(|pj| {
+            .zip(&record_gated)
+            .filter(|(_, gated)| **gated)
+            .map(|(pj, _)| {
                 (
                     pj.job.uri.clone(),
                     pj.job.cid.clone(),
@@ -2016,11 +2081,18 @@ impl IndexerManager {
         };
         let records_ms = records_start.elapsed().as_millis();
 
-        // Track which jobs were applied (not stale)
+        // Track which jobs were applied (not stale); gated jobs consume the
+        // record results in order, ungated boilerplate is always applied.
         let mut applied_jobs: Vec<&ParsedJob<'_>> = Vec::new();
-        for (i, applied) in record_results.iter().enumerate() {
-            if *applied {
-                applied_jobs.push(&parsed_jobs[i]);
+        let mut gated_results = record_results.iter();
+        for (i, pj) in parsed_jobs.iter().enumerate() {
+            let applied = if record_gated[i] {
+                *gated_results.next().unwrap_or(&false)
+            } else {
+                true
+            };
+            if applied {
+                applied_jobs.push(pj);
             } else {
                 metrics::INDEXER_STALE_WRITES_SKIPPED_TOTAL.inc();
             }

--- a/rsky-wintermute/src/indexer/tests.rs
+++ b/rsky-wintermute/src/indexer/tests.rs
@@ -158,7 +158,8 @@ mod indexer_tests {
                 match indexer.storage.dequeue_firehose_backfill() {
                     Ok(Some((key, index_job))) => {
                         let result =
-                            IndexerManager::process_job(&indexer.pool_backfill, &index_job).await;
+                            IndexerManager::process_job(&indexer.pool_backfill, &index_job, false)
+                                .await;
 
                         match result {
                             Ok(()) => {
@@ -401,7 +402,8 @@ mod indexer_tests {
                 match indexer.storage.dequeue_firehose_backfill() {
                     Ok(Some((key, index_job))) => {
                         let result =
-                            IndexerManager::process_job(&indexer.pool_backfill, &index_job).await;
+                            IndexerManager::process_job(&indexer.pool_backfill, &index_job, false)
+                                .await;
 
                         if result.is_ok() {
                             drop(indexer.storage.remove_firehose_backfill(&key));
@@ -446,7 +448,7 @@ mod indexer_tests {
             rev: "test".to_owned(),
         };
 
-        let result = IndexerManager::process_job(&pool, &valid_job).await;
+        let result = IndexerManager::process_job(&pool, &valid_job, false).await;
         assert!(
             result.is_ok(),
             "expected valid URI to succeed: {:?}",
@@ -1330,7 +1332,7 @@ mod indexer_tests {
             );
 
             // Process the job through indexer
-            match IndexerManager::process_job(&pool, &job_with_record).await {
+            match IndexerManager::process_job(&pool, &job_with_record, false).await {
                 Ok(()) => tracing::info!("successfully processed job {}", job_with_record.uri),
                 Err(e) => {
                     tracing::error!("failed to process job {}: {}", job_with_record.uri, e);
@@ -1399,7 +1401,7 @@ mod indexer_tests {
             rev: "test".to_owned(),
         };
 
-        let result = IndexerManager::process_job(&pool, &job).await;
+        let result = IndexerManager::process_job(&pool, &job, false).await;
 
         // Should fail with missing record error
         assert!(result.is_err());
@@ -1431,7 +1433,7 @@ mod indexer_tests {
             rev: "rev1".to_owned(),
         };
 
-        IndexerManager::process_job(&pool, &create_job)
+        IndexerManager::process_job(&pool, &create_job, false)
             .await
             .unwrap();
 
@@ -1454,7 +1456,7 @@ mod indexer_tests {
             rev: "rev2".to_owned(),
         };
 
-        IndexerManager::process_job(&pool, &delete_job)
+        IndexerManager::process_job(&pool, &delete_job, false)
             .await
             .unwrap();
 
@@ -1491,7 +1493,7 @@ mod indexer_tests {
             rev: "rev2".to_owned(),
         };
 
-        IndexerManager::process_job(&pool, &initial_job)
+        IndexerManager::process_job(&pool, &initial_job, false)
             .await
             .unwrap();
 
@@ -1509,7 +1511,7 @@ mod indexer_tests {
         };
 
         // Should succeed but skip the stale write
-        IndexerManager::process_job(&pool, &stale_job)
+        IndexerManager::process_job(&pool, &stale_job, false)
             .await
             .unwrap();
 
@@ -1766,7 +1768,7 @@ mod indexer_tests {
                 indexed_at: indexed_at.clone(),
             };
 
-            let result = IndexerManager::process_job(&pool, &create_job).await;
+            let result = IndexerManager::process_job(&pool, &create_job, false).await;
             assert!(
                 result.is_ok(),
                 "Failed to create {collection}: {:?}",
@@ -1783,7 +1785,7 @@ mod indexer_tests {
                 indexed_at: indexed_at.clone(),
             };
 
-            let result = IndexerManager::process_job(&pool, &delete_job).await;
+            let result = IndexerManager::process_job(&pool, &delete_job, false).await;
             assert!(
                 result.is_ok(),
                 "Failed to delete {collection}: {:?}",
@@ -1863,7 +1865,7 @@ mod indexer_tests {
                 record: Some(record.clone()),
                 indexed_at: indexed_at.clone(),
             };
-            let result = IndexerManager::process_job(&pool, &create_job).await;
+            let result = IndexerManager::process_job(&pool, &create_job, false).await;
             assert!(
                 result.is_ok(),
                 "Failed to create {collection}: {:?}",
@@ -1879,7 +1881,7 @@ mod indexer_tests {
                 record: None,
                 indexed_at: indexed_at.clone(),
             };
-            let result = IndexerManager::process_job(&pool, &delete_job).await;
+            let result = IndexerManager::process_job(&pool, &delete_job, false).await;
             assert!(
                 result.is_ok(),
                 "Failed to delete {collection}: {:?}",
@@ -2368,7 +2370,8 @@ mod indexer_tests {
                 job("toggle2", WriteAction::Create, "3c", true),
             ),
         ];
-        let (results, batch_failed) = IndexerManager::process_jobs_batch(&pool, &jobs, false).await;
+        let (results, batch_failed) =
+            IndexerManager::process_jobs_batch(&pool, &jobs, false, false).await;
         assert!(!batch_failed);
         assert_eq!(results.len(), 3);
         for (_, r) in &results {
@@ -2413,7 +2416,7 @@ mod indexer_tests {
             ),
         ];
         let (results, batch_failed) =
-            IndexerManager::process_jobs_batch(&pool, &cross_jobs, false).await;
+            IndexerManager::process_jobs_batch(&pool, &cross_jobs, false, false).await;
         assert!(!batch_failed);
         assert!(results.iter().all(|(_, r)| r.is_ok()));
 
@@ -2449,7 +2452,7 @@ mod indexer_tests {
             job("toggle3", WriteAction::Delete, "3f", false),
         )];
         let (results, batch_failed) =
-            IndexerManager::process_jobs_batch(&pool, &delete_jobs, false).await;
+            IndexerManager::process_jobs_batch(&pool, &delete_jobs, false, false).await;
         assert!(!batch_failed);
         assert!(results.iter().all(|(_, r)| r.is_ok()));
 
@@ -2495,7 +2498,7 @@ mod indexer_tests {
             },
         )];
         let (results, batch_failed) =
-            IndexerManager::process_jobs_batch(&pool, &reply_jobs, false).await;
+            IndexerManager::process_jobs_batch(&pool, &reply_jobs, false, false).await;
         assert!(!batch_failed);
         assert!(results.iter().all(|(_, r)| r.is_ok()));
 
@@ -2882,7 +2885,8 @@ mod indexer_tests {
                 ),
             ),
         ];
-        let (results, batch_failed) = IndexerManager::process_jobs_batch(&pool, &jobs, false).await;
+        let (results, batch_failed) =
+            IndexerManager::process_jobs_batch(&pool, &jobs, false, false).await;
         assert!(!batch_failed);
         for (_, r) in &results {
             assert!(r.is_ok(), "job failed: {r:?}");
@@ -2915,6 +2919,174 @@ mod indexer_tests {
         drop(client);
 
         for did in [author, actor] {
+            cleanup_test_data(&pool, did).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn skip_boilerplate_omits_record_rows_with_exact_effects() {
+        use crate::types::{IndexJob, WriteAction};
+
+        let pool = setup_test_pool();
+        let author = "did:plc:wintermute-test-skip-author";
+        let liker = "did:plc:wintermute-test-skip-liker";
+        for did in [author, liker] {
+            cleanup_test_data(&pool, did).await;
+        }
+        let client = pool.get().await.unwrap();
+        for did in [author, liker] {
+            client
+                .execute(
+                    "INSERT INTO actor (did, \"indexedAt\") VALUES ($1, NOW()) \
+                     ON CONFLICT (did) DO NOTHING",
+                    &[&did],
+                )
+                .await
+                .unwrap();
+        }
+        drop(client);
+
+        let cid = "bafyreihhl5mpvjkrhnnagen2fomozzhnhhdq2jr6cego2nzbvmwewv5rd4";
+        let ts = "2026-08-04T00:00:00.000Z";
+        let post_uri = format!("at://{author}/app.bsky.feed.post/skippost");
+        let like_uri = format!("at://{liker}/app.bsky.feed.like/skiplike");
+
+        let jobs = vec![
+            (
+                b"s1".to_vec(),
+                IndexJob {
+                    uri: post_uri.clone(),
+                    cid: cid.to_owned(),
+                    action: WriteAction::Create,
+                    record: Some(serde_json::json!({
+                        "$type": "app.bsky.feed.post", "text": "skip test", "createdAt": ts
+                    })),
+                    indexed_at: ts.to_owned(),
+                    rev: "3a".to_owned(),
+                },
+            ),
+            (
+                b"s2".to_vec(),
+                IndexJob {
+                    uri: like_uri.clone(),
+                    cid: cid.to_owned(),
+                    action: WriteAction::Create,
+                    record: Some(serde_json::json!({
+                        "$type": "app.bsky.feed.like",
+                        "subject": {"uri": post_uri, "cid": cid},
+                        "createdAt": ts
+                    })),
+                    indexed_at: ts.to_owned(),
+                    rev: "3a".to_owned(),
+                },
+            ),
+        ];
+
+        let (results, batch_failed) =
+            IndexerManager::process_jobs_batch(&pool, &jobs, false, true).await;
+        assert!(!batch_failed);
+        for (_, r) in &results {
+            assert!(r.is_ok(), "job failed: {r:?}");
+        }
+
+        let client = pool.get().await.unwrap();
+        let record_rows: i64 = client
+            .query_one(
+                "SELECT count(*) FROM record WHERE uri = ANY($1)",
+                &[&vec![post_uri.clone(), like_uri.clone()]],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(record_rows, 1, "only the post belongs in the record table");
+        let post_record: i64 = client
+            .query_one("SELECT count(*) FROM record WHERE uri = $1", &[&post_uri])
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(post_record, 1);
+        let like_row: i64 = client
+            .query_one("SELECT count(*) FROM \"like\" WHERE uri = $1", &[&like_uri])
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(like_row, 1, "typed like row must exist without record row");
+        let like_count: i64 = client
+            .query_one(
+                "SELECT COALESCE((SELECT \"likeCount\" FROM post_agg WHERE uri = $1), 0)",
+                &[&post_uri],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(like_count, 1);
+        let notif: i64 = client
+            .query_one(
+                "SELECT count(*) FROM notification WHERE did = $1 AND \"recordUri\" = $2",
+                &[&author, &like_uri],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(notif, 1, "like notification must exist");
+        drop(client);
+
+        // Replay: idempotent without the record gate.
+        let (replay_results, replay_failed) =
+            IndexerManager::process_jobs_batch(&pool, &jobs, false, true).await;
+        assert!(!replay_failed);
+        for (_, r) in &replay_results {
+            assert!(r.is_ok());
+        }
+        let client = pool.get().await.unwrap();
+        let like_count: i64 = client
+            .query_one(
+                "SELECT COALESCE((SELECT \"likeCount\" FROM post_agg WHERE uri = $1), 0)",
+                &[&post_uri],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(like_count, 1, "replay must not double count");
+        drop(client);
+
+        // Delete the like with the flag on: typed row gone, count exact.
+        let delete_jobs = vec![(
+            b"s3".to_vec(),
+            IndexJob {
+                uri: like_uri.clone(),
+                cid: String::new(),
+                action: WriteAction::Delete,
+                record: None,
+                indexed_at: ts.to_owned(),
+                rev: "3b".to_owned(),
+            },
+        )];
+        let (del_results, del_failed) =
+            IndexerManager::process_jobs_batch(&pool, &delete_jobs, false, true).await;
+        assert!(!del_failed);
+        for (_, r) in &del_results {
+            assert!(r.is_ok());
+        }
+        let client = pool.get().await.unwrap();
+        let like_row: i64 = client
+            .query_one("SELECT count(*) FROM \"like\" WHERE uri = $1", &[&like_uri])
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(like_row, 0, "typed like row must be deleted");
+        let like_count: i64 = client
+            .query_one(
+                "SELECT COALESCE((SELECT \"likeCount\" FROM post_agg WHERE uri = $1), 0)",
+                &[&post_uri],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(like_count, 0, "likeCount must return to zero");
+        drop(client);
+
+        for did in [author, liker] {
             cleanup_test_data(&pool, did).await;
         }
     }


### PR DESCRIPTION
Behind RECORD_SKIP_BOILERPLATE (default off), like/follow/repost/block writes bypass the record table; typed-table conflict handling preserves idempotency and exact aggregates. Ships dark; flips by env after the dataplane synthesis soaks.