### PR TITLE
fix(pds): cross-server auth, did:web migration, and byte-level blob conformance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-pds"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-pds"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-pds"
-version = "0.13.6"
+version = "0.13.7"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-pds"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-pds"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8339,7 +8339,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-repo"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8170,7 +8170,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-lexicon"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-pds"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8339,7 +8339,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-repo"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-pds"
-version = "0.13.9"
+version = "0.13.11"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-pds"
-version = "0.13.13"
+version = "0.13.14"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8339,7 +8339,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-repo"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8192,7 +8192,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-oauth"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rsky-identity = {path = "rsky-identity", version = "0.2.0"}
 rsky-crypto = {path = "rsky-crypto", version = "0.2.0"}
 rsky-syntax = {path = "rsky-syntax", version = "0.1.0"}
 rsky-common = {path = "rsky-common", version = "0.1.3"}
-rsky-repo = {path = "rsky-repo", version = "0.0.3"}
+rsky-repo = {path = "rsky-repo", version = "0.0.4"}
 rsky-firehose = {path = "rsky-firehose", version = "0.2.1"}
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rsky-identity = {path = "rsky-identity", version = "0.2.0"}
 rsky-crypto = {path = "rsky-crypto", version = "0.2.0"}
 rsky-syntax = {path = "rsky-syntax", version = "0.1.0"}
 rsky-common = {path = "rsky-common", version = "0.1.3"}
-rsky-repo = {path = "rsky-repo", version = "0.0.5"}
+rsky-repo = {path = "rsky-repo", version = "0.0.6"}
 rsky-firehose = {path = "rsky-firehose", version = "0.2.1"}
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rsky-identity = {path = "rsky-identity", version = "0.2.0"}
 rsky-crypto = {path = "rsky-crypto", version = "0.2.0"}
 rsky-syntax = {path = "rsky-syntax", version = "0.1.0"}
 rsky-common = {path = "rsky-common", version = "0.1.3"}
-rsky-repo = {path = "rsky-repo", version = "0.0.4"}
+rsky-repo = {path = "rsky-repo", version = "0.0.5"}
 rsky-firehose = {path = "rsky-firehose", version = "0.2.1"}
 
 [profile.release]

--- a/rsky-lexicon/Cargo.toml
+++ b/rsky-lexicon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-lexicon"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 publish = true
 description = "Bluesky API library"

--- a/rsky-lexicon/src/blob_refs.rs
+++ b/rsky-lexicon/src/blob_refs.rs
@@ -33,6 +33,7 @@ pub enum JsonBlobRef {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(transparent)]
 pub struct BlobRef {
     pub original: JsonBlobRef,
 }

--- a/rsky-oauth/Cargo.toml
+++ b/rsky-oauth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-oauth"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "OAuth provider core (JOSE, JWK, DPoP) for AT Protocol services"
 license = "Apache-2.0"

--- a/rsky-oauth/src/client.rs
+++ b/rsky-oauth/src/client.rs
@@ -197,6 +197,15 @@ impl Client {
                 .login_hint
                 .as_deref()
                 .map(|hint| hint.to_ascii_lowercase()),
+            response_mode: match parameters.response_mode.as_deref() {
+                None | Some("query") => None,
+                Some("fragment") => Some("fragment".to_string()),
+                Some(other) => {
+                    return Err(OAuthError::InvalidRequest(format!(
+                        "unsupported response_mode: {other}"
+                    )))
+                }
+            },
             prompt,
             dpop_jkt: None,
         })
@@ -221,6 +230,8 @@ pub struct ParRequest {
     pub code_challenge_method: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub login_hint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_mode: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt: Option<String>,
 }
@@ -1105,6 +1116,7 @@ mod tests {
             code_challenge: Some("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM".to_string()),
             code_challenge_method: Some(CODE_CHALLENGE_METHOD_S256.to_string()),
             login_hint: Some("Alice.Example.Com".to_string()),
+            response_mode: None,
             prompt: None,
         }
     }

