### PR TITLE
fix(wintermute): bound deadpool wait, create and recycle timeouts

### DIFF
--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/src/bin/car_loader.rs
+++ b/rsky-wintermute/src/bin/car_loader.rs
@@ -162,7 +162,7 @@ async fn main() -> Result<()> {
 fn build_pg_pool(args: &Args) -> Result<Pool> {
     let mut cfg = Config::new();
     cfg.url = Some(args.database_url.clone());
-    cfg.pool = Some(deadpool_postgres::PoolConfig::new(args.db_pool_size));
+    cfg.pool = Some(rsky_wintermute::config::pg_pool_config(args.db_pool_size));
     cfg.manager = Some(ManagerConfig {
         recycling_method: RecyclingMethod::Fast,
     });

--- a/rsky-wintermute/src/bin/label_sync.rs
+++ b/rsky-wintermute/src/bin/label_sync.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<()> {
     pg_config.manager = Some(ManagerConfig {
         recycling_method: RecyclingMethod::Fast,
     });
-    pg_config.pool = Some(deadpool_postgres::PoolConfig::new(16));
+    pg_config.pool = Some(rsky_wintermute::config::pg_pool_config(16));
 
     let pool = Arc::new(
         pg_config

--- a/rsky-wintermute/src/config.rs
+++ b/rsky-wintermute/src/config.rs
@@ -183,14 +183,83 @@ pub static INLINE_CONCURRENCY: LazyLock<usize> = LazyLock::new(|| {
         .unwrap_or(100) // Default: 100 concurrent inline indexing tasks (5x pool size)
 });
 
-// Database pool size per component (firehose, labels, indexer, backfiller each get a pool)
-// With 4 pools, default 20 each = 80 connections, leaving headroom under Postgres default 100
+// Database pool size, applied PER POOL -- and pools are created per relay host and per
+// labeler host, not once globally. The real ceiling is therefore
+//   DB_POOL_SIZE * (relay hosts + labeler hosts)          -- ingester + labels
+//   + max(DB_POOL_SIZE/4, FIREHOSE_LIVE_SHARDS * 8)       -- indexer live
+//   + max(DB_POOL_SIZE/2, 10) + max(DB_POOL_SIZE/4, 5)    -- indexer backfill + labels
+// With 3 relays, 3 labelers, DB_POOL_SIZE=36 and 6 live shards that is 291 connections,
+// which will exhaust a server running the Postgres default max_connections. Size it
+// against the host lists, not against the number of components.
 pub static DB_POOL_SIZE: LazyLock<usize> = LazyLock::new(|| {
     std::env::var("DB_POOL_SIZE")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(20) // Default: 20 connections per pool (80 total across 4 pools)
+        .unwrap_or(20) // Default: 20 connections per pool
 });
+
+// Pool timeouts. deadpool leaves all three unset by default, which means a caller that
+// cannot get a connection waits *forever* instead of failing: an exhausted pool surfaces
+// as silently stalled indexing rather than an error, and a connection the server closed
+// underneath the pool is never noticed (every pool here uses RecyclingMethod::Fast, which
+// runs no validation query on checkout). Bound all three so starvation is observable.
+//
+// Set any of these to 0 to disable that individual timeout and restore the old
+// unbounded behaviour.
+const DEFAULT_DB_WAIT_TIMEOUT_SECS: u64 = 30;
+const DEFAULT_DB_CREATE_TIMEOUT_SECS: u64 = 10;
+const DEFAULT_DB_RECYCLE_TIMEOUT_SECS: u64 = 10;
+
+/// Parse a timeout given in whole seconds. An absent or unparseable value falls back to
+/// `default_secs`; an explicit `0` means "no timeout" and maps to [`None`].
+#[must_use]
+fn parse_timeout_secs(raw: Option<&str>, default_secs: u64) -> Option<Duration> {
+    let secs = raw
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(default_secs);
+    if secs == 0 {
+        None
+    } else {
+        Some(Duration::from_secs(secs))
+    }
+}
+
+fn timeout_from_env(var: &str, default_secs: u64) -> Option<Duration> {
+    parse_timeout_secs(std::env::var(var).ok().as_deref(), default_secs)
+}
+
+/// How long to wait for a free slot before giving up.
+pub static DB_WAIT_TIMEOUT: LazyLock<Option<Duration>> =
+    LazyLock::new(|| timeout_from_env("DB_WAIT_TIMEOUT_SECS", DEFAULT_DB_WAIT_TIMEOUT_SECS));
+
+/// How long to wait for a brand-new connection to be established.
+pub static DB_CREATE_TIMEOUT: LazyLock<Option<Duration>> =
+    LazyLock::new(|| timeout_from_env("DB_CREATE_TIMEOUT_SECS", DEFAULT_DB_CREATE_TIMEOUT_SECS));
+
+/// How long to wait for an existing connection to be recycled for reuse.
+pub static DB_RECYCLE_TIMEOUT: LazyLock<Option<Duration>> =
+    LazyLock::new(|| timeout_from_env("DB_RECYCLE_TIMEOUT_SECS", DEFAULT_DB_RECYCLE_TIMEOUT_SECS));
+
+/// Build the [`Timeouts`] every pool in this crate shares.
+#[must_use]
+pub fn pg_pool_timeouts() -> deadpool_postgres::Timeouts {
+    deadpool_postgres::Timeouts {
+        wait: *DB_WAIT_TIMEOUT,
+        create: *DB_CREATE_TIMEOUT,
+        recycle: *DB_RECYCLE_TIMEOUT,
+    }
+}
+
+/// The single place a Postgres pool is configured. Use this instead of
+/// `PoolConfig::new(size)`, which leaves every timeout unset.
+#[must_use]
+pub fn pg_pool_config(max_size: usize) -> deadpool_postgres::PoolConfig {
+    deadpool_postgres::PoolConfig {
+        max_size,
+        timeouts: pg_pool_timeouts(),
+        ..Default::default()
+    }
+}
 
 // Backfiller direct write mode - bypass Fjall queue and write directly to PostgreSQL
 // This eliminates the Fjall dequeue bottleneck (~3.5s per batch) for backfill operations
@@ -316,5 +385,91 @@ mod tests {
         assert!(record_collection_allowed("com.whtwnd.blog.entry"));
         assert!(ingest_collection_allowed("app.bsky.feed.post"));
         assert!(!ingest_collection_allowed("com.whtwnd.blog.entry"));
+    }
+
+    #[test]
+    fn timeout_absent_uses_default() {
+        assert_eq!(parse_timeout_secs(None, 30), Some(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn timeout_parses_explicit_value() {
+        assert_eq!(
+            parse_timeout_secs(Some("45"), 30),
+            Some(Duration::from_secs(45))
+        );
+    }
+
+    #[test]
+    fn timeout_zero_disables() {
+        // 0 is the documented escape hatch back to deadpool's unbounded behaviour.
+        assert_eq!(parse_timeout_secs(Some("0"), 30), None);
+    }
+
+    #[test]
+    fn timeout_unparseable_falls_back_to_default() {
+        assert_eq!(
+            parse_timeout_secs(Some("banana"), 30),
+            Some(Duration::from_secs(30))
+        );
+        assert_eq!(
+            parse_timeout_secs(Some(""), 7),
+            Some(Duration::from_secs(7))
+        );
+        // Negative values do not parse as u64, so they fall back rather than wrapping.
+        assert_eq!(
+            parse_timeout_secs(Some("-5"), 7),
+            Some(Duration::from_secs(7))
+        );
+    }
+
+    #[test]
+    fn timeout_trims_surrounding_whitespace() {
+        assert_eq!(
+            parse_timeout_secs(Some("  12\n"), 30),
+            Some(Duration::from_secs(12))
+        );
+    }
+
+    #[test]
+    fn timeout_default_of_zero_stays_disabled() {
+        assert_eq!(parse_timeout_secs(None, 0), None);
+    }
+
+    #[test]
+    fn timeout_from_env_reads_the_named_var() {
+        // Unset in the test process, so this exercises the fallback path.
+        assert_eq!(
+            timeout_from_env("RSKY_WINTERMUTE_TIMEOUT_VAR_THAT_IS_NOT_SET", 11),
+            Some(Duration::from_secs(11))
+        );
+    }
+
+    #[test]
+    fn pool_timeouts_bound_all_three_by_default() {
+        // The whole point of the helper: none of these may be None by default, or a
+        // starved pool waits forever instead of erroring.
+        let t = pg_pool_timeouts();
+        assert_eq!(
+            t.wait,
+            Some(Duration::from_secs(DEFAULT_DB_WAIT_TIMEOUT_SECS))
+        );
+        assert_eq!(
+            t.create,
+            Some(Duration::from_secs(DEFAULT_DB_CREATE_TIMEOUT_SECS))
+        );
+        assert_eq!(
+            t.recycle,
+            Some(Duration::from_secs(DEFAULT_DB_RECYCLE_TIMEOUT_SECS))
+        );
+    }
+
+    #[test]
+    fn pool_config_carries_size_and_timeouts() {
+        let cfg = pg_pool_config(12);
+        assert_eq!(cfg.max_size, 12);
+        assert_eq!(cfg.timeouts.wait, pg_pool_timeouts().wait);
+        assert_eq!(cfg.timeouts.create, pg_pool_timeouts().create);
+        assert_eq!(cfg.timeouts.recycle, pg_pool_timeouts().recycle);
     }
 }

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -142,7 +142,7 @@ impl IndexerManager {
         pg_config.manager = Some(ManagerConfig {
             recycling_method: RecyclingMethod::Fast,
         });
-        pg_config.pool = Some(deadpool_postgres::PoolConfig::new(size));
+        pg_config.pool = Some(crate::config::pg_pool_config(size));
 
         pg_config
             .create_pool(Some(Runtime::Tokio1), NoTls)

--- a/rsky-wintermute/src/ingester/labels.rs
+++ b/rsky-wintermute/src/ingester/labels.rs
@@ -26,7 +26,7 @@ pub async fn subscribe_labels(
     pg_config.manager = Some(ManagerConfig {
         recycling_method: RecyclingMethod::Fast,
     });
-    pg_config.pool = Some(deadpool_postgres::PoolConfig::new(pool_size));
+    pg_config.pool = Some(crate::config::pg_pool_config(pool_size));
 
     let pool = Arc::new(
         pg_config

--- a/rsky-wintermute/src/ingester/mod.rs
+++ b/rsky-wintermute/src/ingester/mod.rs
@@ -134,7 +134,7 @@ impl IngesterManager {
         pg_config.manager = Some(ManagerConfig {
             recycling_method: RecyclingMethod::Fast,
         });
-        pg_config.pool = Some(deadpool_postgres::PoolConfig::new(pool_size));
+        pg_config.pool = Some(crate::config::pg_pool_config(pool_size));
 
         let pool = match pg_config.create_pool(Some(Runtime::Tokio1), NoTls) {
             Ok(p) => Arc::new(p),


### PR DESCRIPTION
## Problem

`deadpool` leaves `wait`, `create` and `recycle` unset by default, so a caller that cannot
get a connection waits **forever** rather than failing. An exhausted pool therefore shows up
as silently stalled indexing instead of an error. Every pool here also uses
`RecyclingMethod::Fast`, which runs no validation query on checkout, so a connection the
server closed underneath the pool is never noticed either.

This is not hypothetical: the pools had drifted to ~148 idle connections against a
300-connection server, the longest idle for nearly 23 hours.

## Change

- Add `DB_WAIT_TIMEOUT_SECS` (default 30), `DB_CREATE_TIMEOUT_SECS` (10) and
  `DB_RECYCLE_TIMEOUT_SECS` (10). Set any to `0` to disable that one and restore the
  previous unbounded behaviour.
- Route all five pool-creation sites through a single `config::pg_pool_config` helper
  instead of five separate `PoolConfig::new` calls, so timeouts cannot be forgotten at a
  new call site.
- Document that `DB_POOL_SIZE` is applied **per relay host and per labeler host**, not
  globally. The real ceiling is `DB_POOL_SIZE * (relays + labelers)` plus the three indexer
  pools. The previous comment claimed "4 pools, default 20 each = 80 connections", which
  predates multi-host lists.

## Behaviour change worth reviewing

Acquisition can now fail with `PoolError::Timeout(Wait)` where it previously blocked
indefinitely. That is the intent — a starved pool becomes observable — but it does mean
callers see a new error variant under sustained saturation. The `.max(live_shards * 8)`
floor on the indexer live pool exists precisely because there was no acquire timeout; that
floor is left untouched here.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --all-targets` produces zero warnings for this crate
- 9 new unit tests covering timeout parsing (default, explicit, `0`, unparseable, negative,
  whitespace) and the pool config helper; all 14 `config::` tests pass
- `cargo build --release` succeeds
- Minor version bump 0.8.0 → 0.9.0 for the new public helpers

The DB-backed tests in `ingester::tests` / `indexer::tests` fail locally without a
Postgres on `localhost` (`ConnectionRefused`), identically on unmodified `main`.