### PR TITLE
fix(wintermute): distinguish an absent record row from a stale delete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -88,6 +88,13 @@ struct ParsedJob<'a> {
     rkey: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecordDeletion {
+    Deleted,
+    Absent,
+    StaleRev,
+}
+
 impl IndexerManager {
     pub fn new(storage: Arc<Storage>, database_url: &str) -> Result<Self, WintermuteError> {
         let pool_size = *DB_POOL_SIZE;
@@ -1127,7 +1134,7 @@ impl IndexerManager {
         client: &deadpool_postgres::Client,
         uri: &str,
         rev: &str,
-    ) -> Result<bool, WintermuteError> {
+    ) -> Result<RecordDeletion, WintermuteError> {
         // Delete the record from the record table (matching TypeScript dataplane behavior)
         // Only delete if the record's rev is <= the delete operation's rev
         let result = client
@@ -1144,7 +1151,22 @@ impl IndexerManager {
             .execute("DELETE FROM duplicate_record WHERE uri = $1", &[&uri])
             .await?;
 
-        Ok(result.is_some())
+        if result.is_some() {
+            return Ok(RecordDeletion::Deleted);
+        }
+
+        // An absent record row is not a stale delete: it may never have been
+        // written, or already been removed. Only a surviving newer rev means
+        // this delete lost a race and must not cascade.
+        let survivor = client
+            .query_opt("SELECT rev FROM record WHERE uri = $1", &[&uri])
+            .await?;
+
+        Ok(if survivor.is_some() {
+            RecordDeletion::StaleRev
+        } else {
+            RecordDeletion::Absent
+        })
     }
 
     // listNotifications gates on the subject's existence, never on the notified
@@ -1460,17 +1482,14 @@ impl IndexerManager {
                 }
             }
             WriteAction::Delete => {
-                // Boilerplate deletes bypass the record gate: the typed
-                // delete is idempotent when the row is already absent.
-                let applied =
-                    if skip_boilerplate && crate::config::boilerplate_collection(&collection) {
-                        drop(Self::delete_generic_record(&client, &job.uri, &job.rev).await);
-                        true
-                    } else {
-                        Self::delete_generic_record(&client, &job.uri, &job.rev).await?
-                    };
+                // An absent record row must still cascade — under the boilerplate
+                // skip there is never a record row to gate on — but a surviving
+                // newer rev means this delete lost a race and must not.
+                let outcome = Self::delete_generic_record(&client, &job.uri, &job.rev).await?;
 
-                if !applied {
+                if outcome == RecordDeletion::StaleRev {
+                    metrics::INDEXER_STALE_WRITES_SKIPPED_TOTAL.inc();
+                    tracing::debug!("skipping stale delete for {}", job.uri);
                     return Ok(());
                 }
 

--- a/rsky-wintermute/src/indexer/tests.rs
+++ b/rsky-wintermute/src/indexer/tests.rs
@@ -1533,6 +1533,144 @@ mod indexer_tests {
     }
 
     const NOTIF_BY_RECORD: &str = "SELECT COUNT(*) FROM notification WHERE \"recordUri\" = $1";
+    const LIKE_BY_URI: &str = "SELECT COUNT(*) FROM \"like\" WHERE uri = $1";
+
+    #[tokio::test]
+    async fn test_delete_cascades_without_boilerplate_skip_when_record_absent() {
+        use crate::types::{IndexJob, WriteAction};
+
+        let pool = setup_test_pool();
+        let test_did = "did:plc:cascadenoskip";
+        let subject_did = "did:plc:cascadenoskipsubject";
+        let test_uri = format!("at://{test_did}/app.bsky.feed.like/cn1");
+        let subject_uri = format!("at://{subject_did}/app.bsky.feed.post/sub1");
+
+        cleanup_test_data(&pool, test_did).await;
+        cleanup_test_data(&pool, subject_did).await;
+
+        IndexerManager::process_job(
+            &pool,
+            &IndexJob {
+                uri: test_uri.clone(),
+                cid: "bafylike3".to_owned(),
+                action: WriteAction::Create,
+                record: Some(subject_record(&subject_uri)),
+                indexed_at: "2024-01-01T00:00:00Z".to_owned(),
+                rev: "rev1".to_owned(),
+            },
+            false,
+        )
+        .await
+        .unwrap();
+
+        let client = pool.get().await.unwrap();
+        // Drop only the record row, leaving the typed row: the state a prune or a
+        // create that predates the record write leaves behind.
+        client
+            .execute("DELETE FROM record WHERE uri = $1", &[&test_uri])
+            .await
+            .unwrap();
+
+        IndexerManager::process_job(
+            &pool,
+            &IndexJob {
+                uri: test_uri.clone(),
+                cid: "bafylike3".to_owned(),
+                action: WriteAction::Delete,
+                record: None,
+                indexed_at: "2024-01-01T01:00:00Z".to_owned(),
+                rev: "rev2".to_owned(),
+            },
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_one(&client, LIKE_BY_URI, &test_uri).await,
+            0,
+            "an absent record row must still cascade to the typed table"
+        );
+        assert_eq!(
+            count_one(&client, NOTIF_BY_RECORD, &test_uri).await,
+            0,
+            "notification should be retracted"
+        );
+
+        cleanup_test_data(&pool, test_did).await;
+        cleanup_test_data(&pool, subject_did).await;
+    }
+
+    #[tokio::test]
+    async fn test_stale_delete_does_not_cascade_under_boilerplate_skip() {
+        use crate::types::{IndexJob, WriteAction};
+
+        let pool = setup_test_pool();
+        let test_did = "did:plc:staleskipdelete";
+        let subject_did = "did:plc:staleskipdeletesubject";
+        let test_uri = format!("at://{test_did}/app.bsky.feed.like/sk1");
+        let subject_uri = format!("at://{subject_did}/app.bsky.feed.post/sub1");
+
+        cleanup_test_data(&pool, test_did).await;
+        cleanup_test_data(&pool, subject_did).await;
+
+        // Created without the skip so a record row exists at rev2 to gate on.
+        IndexerManager::process_job(
+            &pool,
+            &IndexJob {
+                uri: test_uri.clone(),
+                cid: "bafylike4".to_owned(),
+                action: WriteAction::Create,
+                record: Some(subject_record(&subject_uri)),
+                indexed_at: "2024-01-01T00:00:00Z".to_owned(),
+                rev: "rev2".to_owned(),
+            },
+            false,
+        )
+        .await
+        .unwrap();
+
+        // A delete carrying an older rev lost a race against that record.
+        IndexerManager::process_job(
+            &pool,
+            &IndexJob {
+                uri: test_uri.clone(),
+                cid: "bafylike4".to_owned(),
+                action: WriteAction::Delete,
+                record: None,
+                indexed_at: "2024-01-01T01:00:00Z".to_owned(),
+                rev: "rev1".to_owned(),
+            },
+            true,
+        )
+        .await
+        .unwrap();
+
+        let client = pool.get().await.unwrap();
+        assert_eq!(
+            count_one(&client, LIKE_BY_URI, &test_uri).await,
+            1,
+            "a stale delete must not cascade even under the boilerplate skip"
+        );
+        assert_eq!(
+            count_one(&client, NOTIF_BY_RECORD, &test_uri).await,
+            1,
+            "notification should survive a stale delete"
+        );
+        assert_eq!(
+            count_one(
+                &client,
+                "SELECT COUNT(*) FROM record WHERE uri = $1",
+                &test_uri
+            )
+            .await,
+            1,
+            "record row should survive a stale delete"
+        );
+
+        cleanup_test_data(&pool, test_did).await;
+        cleanup_test_data(&pool, subject_did).await;
+    }
 
     fn subject_record(subject_uri: &str) -> serde_json::Value {
         serde_json::json!({


### PR DESCRIPTION
## Summary

Builds on #223. The delete path treats "no record row deleted" as a lost race and skips the typed cleanup, so the typed row is orphaned whenever the record row is simply absent rather than newer. #223 works around that by forcing the cascade for the boilerplate collections (`like`, `repost`, `follow`, `block`), which fixes the common case but does it unconditionally: a delete carrying an older rev than a surviving record row now cascades into a live typed row, and the error from the record delete is discarded.

This returns the deletion outcome instead of a bool. An absent record row cascades; a surviving newer rev does not; and the distinction holds for every collection rather than only the boilerplate set. Practical exposure of the stale-rev case is small — rkeys are TIDs, so delete-then-recreate at the same key is rare — so this is a correctness cleanup rather than an urgent fix.

Stacked on #227; review that one first. Retarget to `main` once it merges.

## Test plan

- [ ] `cargo clippy -p rsky-wintermute --all-targets` is clean
- [ ] `cargo test -p rsky-wintermute --lib` against a schema-loaded Postgres, including the two added cases: cascade with the skip off and the record row absent, and no cascade for a stale-rev delete with the skip on
- [ ] `cargo llvm-cov -p rsky-wintermute`
- [ ] `cargo build --release -p rsky-wintermute`
- [ ] Confirm the stale-writes-skipped counter moves for a stale delete and stays flat for an absent record row