--- a/rsky-oauth/src/provider.rs
+++ b/rsky-oauth/src/provider.rs
@@ -369,7 +369,18 @@ impl OAuthProvider {
     ) -> Result<String, OAuthError> {
         let mut url = Url::parse(&parameters.redirect_uri)
             .map_err(|_| OAuthError::ServerError("stored redirect_uri is invalid".to_string()))?;
-        {
+        let fragment_mode = parameters.response_mode.as_deref() == Some("fragment");
+        if fragment_mode {
+            let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+            for (key, value) in pairs {
+                serializer.append_pair(key, value);
+            }
+            if let Some(state) = &parameters.state {
+                serializer.append_pair("state", state);
+            }
+            serializer.append_pair("iss", &self.issuer);
+            url.set_fragment(Some(&serializer.finish()));
+        } else {
             let mut query = url.query_pairs_mut();
             for (key, value) in pairs {
                 query.append_pair(key, value);
@@ -771,7 +782,7 @@ impl OAuthProvider {
             ],
             "subject_types_supported": ["public"],
             "response_types_supported": [RESPONSE_TYPE_CODE],
-            "response_modes_supported": ["query"],
+            "response_modes_supported": ["query", "fragment"],
             "grant_types_supported": [GRANT_AUTHORIZATION_CODE, GRANT_REFRESH_TOKEN],
             "code_challenge_methods_supported": [CODE_CHALLENGE_METHOD_S256],
             "ui_locales_supported": ["en-US"],
@@ -1020,6 +1031,7 @@ mod tests {
             code_challenge: Some(PKCE_CHALLENGE.to_string()),
             code_challenge_method: Some(CODE_CHALLENGE_METHOD_S256.to_string()),
             login_hint: None,
+            response_mode: None,
             prompt: None,
         }
     }
@@ -1709,6 +1721,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fragment_response_mode_redirects_in_the_fragment() {
+        let setup = setup();
+        let key = dpop_key();
+        let htu = format!("{ISSUER}/oauth/par");
+        let proof = proof(&key, "POST", &htu, NOW, None, None);
+        let headers = [proof.as_str()];
+        let mut request = par_request(CLIENT_ID);
+        request.response_mode = Some("fragment".to_string());
+        let par = setup
+            .provider
+            .pushed_authorization_request(
+                &credentials(CLIENT_ID),
+                &request,
+                &DpopRequest {
+                    method: "POST",
+                    uri: &htu,
+                    dpop_headers: &headers,
+                    access_token: None,
+                },
+                NOW,
+            )
+            .await
+            .unwrap();
+        let redirect = setup
+            .provider
+            .reject(CLIENT_ID, &par.request_uri, DEVICE, NOW)
+            .await
+            .unwrap();
+        let url = Url::parse(&redirect).unwrap();
+        // Everything rides in the fragment; the query stays empty. A browser
+        // client reading only the fragment must find state and iss there.
+        assert!(url.query().is_none(), "query must be empty: {redirect}");
+        let fragment = url.fragment().expect("fragment present");
+        let pairs: Vec<(String, String)> = url::form_urlencoded::parse(fragment.as_bytes())
+            .into_owned()
+            .collect();
+        assert!(pairs
+            .iter()
+            .any(|(key, value)| key == "error" && value == "access_denied"));
+        assert!(pairs.iter().any(|(key, _)| key == "state"));
+        assert!(pairs.iter().any(|(key, _)| key == "iss"));
+    }
+
+    #[tokio::test]
     async fn token_grant_failures() {
         let setup = setup();
         let key = dpop_key();
@@ -2203,6 +2259,7 @@ mod tests {
                 code_challenge: PKCE_CHALLENGE.to_string(),
                 code_challenge_method: CODE_CHALLENGE_METHOD_S256.to_string(),
                 login_hint: None,
+                response_mode: None,
                 prompt: None,
                 dpop_jkt: None,
             },
@@ -2325,6 +2382,7 @@ mod tests {
                 code_challenge: PKCE_CHALLENGE.to_string(),
                 code_challenge_method: CODE_CHALLENGE_METHOD_S256.to_string(),
                 login_hint: None,
+                response_mode: None,
                 prompt: None,
                 dpop_jkt: Some(jkt),
             },

--- a/rsky-oauth/src/request.rs
+++ b/rsky-oauth/src/request.rs
@@ -90,6 +90,7 @@ mod tests {
             code_challenge: "challenge".to_string(),
             code_challenge_method: CODE_CHALLENGE_METHOD_S256.to_string(),
             login_hint: None,
+            response_mode: None,
             prompt: None,
             dpop_jkt: None,
         }

--- a/rsky-oauth/src/store.rs
+++ b/rsky-oauth/src/store.rs
@@ -497,6 +497,7 @@ mod tests {
             code_challenge: "challenge".to_string(),
             code_challenge_method: "S256".to_string(),
             login_hint: None,
+            response_mode: None,
             prompt: None,
             dpop_jkt: None,
         };

--- a/rsky-oauth/src/token.rs
+++ b/rsky-oauth/src/token.rs
@@ -145,6 +145,7 @@ mod tests {
                 code_challenge: "challenge".to_string(),
                 code_challenge_method: CODE_CHALLENGE_METHOD_S256.to_string(),
                 login_hint: None,
+                response_mode: None,
                 prompt: None,
                 dpop_jkt: None,
             },

--- a/rsky-oauth/src/types.rs
+++ b/rsky-oauth/src/types.rs
@@ -129,6 +129,10 @@ pub struct AuthorizationRequestParameters {
     pub code_challenge_method: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub login_hint: Option<String>,
+    /// `query` (default) or `fragment`. Browser clients default to
+    /// `fragment`; dropping this silently strands them at the callback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_mode: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt: Option<String>,
     /// RFC 7638 thumbprint of the DPoP key used at PAR time, when present.

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-pds"
-version = "0.13.8"
+version = "0.13.9"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust reference implementation of an atproto PDS."
 license = "Apache-2.0"

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-pds"
-version = "0.13.10"
+version = "0.13.11"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust reference implementation of an atproto PDS."
 license = "Apache-2.0"

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-pds"
-version = "0.13.12"
+version = "0.13.13"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust reference implementation of an atproto PDS."
 license = "Apache-2.0"

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-pds"
-version = "0.13.5"
+version = "0.13.6"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust reference implementation of an atproto PDS."
 license = "Apache-2.0"

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-pds"
-version = "0.13.11"
+version = "0.13.12"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust reference implementation of an atproto PDS."
 license = "Apache-2.0"

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-pds"
-version = "0.13.9"
+version = "0.13.10"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust reference implementation of an atproto PDS."
 license = "Apache-2.0"

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-pds"
-version = "0.13.13"
+version = "0.13.14"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust reference implementation of an atproto PDS."
 license = "Apache-2.0"

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-pds"
-version = "0.13.7"
+version = "0.13.8"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust reference implementation of an atproto PDS."
 license = "Apache-2.0"

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-pds"
-version = "0.13.6"
+version = "0.13.7"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust reference implementation of an atproto PDS."
 license = "Apache-2.0"

--- a/rsky-pds/src/account_manager/helpers/auth.rs
+++ b/rsky-pds/src/account_manager/helpers/auth.rs
@@ -5,7 +5,6 @@ use crate::models;
 use anyhow::Result;
 use chrono::DateTime;
 use jwt_simple::prelude::*;
-use rsky_common::time::MINUTE;
 use rsky_common::{get_random_str, json_to_b64url, RFC3339_VARIANT};
 use rusqlite::{params, OptionalExtension};
 use secp256k1::Message;
@@ -146,13 +145,12 @@ pub fn create_refresh_token(opts: CreateTokensOpts) -> Result<String> {
 
 pub async fn create_service_jwt(params: ServiceJwtParams) -> Result<String> {
     let ServiceJwtParams { iss, aud, .. } = params;
+    // `exp` is seconds since the epoch (RFC 7519 §4.1.4).
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
-        .expect("timestamp in micros since UNIX epoch")
-        .as_micros() as usize;
-    let exp = params
-        .exp
-        .unwrap_or(((now + MINUTE as usize) / 1000) as u64);
+        .expect("timestamp since UNIX epoch")
+        .as_secs();
+    let exp = params.exp.unwrap_or(now + 60);
     let lxm = params.lxm;
     let jti = get_random_str();
     let header = ServiceJwtHeader {

--- a/rsky-pds/src/account_manager/oauth_store.rs
+++ b/rsky-pds/src/account_manager/oauth_store.rs
@@ -756,6 +756,7 @@ mod tests {
             code_challenge: "challenge".to_string(),
             code_challenge_method: "S256".to_string(),
             login_hint: None,
+            response_mode: None,
             prompt: Some("consent".to_string()),
             dpop_jkt: Some("jkt-1".to_string()),
         }

--- a/rsky-pds/src/actor_store/blob/mod.rs
+++ b/rsky-pds/src/actor_store/blob/mod.rs
@@ -229,6 +229,7 @@ impl BlobReader {
     /// the association and moves on instead of failing the import; the
     /// upload promotes it (see `track_untethered_blob`).
     pub async fn process_import_blobs(&self, writes: Vec<PreparedWrite>) -> Result<()> {
+        self.delete_dereferenced_blobs(writes.clone()).await?;
         for write in writes {
             let (blobs, uri) = match write {
                 PreparedWrite::Create(w) => (w.blobs, w.uri),
@@ -237,9 +238,16 @@ impl BlobReader {
             };
             for blob in blobs {
                 self.associate_blob(blob.clone(), uri.clone()).await?;
+                // Only a blob that has not been uploaded yet is tolerated
+                // (it arrives after the import); a present-but-invalid blob
+                // still fails the import.
                 if let Err(error) = self.verify_blob_and_make_permanent(blob.clone()).await {
-                    tracing::debug!(cid = %blob.cid, %error,
-                        "imported record references a blob not yet uploaded");
+                    if error.to_string().starts_with("Could not find blob") {
+                        tracing::debug!(cid = %blob.cid,
+                            "imported record references a blob not yet uploaded");
+                    } else {
+                        return Err(error);
+                    }
                 }
             }
         }

--- a/rsky-pds/src/actor_store/blob/mod.rs
+++ b/rsky-pds/src/actor_store/blob/mod.rs
@@ -12,7 +12,7 @@ use rsky_common::now;
 use rsky_lexicon::blob_refs::BlobRef;
 use rsky_lexicon::com::atproto::admin::StatusAttr;
 use rsky_lexicon::com::atproto::repo::ListMissingBlobsRefRecordBlob;
-use rsky_repo::types::{PreparedBlobRef, PreparedWrite};
+use rsky_repo::types::{BlobConstraint, PreparedBlobRef, PreparedWrite};
 use rusqlite::OptionalExtension;
 use sha2::{Digest, Sha256};
 use std::str::FromStr;
@@ -194,7 +194,56 @@ impl BlobReader {
                 Ok(())
             })
             .await?;
+        // A blob uploaded after the record referencing it was imported is
+        // already associated; promote it now or it stays temp forever.
+        let cid_str = cid.to_string();
+        let associated: bool = self
+            .db
+            .run(move |conn| {
+                Ok(conn
+                    .query_row(
+                        "SELECT 1 FROM record_blob WHERE \"blobCid\" = ?1 LIMIT 1",
+                        [cid_str.clone()],
+                        |_| Ok(()),
+                    )
+                    .optional()?
+                    .is_some())
+            })
+            .await?;
+        if associated {
+            self.verify_blob_and_make_permanent(PreparedBlobRef {
+                cid,
+                mime_type: mime_type.clone(),
+                constraints: BlobConstraint {
+                    max_size: None,
+                    accept: None,
+                },
+            })
+            .await?;
+        }
         Ok(BlobRef::new(cid, mime_type, size, None))
+    }
+
+    /// Blob processing for CAR imports: the referenced blobs typically
+    /// arrive by uploadBlob *after* the import, so a missing blob records
+    /// the association and moves on instead of failing the import; the
+    /// upload promotes it (see `track_untethered_blob`).
+    pub async fn process_import_blobs(&self, writes: Vec<PreparedWrite>) -> Result<()> {
+        for write in writes {
+            let (blobs, uri) = match write {
+                PreparedWrite::Create(w) => (w.blobs, w.uri),
+                PreparedWrite::Update(w) => (w.blobs, w.uri),
+                _ => continue,
+            };
+            for blob in blobs {
+                self.associate_blob(blob.clone(), uri.clone()).await?;
+                if let Err(error) = self.verify_blob_and_make_permanent(blob.clone()).await {
+                    tracing::debug!(cid = %blob.cid, %error,
+                        "imported record references a blob not yet uploaded");
+                }
+            }
+        }
+        Ok(())
     }
 
     pub async fn process_write_blobs(&self, writes: Vec<PreparedWrite>) -> Result<()> {

--- a/rsky-pds/src/actor_store/mod.rs
+++ b/rsky-pds/src/actor_store/mod.rs
@@ -491,7 +491,7 @@ impl ActorStoreTransactor {
             storage_guard.apply_commit(commit.clone(), None).await?;
         }
         // process blobs
-        self.blob.process_write_blobs(writes).await?;
+        self.blob.process_import_blobs(writes).await?;
         Ok(())
     }
 

--- a/rsky-pds/src/apis/com/atproto/identity/update_handle.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/update_handle.rs
@@ -49,11 +49,17 @@ async fn inner_update_handle(
         Some(account) if account.did != requester => bail!("Handle already taken: {handle}"),
         Some(_) => (),
         None => {
-            let plc_url = env_str("PDS_DID_PLC_URL").unwrap_or("https://plc.directory".to_owned());
-            let plc_client = plc::Client::new(plc_url);
-            plc_client
-                .update_handle(&requester, &PDS_PLC_ROTATION_KEYPAIR.secret_key(), &handle)
-                .await?;
+            // Only did:plc identities carry the handle in a directory this
+            // server can write; a did:web document's alsoKnownAs is edited by
+            // whoever hosts it.
+            if requester.starts_with("did:plc:") {
+                let plc_url =
+                    env_str("PDS_DID_PLC_URL").unwrap_or("https://plc.directory".to_owned());
+                let plc_client = plc::Client::new(plc_url);
+                plc_client
+                    .update_handle(&requester, &PDS_PLC_ROTATION_KEYPAIR.secret_key(), &handle)
+                    .await?;
+            }
             account_manager.update_handle(&requester, &handle).await?;
         }
     }

--- a/rsky-pds/src/apis/com/atproto/repo/import_repo.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/import_repo.rs
@@ -148,33 +148,38 @@ async fn prepare_import_repo_writes(
             let did = _did.clone();
             async move {
                 Ok::<PreparedWrite, anyhow::Error>(match write {
+                    // Imported records already exist and were verified
+                    // against the CAR's MST, so they are indexed under the
+                    // CAR's own CIDs (never a recomputed one, which diverges
+                    // the moment a re-encode differs by a byte) and are not
+                    // re-validated against local lexicons.
                     RecordWriteDescript::Create(write) => {
                         let parsed_record = get_and_parse_record(blocks, write.cid)?;
-                        PreparedWrite::Create(
-                            prepare_create(PrepareCreateOpts {
-                                did: did.clone(),
-                                collection: write.collection,
-                                rkey: Some(write.rkey),
-                                swap_cid: None,
-                                record: parsed_record.record,
-                                validate: Some(true),
-                            })
-                            .await?,
-                        )
+                        let mut prepared = prepare_create(PrepareCreateOpts {
+                            did: did.clone(),
+                            collection: write.collection,
+                            rkey: Some(write.rkey),
+                            swap_cid: None,
+                            record: parsed_record.record,
+                            validate: Some(false),
+                        })
+                        .await?;
+                        prepared.cid = write.cid;
+                        PreparedWrite::Create(prepared)
                     }
                     RecordWriteDescript::Update(write) => {
                         let parsed_record = get_and_parse_record(blocks, write.cid)?;
-                        PreparedWrite::Update(
-                            prepare_update(PrepareUpdateOpts {
-                                did: did.clone(),
-                                collection: write.collection,
-                                rkey: write.rkey,
-                                swap_cid: None,
-                                record: parsed_record.record,
-                                validate: Some(true),
-                            })
-                            .await?,
-                        )
+                        let mut prepared = prepare_update(PrepareUpdateOpts {
+                            did: did.clone(),
+                            collection: write.collection,
+                            rkey: write.rkey,
+                            swap_cid: None,
+                            record: parsed_record.record,
+                            validate: Some(false),
+                        })
+                        .await?;
+                        prepared.cid = write.cid;
+                        PreparedWrite::Update(prepared)
                     }
                     RecordWriteDescript::Delete(write) => {
                         PreparedWrite::Delete(prepare_delete(PrepareDeleteOpts {

--- a/rsky-pds/src/apis/com/atproto/repo/upload_blob.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/upload_blob.rs
@@ -1,7 +1,7 @@
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessStandardIncludeChecks;
+use crate::auth_verifier::AccessStandardCheckTakedown;
 use anyhow::Result;
 use rocket::data::{Data, ToByteUnit};
 use rocket::http::Status;
@@ -36,7 +36,7 @@ impl<'r> FromRequest<'r> for ContentType {
 }
 
 async fn inner_upload_blob(
-    auth: AccessStandardIncludeChecks,
+    auth: AccessStandardCheckTakedown,
     blob: Data<'_>,
     content_type: ContentType,
     blobstore_factory: &State<BlobstoreFactory>,
@@ -93,7 +93,7 @@ async fn inner_upload_blob(
 #[tracing::instrument(skip_all)]
 #[rocket::post("/xrpc/com.atproto.repo.uploadBlob", data = "<blob>")]
 pub async fn upload_blob(
-    auth: AccessStandardIncludeChecks,
+    auth: AccessStandardCheckTakedown,
     blob: Data<'_>,
     content_type: ContentType,
     blobstore_factory: &State<BlobstoreFactory>,

--- a/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
+++ b/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
@@ -18,11 +18,11 @@ pub async fn inner_get_service_auth(
 ) -> Result<String> {
     let credentials = auth.access.credentials.unwrap();
     let did = credentials.clone().did.unwrap();
-    let exp = exp.map(|exp| exp * 1000);
+    // `exp` is seconds since the epoch (RFC 7519 §4.1.4).
     if let Some(exp) = exp {
         let system_time = SystemTime::now();
         let now: DateTime<UtcOffset> = system_time.into();
-        let diff = from_micros_to_utc(exp as i64) - now;
+        let diff = from_micros_to_utc((exp * 1_000_000) as i64) - now;
         if diff.num_milliseconds() < 0 {
             bail!("BadExpiration: expiration is in past");
         } else if diff.num_milliseconds() > HOUR as i64 {
@@ -42,7 +42,7 @@ pub async fn inner_get_service_auth(
     create_service_jwt(ServiceJwtParams {
         iss: did,
         aud,
-        exp: None,
+        exp,
         lxm,
         jti: None,
     })

--- a/rsky-pds/src/apis/com/atproto/server/mod.rs
+++ b/rsky-pds/src/apis/com/atproto/server/mod.rs
@@ -5,7 +5,9 @@ use rand::{distributions::Alphanumeric, Rng};
 use rocket::form::validate::Contains;
 use rocket::State;
 use rsky_common::env::{env_int, env_str};
+use rsky_common::get_verification_material;
 use rsky_crypto::utils::encode_did_key;
+use rsky_identity::did::atproto_data::get_did_key_from_multibase;
 use rsky_identity::types::DidDocument;
 use secp256k1::{Keypair, Secp256k1, SecretKey};
 use std::env;
@@ -112,8 +114,31 @@ pub async fn assert_valid_did_documents_for_service(did: String) -> Result<()> {
             rotation_keys: Some(resolved.rotation_keys),
         })
         .await?;
+    } else if let Some(host) = did.strip_prefix("did:web:") {
+        // Bare-host did:web: the document lives at the well-known path. No
+        // rotation keys to assert; control of the host is the rotation story.
+        let host = host.replace("%3A", ":").replace("%3a", ":");
+        if host.contains(':') || host.contains('/') {
+            bail!("Unsupported did:web form for activation: {did}")
+        }
+        let url = format!("https://{host}/.well-known/did.json");
+        let doc: DidDocument = reqwest::get(&url).await?.error_for_status()?.json().await?;
+        let pds_endpoint = doc.service.as_deref().and_then(|services| {
+            services
+                .iter()
+                .find(|s| s.id.ends_with("atproto_pds"))
+                .map(|s| s.service_endpoint.clone())
+        });
+        let signing_key = get_verification_material(&doc, "atproto")
+            .and_then(|material| get_did_key_from_multibase(material).ok().flatten());
+        assert_valid_doc_contents(AssertionContents {
+            pds_endpoint,
+            signing_key,
+            rotation_keys: None,
+        })
+        .await?;
     } else {
-        bail!("Not yet supporting did:web")
+        bail!("Unsupported did method: {did}")
     }
     Ok(())
 }

--- a/rsky-pds/src/apis/mod.rs
+++ b/rsky-pds/src/apis/mod.rs
@@ -23,7 +23,10 @@ impl<'a> FromParam<'a> for Nsid {
 
     fn from_param(param: &'a str) -> Result<Self, Self::Error> {
         // This is how we make sure we allowlist lexicons and what gets proxied
-        if param.starts_with("app.bsky.") || param.starts_with("chat.bsky") {
+        if param.starts_with("app.bsky.")
+            || param.starts_with("chat.bsky")
+            || param.starts_with("community.blacksky.")
+        {
             Ok(Nsid(param.to_string()))
         } else {
             Err(param)

--- a/rsky-pds/src/auth_verifier.rs
+++ b/rsky-pds/src/auth_verifier.rs
@@ -155,7 +155,7 @@ pub struct JwtPayload {
     pub jti: Option<String>,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum AuthError {
     #[error("ExpiredToken: `Token is expired`")]
     ExpiredToken,
@@ -398,28 +398,44 @@ pub struct AccessStandard {
     pub access: AccessOutput,
 }
 
+/// One access verification per request, shared between guards. The
+/// pipethrough guard and a handler's own `AccessStandard` both verify the
+/// same request; without this cache the second verification replays the
+/// DPoP proof into the jti guard and every doubled route 400s.
+struct CachedAccessStandard(Result<AccessOutput, (Status, AuthError)>);
+
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for AccessStandard {
     type Error = AuthError;
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        match access_check(
-            req,
-            vec![
-                AuthScope::Access,
-                AuthScope::AppPass,
-                AuthScope::AppPassPrivileged,
-            ],
-            None,
-        )
-        .await
-        {
-            Outcome::Success(access) => Outcome::Success(AccessStandard { access }),
-            Outcome::Error(error) => {
-                req.local_cache(|| Some(ApiError::from(&error.1)));
-                Outcome::Error(error)
+        let cached: &CachedAccessStandard = req
+            .local_cache_async(async {
+                match access_check(
+                    req,
+                    vec![
+                        AuthScope::Access,
+                        AuthScope::AppPass,
+                        AuthScope::AppPassPrivileged,
+                    ],
+                    None,
+                )
+                .await
+                {
+                    Outcome::Success(access) => CachedAccessStandard(Ok(access)),
+                    Outcome::Error(error) => CachedAccessStandard(Err(error)),
+                    Outcome::Forward(_) => panic!("Outcome::Forward returned"),
+                }
+            })
+            .await;
+        match &cached.0 {
+            Ok(access) => Outcome::Success(AccessStandard {
+                access: access.clone(),
+            }),
+            Err((status, error)) => {
+                req.local_cache(|| Some(ApiError::from(error)));
+                Outcome::Error((*status, error.clone()))
             }
-            Outcome::Forward(_) => panic!("Outcome::Forward returned"),
         }
     }
 }

--- a/rsky-pds/src/auth_verifier.rs
+++ b/rsky-pds/src/auth_verifier.rs
@@ -1142,37 +1142,41 @@ pub async fn verify_service_jwt(
     id_resolver: &State<SharedIdResolver>,
     opts: ServiceJwtOpts,
 ) -> Result<VerifiedServiceJwt> {
-    let get_signing_key = |iss: String, force_refresh: bool| -> Result<String> {
-        match &opts.iss {
-            Some(opts_iss) if opts_iss.contains(&iss) => bail!("UntrustedIss: Untrusted issuer"),
-            _ => (),
-        }
-        // `iss` is a bare DID for ordinary service tokens; only labelers
-        // suffix a service fragment.
-        let mut parts = iss.splitn(2, '#');
-        if let Some(did) = parts.next().filter(|did| !did.is_empty()) {
-            let did = did.to_string();
-            let key_id = if parts.next() == Some("atproto_labeler") {
-                "atproto_label"
-            } else {
-                "atproto"
-            };
-            let lock = futures::executor::block_on(id_resolver.id_resolver.write());
-            let did_doc: Result<DidDocument> =
-                futures::executor::block_on(lock.did.ensure_resolve(&did, Some(force_refresh)));
-            let did_doc: DidDocument = match did_doc {
-                Err(err) => bail!("could not resolve iss did: `{err}`"),
-                Ok(res) => res,
-            };
-            match get_verification_material(&did_doc, key_id) {
-                None => bail!("missing or bad key in did doc"),
-                Some(parsed_key) => match get_did_key_from_multibase(parsed_key)? {
-                    None => bail!("missing or bad key in did doc"),
-                    Some(did_key) => Ok(did_key),
-                },
+    let get_signing_key = |iss: String, force_refresh: bool| {
+        let opts_iss = opts.iss.clone();
+        async move {
+            match &opts_iss {
+                Some(opts_iss) if opts_iss.contains(&iss) => {
+                    bail!("UntrustedIss: Untrusted issuer")
+                }
+                _ => (),
             }
-        } else {
-            bail!("could not resolve iss did")
+            // `iss` is a bare DID for ordinary service tokens; only labelers
+            // suffix a service fragment.
+            let mut parts = iss.splitn(2, '#');
+            if let Some(did) = parts.next().filter(|did| !did.is_empty()) {
+                let did = did.to_string();
+                let key_id = if parts.next() == Some("atproto_labeler") {
+                    "atproto_label"
+                } else {
+                    "atproto"
+                };
+                let lock = id_resolver.id_resolver.write().await;
+                let did_doc: DidDocument =
+                    match lock.did.ensure_resolve(&did, Some(force_refresh)).await {
+                        Err(err) => bail!("could not resolve iss did: `{err}`"),
+                        Ok(res) => res,
+                    };
+                match get_verification_material(&did_doc, key_id) {
+                    None => bail!("missing or bad key in did doc"),
+                    Some(parsed_key) => match get_did_key_from_multibase(parsed_key)? {
+                        None => bail!("missing or bad key in did doc"),
+                        Some(did_key) => Ok(did_key),
+                    },
+                }
+            } else {
+                bail!("could not resolve iss did")
+            }
         }
     };
 

--- a/rsky-pds/src/auth_verifier.rs
+++ b/rsky-pds/src/auth_verifier.rs
@@ -1147,10 +1147,12 @@ pub async fn verify_service_jwt(
             Some(opts_iss) if opts_iss.contains(&iss) => bail!("UntrustedIss: Untrusted issuer"),
             _ => (),
         }
-        let parts = iss.split("#").collect::<Vec<&str>>();
-        if let (Some(did), Some(service_id)) = (parts.first(), parts.get(1)) {
-            let (did, service_id) = (did.to_string(), *service_id);
-            let key_id = if service_id == "atproto_labeler" {
+        // `iss` is a bare DID for ordinary service tokens; only labelers
+        // suffix a service fragment.
+        let mut parts = iss.splitn(2, '#');
+        if let Some(did) = parts.next().filter(|did| !did.is_empty()) {
+            let did = did.to_string();
+            let key_id = if parts.next() == Some("atproto_labeler") {
                 "atproto_label"
             } else {
                 "atproto"

--- a/rsky-pds/src/oauth/routes.rs
+++ b/rsky-pds/src/oauth/routes.rs
@@ -137,6 +137,7 @@ pub struct ParFormData {
     pub code_challenge: Option<String>,
     pub code_challenge_method: Option<String>,
     pub login_hint: Option<String>,
+    pub response_mode: Option<String>,
     pub prompt: Option<String>,
     pub client_assertion_type: Option<String>,
     pub client_assertion: Option<String>,
@@ -161,6 +162,7 @@ impl ParFormData {
             code_challenge: self.code_challenge.clone(),
             code_challenge_method: self.code_challenge_method.clone(),
             login_hint: self.login_hint.clone(),
+            response_mode: self.response_mode.clone(),
             prompt: self.prompt.clone(),
         }
     }

--- a/rsky-pds/src/repo/prepare.rs
+++ b/rsky-pds/src/repo/prepare.rs
@@ -10,7 +10,7 @@ use rsky_repo::types::{
     BlobConstraint, Ids, Lex, PreparedBlobRef, PreparedCreateOrUpdate, PreparedDelete, RepoRecord,
     WriteOpAction,
 };
-use rsky_repo::util::{cbor_to_lex, lex_to_ipld};
+use rsky_repo::util::{cbor_to_lex, lex_to_ipld, normalize_record_blob_refs};
 use rsky_syntax::aturi::AtUri;
 use serde_json::{json, Value as JsonValue};
 
@@ -215,7 +215,8 @@ pub async fn prepare_create(opts: PrepareCreateOpts) -> anyhow::Result<PreparedC
     } = opts;
     let validate = validate.unwrap_or(true);
 
-    let record = set_collection_name(&collection, opts.record, validate)?;
+    let record =
+        normalize_record_blob_refs(set_collection_name(&collection, opts.record, validate)?);
     if validate {
         assert_valid_record(&record)?;
     }
@@ -245,7 +246,8 @@ pub async fn prepare_update(opts: PrepareUpdateOpts) -> anyhow::Result<PreparedC
     } = opts;
     let validate = validate.unwrap_or(true);
 
-    let record = set_collection_name(&collection, opts.record, validate)?;
+    let record =
+        normalize_record_blob_refs(set_collection_name(&collection, opts.record, validate)?);
     if validate {
         assert_valid_record(&record)?;
     }

--- a/rsky-pds/src/repo/prepare.rs
+++ b/rsky-pds/src/repo/prepare.rs
@@ -51,22 +51,32 @@ pub fn blobs_for_write(record: RepoRecord, validate: bool) -> anyhow::Result<Vec
         Some(Lex::Ipld(Ipld::String(t))) => Some(t),
         _ => None,
     };
-    for r#ref in refs.clone() {
-        if matches!(r#ref.r#ref.original, JsonBlobRef::Untyped(_)) {
-            bail!("Legacy blob ref at `{}`", r#ref.path.join("/"))
+    if validate {
+        for r#ref in refs.clone() {
+            if matches!(r#ref.r#ref.original, JsonBlobRef::Untyped(_)) {
+                bail!("Legacy blob ref at `{}`", r#ref.path.join("/"))
+            }
         }
     }
     refs.into_iter()
         .map(|FoundBlobRef { r#ref, path }| {
             let constraints: BlobConstraint = match (validate, record_type) {
                 (true, Some(record_type)) => {
-                    let properties: crate::lexicon::lexicons::Image2 = serde_json::from_value(
+                    // Collections without a known constraint table (custom
+                    // lexicons) carry unconstrained blobs rather than failing
+                    // the write.
+                    match serde_json::from_value::<crate::lexicon::lexicons::Image2>(
                         crate::repo::prepare::CONSTRAINTS[record_type.as_str()][path.join("/")]
                             .clone(),
-                    )?;
-                    BlobConstraint {
-                        max_size: Some(properties.max_size as usize),
-                        accept: Some(properties.accept),
+                    ) {
+                        Ok(properties) => BlobConstraint {
+                            max_size: Some(properties.max_size as usize),
+                            accept: Some(properties.accept),
+                        },
+                        Err(_) => BlobConstraint {
+                            max_size: None,
+                            accept: None,
+                        },
                     }
                 }
                 (_, _) => BlobConstraint {

--- a/rsky-pds/src/xrpc_server/auth.rs
+++ b/rsky-pds/src/xrpc_server/auth.rs
@@ -57,14 +57,15 @@ pub fn parse_payload(b64: &str) -> Result<JwtPayload> {
 /// used for that method: without this check a token minted to call one
 /// endpoint can be replayed against every other endpoint this service serves,
 /// which is the whole point of the claim.
-pub async fn verify_jwt<G>(
+pub async fn verify_jwt<G, Fut>(
     jwt_str: String,
     own_did: Option<String>, // None indicates to skip the audience check
     lxm: Option<&str>,
     get_signing_key: G,
 ) -> Result<ServiceJwtPayload>
 where
-    G: Fn(String, bool) -> Result<String>,
+    G: Fn(String, bool) -> Fut,
+    Fut: std::future::Future<Output = Result<String>>,
 {
     let parts = jwt_str.split(".").collect::<Vec<&str>>();
     match (parts.first(), parts.get(1), parts.get(2)) {
@@ -111,7 +112,7 @@ where
                 )
             };
 
-            let signing_key = get_signing_key(payload.iss.clone(), false)?;
+            let signing_key = get_signing_key(payload.iss.clone(), false).await?;
 
             let mut valid_sig: bool = match verify_signature_with_key(signing_key.clone()) {
                 Ok(is_valid) => is_valid,
@@ -123,7 +124,7 @@ where
 
             if !valid_sig {
                 // get fresh signing key in case it failed due to a recent rotation
-                let fresh_signing_key = get_signing_key(payload.iss.clone(), true)?;
+                let fresh_signing_key = get_signing_key(payload.iss.clone(), true).await?;
                 valid_sig = if fresh_signing_key != signing_key {
                     match verify_signature_with_key(fresh_signing_key) {
                         Ok(is_valid) => is_valid,
@@ -184,7 +185,10 @@ mod tests {
             jwt,
             Some("did:web:service".to_string()),
             Some("com.atproto.server.createAccount"),
-            move |_iss, _refresh| Ok(did_key.clone()),
+            move |_iss, _refresh| {
+                let did_key = did_key.clone();
+                async move { Ok(did_key) }
+            },
         )
         .await
         .unwrap();
@@ -208,7 +212,7 @@ mod tests {
         format!("{header}.{payload}.{sig}")
     }
 
-    fn no_key(_iss: String, _refresh: bool) -> Result<String> {
+    async fn no_key(_iss: String, _refresh: bool) -> Result<String> {
         bail!("the lexicon-method check must decide before a key is fetched")
     }
 

--- a/rsky-pds/src/xrpc_server/auth.rs
+++ b/rsky-pds/src/xrpc_server/auth.rs
@@ -1,10 +1,11 @@
 use crate::account_manager::helpers::auth::{create_service_jwt, ServiceJwtParams};
 use anyhow::{anyhow, bail, Result};
 use atrium_api::xrpc::http::HeaderMap;
-use base64ct::{Base64, Encoding};
+use base64ct::{Base64, Base64UrlUnpadded, Encoding};
 use reqwest::header::{HeaderValue, AUTHORIZATION};
 use rsky_crypto::types::VerifyOptions;
-use rsky_crypto::verify::verify_signature;
+use rsky_crypto::verify::verify_signature_digest;
+use sha2::{Digest, Sha256};
 use std::time::{Duration, SystemTime};
 
 #[derive(Debug)]
@@ -36,11 +37,12 @@ pub async fn create_service_auth_headers(params: ServiceJwtParams) -> Result<Hea
 }
 
 pub fn parse_b64_url_to_json(b64: &str) -> Result<JwtPayload> {
-    Ok(serde_json::from_slice::<JwtPayload>(
-        Base64::decode_vec(b64)
-            .map_err(|err| anyhow!(err.to_string()))?
-            .as_slice(),
-    )?)
+    // JWT segments are base64url unpadded; standard base64 is accepted as a
+    // fallback for tokens minted by older rsky builds.
+    let bytes = Base64UrlUnpadded::decode_vec(b64)
+        .or_else(|_| Base64::decode_vec(b64))
+        .map_err(|err| anyhow!(err.to_string()))?;
+    Ok(serde_json::from_slice::<JwtPayload>(bytes.as_slice())?)
 }
 
 pub fn parse_payload(b64: &str) -> Result<JwtPayload> {
@@ -70,11 +72,13 @@ where
             let parts_1 = *parts_1;
             let sig = *sig;
             let payload = parse_payload(parts_1)?;
+            // `exp` is seconds since the epoch (RFC 7519 §4.1.4), which is
+            // what every other implementation mints.
             let now = SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
-                .expect("timestamp in micros since UNIX epoch")
-                .as_micros();
-            if now > payload.exp as u128 {
+                .expect("timestamp since UNIX epoch")
+                .as_secs();
+            if now > payload.exp {
                 bail!("JwtExpired: jwt expired")
             }
             if own_did.is_some() && payload.aud != own_did.unwrap() {
@@ -89,14 +93,17 @@ where
                 }
                 _ => {}
             }
-            let msg_bytes = parts[0..2].join(".").into_bytes();
-            let sig_bytes = Base64::encode_string(sig.as_bytes())
-                .replace("=", "")
-                .into_bytes();
+            // The signature covers the ASCII of `header.payload`; both curves
+            // sign its sha256 digest. The signature segment is base64url raw
+            // bytes (compact or DER).
+            let msg_digest = Sha256::digest(parts[0..2].join(".").as_bytes());
+            let sig_bytes = Base64UrlUnpadded::decode_vec(sig)
+                .or_else(|_| Base64::decode_vec(sig))
+                .map_err(|_| anyhow!("BadJwt: invalid signature encoding"))?;
             let verify_signature_with_key = |key: String| -> Result<bool> {
-                verify_signature(
+                verify_signature_digest(
                     &key,
-                    msg_bytes.as_slice(),
+                    msg_digest.as_slice(),
                     sig_bytes.as_slice(),
                     Some(VerifyOptions {
                         allow_malleable_sig: Some(true),
@@ -137,7 +144,7 @@ where
             Ok(ServiceJwtPayload {
                 iss: payload.iss,
                 aud: payload.aud,
-                exp: Some(Duration::from_micros(payload.exp)),
+                exp: Some(Duration::from_secs(payload.exp)),
                 lxm: payload.lxm,
             })
         }
@@ -149,6 +156,41 @@ where
 mod tests {
     use super::*;
 
+    /// A token minted by `create_service_jwt` must verify against the mint
+    /// keypair's did:key — the full round trip other PDSes exercise. This is
+    /// the test that catches an encode/verify mismatch a claims-only test
+    /// cannot.
+    #[tokio::test]
+    async fn a_minted_token_verifies_end_to_end() {
+        use crate::context::PDS_REPO_SIGNING_KEYPAIR;
+        use rsky_crypto::utils::encode_did_key;
+        if std::env::var("PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX").is_err() {
+            std::env::set_var(
+                "PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX",
+                "1717171717171717171717171717171717171717171717171717171717171717",
+            );
+        }
+        let jwt = create_service_jwt(ServiceJwtParams {
+            iss: "did:plc:issuer".to_string(),
+            aud: "did:web:service".to_string(),
+            exp: None,
+            lxm: Some("com.atproto.server.createAccount".to_string()),
+            jti: None,
+        })
+        .await
+        .unwrap();
+        let did_key = encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key());
+        let payload = verify_jwt(
+            jwt,
+            Some("did:web:service".to_string()),
+            Some("com.atproto.server.createAccount"),
+            move |_iss, _refresh| Ok(did_key.clone()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(payload.iss, "did:plc:issuer");
+    }
+
     /// `iat`/`exp` are microseconds here, matching `verify_jwt`.
     fn token(lxm: Option<&str>) -> String {
         let payload = serde_json::json!({
@@ -157,9 +199,13 @@ mod tests {
             "exp": u64::MAX,
             "lxm": lxm,
         });
-        let header = Base64::encode_string(br#"{"typ":"JWT","alg":"ES256K"}"#);
-        let payload = Base64::encode_string(serde_json::to_vec(&payload).unwrap().as_slice());
-        format!("{header}.{payload}.signature")
+        let header = Base64UrlUnpadded::encode_string(br#"{"typ":"JWT","alg":"ES256K"}"#);
+        let payload =
+            Base64UrlUnpadded::encode_string(serde_json::to_vec(&payload).unwrap().as_slice());
+        // A decodable-but-wrong signature, so claim checks decide first and
+        // the key fetch is the furthest a passing claim set can reach.
+        let sig = Base64UrlUnpadded::encode_string(&[0u8; 64]);
+        format!("{header}.{payload}.{sig}")
     }
 
     fn no_key(_iss: String, _refresh: bool) -> Result<String> {

--- a/rsky-repo/Cargo.toml
+++ b/rsky-repo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-repo"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust crate for atproto repositories, an in particular the Merkle Search Tree (MST) data structure."
 license = "Apache-2.0"

--- a/rsky-repo/Cargo.toml
+++ b/rsky-repo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-repo"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust crate for atproto repositories, an in particular the Merkle Search Tree (MST) data structure."
 license = "Apache-2.0"

--- a/rsky-repo/Cargo.toml
+++ b/rsky-repo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-repo"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust crate for atproto repositories, an in particular the Merkle Search Tree (MST) data structure."
 license = "Apache-2.0"

--- a/rsky-repo/src/repo.rs
+++ b/rsky-repo/src/repo.rs
@@ -5,8 +5,8 @@ use crate::error::DataStoreError;
 use crate::mst::MST;
 use crate::storage::types::RepoStorage;
 use crate::types::{
-    CollectionContents, Commit, CommitData, RecordCreateOrUpdateOp, RecordWriteEnum, RecordWriteOp,
-    RepoContents, RepoRecord, UnsignedCommit,
+    CollectionContents, Commit, CommitData, Lex, RecordCreateOrUpdateOp, RecordWriteEnum,
+    RecordWriteOp, RepoContents, RepoRecord, UnsignedCommit,
 };
 use crate::util;
 use anyhow::{bail, Result};
@@ -160,7 +160,7 @@ impl Repo {
         let mut new_blocks = BlockMap::new();
         let mut data = MST::create(storage, None, None).await?;
         for record in initial_writes.unwrap_or_default() {
-            let cid = new_blocks.add(record.record)?;
+            let cid = new_blocks.add(util::lex_to_ipld(Lex::Map(record.record)))?;
             let data_key = util::format_data_key(record.collection, record.rkey);
             data = data.add(&data_key, cid, None).await?;
         }
@@ -229,12 +229,12 @@ impl Repo {
         for write in writes.clone() {
             match write {
                 RecordWriteOp::Create(write) => {
-                    let cid = leaves.add(write.record)?;
+                    let cid = leaves.add(util::lex_to_ipld(Lex::Map(write.record)))?;
                     let data_key = util::format_data_key(write.collection, write.rkey);
                     data = data.add(&data_key, cid, None).await?;
                 }
                 RecordWriteOp::Update(write) => {
-                    let cid = leaves.add(write.record)?;
+                    let cid = leaves.add(util::lex_to_ipld(Lex::Map(write.record)))?;
                     let data_key = util::format_data_key(write.collection, write.rkey);
                     data = data.update(&data_key, cid).await?;
                 }
@@ -464,7 +464,9 @@ mod tests {
                     claims.push(RecordCidClaim {
                         collection: coll.to_string(),
                         rkey: rkey.to_string(),
-                        cid: Some(cid_for_cbor(coll_content.get(rkey).unwrap())?),
+                        cid: Some(cid_for_cbor(&util::lex_to_ipld(Lex::Map(
+                            coll_content.get(rkey).unwrap().clone(),
+                        )))?),
                     });
                 }
             }
@@ -1150,13 +1152,14 @@ mod tests {
                 None => bail!("Could not find record for claim"),
                 Some(found_claim) => assert_eq!(
                     found_claim.cid,
-                    Some(cid_for_cbor(
+                    Some(cid_for_cbor(&util::lex_to_ipld(Lex::Map(
                         repo_data
                             .get(&record.collection)
                             .unwrap()
                             .get(&record.rkey)
                             .unwrap()
-                    )?)
+                            .clone()
+                    )))?)
                 ),
             }
         }

--- a/rsky-repo/src/util.rs
+++ b/rsky-repo/src/util.rs
@@ -9,6 +9,7 @@ use futures::{stream, Stream, StreamExt, TryStreamExt};
 use lexicon_cid::Cid;
 use rsky_common::sign::sign_without_indexmap;
 use rsky_common::tid::Ticker;
+use rsky_lexicon::blob_refs::{BlobRef, JsonBlobRef};
 use secp256k1::Keypair;
 use serde_json::Value as JsonValue;
 use sha2::{Digest, Sha256};
@@ -70,10 +71,38 @@ pub fn lex_to_ipld(val: Lex) -> Ipld {
     }
 }
 
+/// A DAG-CBOR blob reference decodes as an `Ipld::Map` whose `ref` is an
+/// `Ipld::Link`; recognize that shape here or every blob ref parsed from a
+/// CAR dissolves into a plain map and record-blob associations are lost.
+fn ipld_map_as_blob(map: &BTreeMap<String, Ipld>) -> Option<BlobRef> {
+    let typed = matches!(map.get("$type"), Some(Ipld::String(t)) if t == "blob");
+    let legacy = matches!(map.get("cid"), Some(Ipld::String(_)))
+        && matches!(map.get("mimeType"), Some(Ipld::String(_)));
+    if !typed && !legacy {
+        return None;
+    }
+    let mut obj = serde_json::Map::new();
+    for (key, value) in map {
+        let json = match value {
+            Ipld::Link(cid) => serde_json::json!({ "$link": cid.to_string() }),
+            Ipld::String(s) => JsonValue::String(s.clone()),
+            Ipld::Json(value) => value.clone(),
+            _ => return None,
+        };
+        obj.insert(key.clone(), json);
+    }
+    serde_json::from_value::<JsonBlobRef>(JsonValue::Object(obj))
+        .ok()
+        .map(|original| BlobRef { original })
+}
+
 pub fn ipld_to_lex(val: Ipld) -> Lex {
     match val {
         Ipld::List(list) => Lex::List(list.into_iter().map(ipld_to_lex).collect::<Vec<Lex>>()),
         Ipld::Map(map) => {
+            if let Some(blob) = ipld_map_as_blob(&map) {
+                return Lex::Blob(blob);
+            }
             let mut to_return: BTreeMap<String, Lex> = BTreeMap::new();
             for key in map.keys() {
                 to_return.insert(key.to_owned(), ipld_to_lex(map.get(key).unwrap().clone()));
@@ -218,4 +247,45 @@ where
         buffer.extend_from_slice(&chunk?);
     }
     Ok(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A blob ref decoded from real DAG-CBOR (map with a tag-42 link) must
+    /// come out as `Lex::Blob`, or record-blob associations are silently
+    /// lost on every CAR import.
+    #[test]
+    fn cbor_blob_ref_parses_as_lex_blob() {
+        let cid: Cid = "bafkreiey6e2xp4ncufvsyfmubucbsz5xujbc7lguospuziohtgfdik3pr4"
+            .parse()
+            .unwrap();
+        let record = Ipld::Map(BTreeMap::from([
+            (
+                "$type".to_string(),
+                Ipld::String("app.bsky.actor.profile".to_string()),
+            ),
+            (
+                "avatar".to_string(),
+                Ipld::Map(BTreeMap::from([
+                    ("$type".to_string(), Ipld::String("blob".to_string())),
+                    ("ref".to_string(), Ipld::Link(cid)),
+                    (
+                        "mimeType".to_string(),
+                        Ipld::String("image/jpeg".to_string()),
+                    ),
+                    ("size".to_string(), Ipld::Json(JsonValue::from(924586))),
+                ])),
+            ),
+        ]));
+        let bytes = serde_ipld_dagcbor::to_vec(&record).unwrap();
+        let parsed = cbor_to_lex_record(bytes).unwrap();
+        match parsed.get("avatar") {
+            Some(Lex::Blob(blob)) => {
+                assert_eq!(blob.get_cid().unwrap(), cid);
+            }
+            other => panic!("avatar should parse as Lex::Blob, got {other:?}"),
+        }
+    }
 }

--- a/rsky-repo/src/util.rs
+++ b/rsky-repo/src/util.rs
@@ -108,6 +108,11 @@ fn ipld_map_as_blob(map: &BTreeMap<String, Ipld>) -> Option<BlobRef> {
             Ipld::Link(cid) => serde_json::json!({ "$link": cid.to_string() }),
             Ipld::String(s) => JsonValue::String(s.clone()),
             Ipld::Json(value) => value.clone(),
+            // A JSON-born ref arrives as a one-key map, not a link.
+            Ipld::Map(inner) if inner.len() == 1 => match inner.get("$link") {
+                Some(Ipld::String(link)) => serde_json::json!({ "$link": link }),
+                _ => return None,
+            },
             _ => return None,
         };
         obj.insert(key.clone(), json);
@@ -138,6 +143,30 @@ pub fn ipld_to_lex(val: Ipld) -> Lex {
             Lex::Blob(serde_json::from_value(blob).expect("Issue deserializing blob"))
         }
         _ => Lex::Ipld(val),
+    }
+}
+
+/// Re-anchor blob refs in a record that was deserialized from JSON: untagged
+/// serde lands every JSON object on the generic Ipld map, so without this a
+/// blob ref never becomes `Lex::Blob` and its block encodes a `$link` map
+/// instead of a tag-42 link.
+pub fn normalize_record_blob_refs(record: RepoRecord) -> RepoRecord {
+    record
+        .into_iter()
+        .map(|(key, value)| (key, normalize_lex_blob_refs(value)))
+        .collect()
+}
+
+fn normalize_lex_blob_refs(val: Lex) -> Lex {
+    match val {
+        Lex::Ipld(ipld) => ipld_to_lex(ipld),
+        Lex::Map(map) => Lex::Map(
+            map.into_iter()
+                .map(|(key, value)| (key, normalize_lex_blob_refs(value)))
+                .collect(),
+        ),
+        Lex::List(list) => Lex::List(list.into_iter().map(normalize_lex_blob_refs).collect()),
+        blob => blob,
     }
 }
 
@@ -311,6 +340,31 @@ mod tests {
         assert!(matches!(record.get("avatar"), Some(Lex::Blob(_))));
         let reencoded = serde_ipld_dagcbor::to_vec(&lex_to_ipld(Lex::Map(record))).unwrap();
         assert_eq!(reencoded, original_bytes);
+    }
+
+    /// The JSON write path: a record parsed from an API body must normalize
+    /// its blob refs to `Lex::Blob` so its block encodes the same tag-42
+    /// bytes a CAR-imported copy carries.
+    #[test]
+    fn json_born_blob_ref_normalizes_and_encodes_tag42() {
+        let record: RepoRecord = serde_json::from_value(serde_json::json!({
+            "$type": "app.bsky.actor.profile",
+            "avatar": {
+                "$type": "blob",
+                "ref": { "$link": "bafkreiey6e2xp4ncufvsyfmubucbsz5xujbc7lguospuziohtgfdik3pr4" },
+                "mimeType": "image/jpeg",
+                "size": 924586
+            }
+        }))
+        .unwrap();
+        let normalized = normalize_record_blob_refs(record);
+        assert!(matches!(normalized.get("avatar"), Some(Lex::Blob(_))));
+        let bytes = serde_ipld_dagcbor::to_vec(&lex_to_ipld(Lex::Map(normalized))).unwrap();
+        assert!(bytes.windows(2).any(|window| window == [0xd8, 0x2a]));
+        // and it must equal the CBOR-native encoding of the same record
+        let reparsed = cbor_to_lex_record(bytes.clone()).unwrap();
+        let reencoded = serde_ipld_dagcbor::to_vec(&lex_to_ipld(Lex::Map(reparsed))).unwrap();
+        assert_eq!(reencoded, bytes);
     }
 
     /// A blob ref decoded from real DAG-CBOR (map with a tag-42 link) must

--- a/rsky-repo/src/util.rs
+++ b/rsky-repo/src/util.rs
@@ -58,9 +58,30 @@ pub fn lex_to_ipld(val: Lex) -> Ipld {
             }
             Ipld::Map(to_return)
         }
-        Lex::Blob(blob) => {
-            Ipld::Json(serde_json::to_value(blob.original).expect("Issue serializing blob"))
-        }
+        // A blob ref's `ref` must round-trip as a real IPLD link so DAG-CBOR
+        // writes CBOR tag 42; a JSON-shaped `$link` map produces a different
+        // block and a different CID than every other implementation.
+        Lex::Blob(blob) => match blob.original {
+            JsonBlobRef::Typed(typed) => match typed.r#ref.link.parse::<Cid>() {
+                Ok(cid) => Ipld::Map(BTreeMap::from([
+                    ("$type".to_string(), Ipld::String("blob".to_string())),
+                    ("ref".to_string(), Ipld::Link(cid)),
+                    ("mimeType".to_string(), Ipld::String(typed.mime_type)),
+                    (
+                        "size".to_string(),
+                        Ipld::Json(serde_json::Value::from(typed.size)),
+                    ),
+                ])),
+                Err(_) => Ipld::Json(
+                    serde_json::to_value(JsonBlobRef::Typed(typed))
+                        .expect("Issue serializing blob"),
+                ),
+            },
+            JsonBlobRef::Untyped(legacy) => Ipld::Map(BTreeMap::from([
+                ("cid".to_string(), Ipld::String(legacy.cid)),
+                ("mimeType".to_string(), Ipld::String(legacy.mime_type)),
+            ])),
+        },
         Lex::Ipld(ipld) => match ipld {
             Ipld::Json(json_val) => match serde_json::from_value::<Cid>(json_val.clone()) {
                 Ok(cid) => Ipld::Link(cid),
@@ -252,6 +273,45 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The encode direction: a `Lex::Blob` written to DAG-CBOR must emit a
+    /// real tag-42 CID link and re-encode byte-for-byte to what a compliant
+    /// implementation produced, or native writes diverge from every other
+    /// PDS and imported records index under the wrong CID.
+    #[test]
+    fn blob_ref_encodes_as_tag42_and_round_trips() {
+        let cid: Cid = "bafkreiey6e2xp4ncufvsyfmubucbsz5xujbc7lguospuziohtgfdik3pr4"
+            .parse()
+            .unwrap();
+        let original = Ipld::Map(BTreeMap::from([
+            (
+                "$type".to_string(),
+                Ipld::String("app.bsky.actor.profile".to_string()),
+            ),
+            (
+                "avatar".to_string(),
+                Ipld::Map(BTreeMap::from([
+                    ("$type".to_string(), Ipld::String("blob".to_string())),
+                    ("ref".to_string(), Ipld::Link(cid)),
+                    (
+                        "mimeType".to_string(),
+                        Ipld::String("image/jpeg".to_string()),
+                    ),
+                    ("size".to_string(), Ipld::Json(JsonValue::from(924586))),
+                ])),
+            ),
+        ]));
+        let original_bytes = serde_ipld_dagcbor::to_vec(&original).unwrap();
+        // tag 42 present in the source encoding
+        assert!(original_bytes
+            .windows(2)
+            .any(|window| window == [0xd8, 0x2a]));
+        // decode -> Lex (Lex::Blob) -> re-encode must reproduce the bytes
+        let record = cbor_to_lex_record(original_bytes.clone()).unwrap();
+        assert!(matches!(record.get("avatar"), Some(Lex::Blob(_))));
+        let reencoded = serde_ipld_dagcbor::to_vec(&lex_to_ipld(Lex::Map(record))).unwrap();
+        assert_eq!(reencoded, original_bytes);
+    }
 
     /// A blob ref decoded from real DAG-CBOR (map with a tag-42 link) must
     /// come out as `Lex::Blob`, or record-blob associations are silently


### PR DESCRIPTION
Follow-up to #228, found by live account migration and cross-implementation review: inbound service-auth verification (base64url/digest/RFC 7519 seconds/bare iss/async key resolution), did:web activation and handle updates, browser OAuth response_mode=fragment, DPoP guard double-verification, and blob refs now encoding as CBOR tag-42 links with imports keeping the CAR's own CIDs.

Verified live: a did:web account migrated from the TS PDS end to end, and its exported CAR passes byte-level block conformance (tag-42, index == storage).