### PR TITLE
fix(pds): permissioned-data authorization blockers and OAuth error semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-pds"
-version = "0.13.14"
+version = "0.13.15"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-pds"
-version = "0.13.15"
+version = "0.13.16"
 dependencies = [
  "anyhow",
  "argon2",

--- a/rsky-oauth/Cargo.toml
+++ b/rsky-oauth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-oauth"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "OAuth provider core (JOSE, JWK, DPoP) for AT Protocol services"
 license = "Apache-2.0"

--- a/rsky-oauth/src/provider.rs
+++ b/rsky-oauth/src/provider.rs
@@ -764,9 +764,18 @@ impl OAuthProvider {
 
     /// The public JWK set served at /oauth/jwks.
     pub fn jwks(&self) -> JwkSet {
-        JwkSet {
-            keys: vec![self.signing_key.to_public()],
+        let mut key = self.signing_key.to_public();
+        // Advertise `alg` and a stable `kid` so a client can pin the key and
+        // survive rotation (RFC 7517 recommendations).
+        if key.alg.is_none() {
+            if let Ok(curve) = key.curve() {
+                key.alg = Some(curve.alg().to_string());
+            }
         }
+        if key.kid.is_none() {
+            key.kid = Some(key.thumbprint());
+        }
+        JwkSet { keys: vec![key] }
     }
 
     /// RFC 8414 authorization server metadata document.
@@ -2403,6 +2412,18 @@ mod tests {
             .await
             .unwrap()
             .is_none());
+    }
+
+    #[test]
+    fn published_jwks_carries_kid_and_alg() {
+        let setup = setup();
+        let jwks = setup.provider.jwks();
+        let key = &jwks.keys[0];
+        assert!(key.d.is_none(), "private scalar must not be published");
+        assert!(key.kid.is_some(), "kid required for key rotation");
+        assert!(key.alg.is_some(), "alg recommended");
+        // kid is the RFC 7638 thumbprint of the public key.
+        assert_eq!(key.kid.as_deref(), Some(key.thumbprint().as_str()));
     }
 
     #[tokio::test]

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-pds"
-version = "0.13.16"
+version = "0.13.17"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust reference implementation of an atproto PDS."
 license = "Apache-2.0"

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-pds"
-version = "0.13.14"
+version = "0.13.15"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust reference implementation of an atproto PDS."
 license = "Apache-2.0"

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-pds"
-version = "0.13.15"
+version = "0.13.16"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust reference implementation of an atproto PDS."
 license = "Apache-2.0"

--- a/rsky-pds/src/apis/com/atproto/repo/apply_writes.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/apply_writes.rs
@@ -171,6 +171,20 @@ pub async fn apply_writes(
     account_manager: AccountManager,
 ) -> Result<Json<ApplyWritesOutput>, ApiError> {
     tracing::debug!("@LOG: debug apply_writes {body:#?}");
+    for write in &body.writes {
+        let (collection, action) = match write {
+            ApplyWritesInputRefWrite::Create(w) => {
+                (&w.collection, crate::oauth_scope::RepoAction::Create)
+            }
+            ApplyWritesInputRefWrite::Update(w) => {
+                (&w.collection, crate::oauth_scope::RepoAction::Update)
+            }
+            ApplyWritesInputRefWrite::Delete(w) => {
+                (&w.collection, crate::oauth_scope::RepoAction::Delete)
+            }
+        };
+        crate::apis::assert_repo_scope(&auth.access.credentials, collection, action)?;
+    }
     match inner_apply_writes(
         body,
         auth,

--- a/rsky-pds/src/apis/com/atproto/repo/create_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/create_record.rs
@@ -125,6 +125,11 @@ pub async fn create_record(
     account_manager: AccountManager,
 ) -> Result<Json<CreateRecordOutput>, ApiError> {
     tracing::debug!("@LOG: debug create_record {body:#?}");
+    crate::apis::assert_repo_scope(
+        &auth.access.credentials,
+        &body.collection,
+        crate::oauth_scope::RepoAction::Create,
+    )?;
     match inner_create_record(
         body,
         auth,

--- a/rsky-pds/src/apis/com/atproto/repo/delete_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/delete_record.rs
@@ -105,6 +105,11 @@ pub async fn delete_record(
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
+    crate::apis::assert_repo_scope(
+        &auth.access.credentials,
+        &body.collection,
+        crate::oauth_scope::RepoAction::Delete,
+    )?;
     match inner_delete_record(
         body,
         auth,

--- a/rsky-pds/src/apis/com/atproto/repo/get_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/get_record.rs
@@ -78,6 +78,9 @@ pub async fn get_record(
     req: ProxyRequest<'_>,
     account_manager: AccountManager,
 ) -> Result<Json<GetRecordOutput>, ApiError> {
+    // social-app substring-matches "Could not locate record: <at-uri>", so
+    // the not-found message must carry the requested uri.
+    let uri = format!("at://{repo}/{collection}/{rkey}");
     match inner_get_record(
         repo,
         collection,
@@ -93,7 +96,9 @@ pub async fn get_record(
         Ok(res) => Ok(Json(res)),
         Err(error) => {
             tracing::error!("@LOG: ERROR: {error}");
-            Err(ApiError::RecordNotFound)
+            Err(ApiError::RecordNotFoundUri(format!(
+                "Could not locate record: {uri}"
+            )))
         }
     }
 }

--- a/rsky-pds/src/apis/com/atproto/repo/put_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/put_record.rs
@@ -133,6 +133,16 @@ pub async fn put_record(
     account_manager: AccountManager,
 ) -> Result<Json<PutRecordOutput>, ApiError> {
     tracing::debug!("@LOG: debug put_record {body:#?}");
+    crate::apis::assert_repo_scope(
+        &auth.access.credentials,
+        &body.collection,
+        crate::oauth_scope::RepoAction::Create,
+    )?;
+    crate::apis::assert_repo_scope(
+        &auth.access.credentials,
+        &body.collection,
+        crate::oauth_scope::RepoAction::Update,
+    )?;
     match inner_put_record(
         body,
         auth,

--- a/rsky-pds/src/apis/com/atproto/space/notify_space_deleted.rs
+++ b/rsky-pds/src/apis/com/atproto/space/notify_space_deleted.rs
@@ -29,13 +29,18 @@ pub async fn space_notify_space_deleted(
 ) -> Result<(), ApiError> {
     let NotifySpaceDeletedInput { space } = body.into_inner();
     let space_id = parse_space_uri(&space)?;
-    let claims =
-        verify_space_service_token(actor_store, id_resolver, &token.0, NOTIFY_SPACE_DELETED_LXM)
-            .await
-            .map_err(|error| {
-                tracing::debug!(%error, "notifySpaceDeleted auth rejected");
-                ApiError::InvalidToken
-            })?;
+    let claims = verify_space_service_token(
+        actor_store,
+        id_resolver,
+        &token.0,
+        NOTIFY_SPACE_DELETED_LXM,
+        &space_id.authority,
+    )
+    .await
+    .map_err(|error| {
+        tracing::debug!(%error, "notifySpaceDeleted auth rejected");
+        ApiError::InvalidToken
+    })?;
     // Only the space authority may announce the space's deletion.
     let iss_did = claims.iss.split('#').next().unwrap_or(&claims.iss);
     if iss_did != space_id.authority {

--- a/rsky-pds/src/apis/com/atproto/space/notify_write.rs
+++ b/rsky-pds/src/apis/com/atproto/space/notify_write.rs
@@ -47,12 +47,18 @@ pub async fn space_notify_write(
 ) -> Result<(), ApiError> {
     let NotifyWriteInput { space, repo, rev } = body.into_inner();
     let space_id = parse_space_uri(&space)?;
-    let claims = verify_space_service_token(actor_store, id_resolver, &token.0, NOTIFY_WRITE_LXM)
-        .await
-        .map_err(|error| {
-            tracing::debug!(%error, "notifyWrite auth rejected");
-            ApiError::InvalidToken
-        })?;
+    let claims = verify_space_service_token(
+        actor_store,
+        id_resolver,
+        &token.0,
+        NOTIFY_WRITE_LXM,
+        &space_id.authority,
+    )
+    .await
+    .map_err(|error| {
+        tracing::debug!(%error, "notifyWrite auth rejected");
+        ApiError::InvalidToken
+    })?;
     // Two legs carry this method. Leg 1 is a repo host telling the space host
     // that one of its members advanced, signed by that member. Leg 2 is the
     // space host forwarding that to a registered subscriber, signed by the
@@ -67,6 +73,17 @@ pub async fn space_notify_write(
     }
     let (_, space_store, keypair) =
         local_space_def(actor_store, blobstore_factory, &space_id).await?;
+    let fresh = space_store
+        .consume_jti(
+            &claims.jti,
+            claims.exp as i64,
+            crate::space_auth::now_secs() as i64,
+        )
+        .await
+        .map_err(space_error)?;
+    if !fresh {
+        return Err(ApiError::InvalidToken);
+    }
     space_store
         .upsert_writer(&space_id.uri(), &repo, &rev, None)
         .await

--- a/rsky-pds/src/apis/mod.rs
+++ b/rsky-pds/src/apis/mod.rs
@@ -55,6 +55,35 @@ pub fn assert_valid_token_method(
     Ok(())
 }
 
+/// Enforce a granular OAuth session's `repo:` scope on a record write.
+///
+/// A session that carries `repo:` grants but no `transition:generic` is
+/// confined to the collections and actions those grants name (proposal 0016
+/// §Scopes). Legacy transition sessions and app passwords carry no `repo:`
+/// grant and are unaffected. Without this a token scoped to one collection
+/// can write any collection.
+pub fn assert_repo_scope(
+    credentials: &Option<Credentials>,
+    collection: &str,
+    action: crate::oauth_scope::RepoAction,
+) -> Result<(), ApiError> {
+    let Some(granted) = credentials.as_ref().and_then(|c| c.granted_scopes.as_ref()) else {
+        return Ok(());
+    };
+    let scopes = crate::oauth_scope::GrantedScopes::parse(granted);
+    if !scopes.is_granular_repo_session() {
+        return Ok(());
+    }
+    if scopes.allows_repo(collection, action) {
+        Ok(())
+    } else {
+        Err(ApiError::BadRequest(
+            "InvalidToken".to_string(),
+            format!("Token scope does not permit {action:?} on {collection}"),
+        ))
+    }
+}
+
 // Lower ranks have higher presidence
 #[tracing::instrument(skip_all)]
 #[allow(unused_variables)]
@@ -473,7 +502,9 @@ impl<'r, 'o: 'r> ::rocket::response::Responder<'r, 'o> for ApiError {
                     "json",
                     &[],
                 )));
-                res.set_status(Status { code: 404u16 });
+                // XRPC maps a named error like RecordNotFound to 400, not 404;
+                // 404 is reserved for an unknown route.
+                res.set_status(Status { code: 400u16 });
                 Ok(res)
             }
         }

--- a/rsky-pds/src/apis/mod.rs
+++ b/rsky-pds/src/apis/mod.rs
@@ -528,6 +528,13 @@ impl From<&AuthError> for ApiError {
     fn from(error: &AuthError) -> Self {
         match error {
             AuthError::ExpiredToken => ApiError::ExpiredToken,
+            // A missing or revoked credential, or one from an untrusted
+            // issuer or for the wrong audience, is an authentication failure
+            // and surfaces as 401. A malformed token (`BadJwt`) stays a 400
+            // client error so the two remain distinguishable.
+            AuthError::AuthRequired(_)
+            | AuthError::BadJwtAudience(_)
+            | AuthError::UntrustedIss(_) => ApiError::AuthRequiredError(error.to_string()),
             other => ApiError::InvalidRequest(other.to_string()),
         }
     }

--- a/rsky-pds/src/apis/mod.rs
+++ b/rsky-pds/src/apis/mod.rs
@@ -77,10 +77,9 @@ pub fn assert_repo_scope(
     if scopes.allows_repo(collection, action) {
         Ok(())
     } else {
-        Err(ApiError::BadRequest(
-            "InvalidToken".to_string(),
-            format!("Token scope does not permit {action:?} on {collection}"),
-        ))
+        Err(ApiError::InsufficientScope(format!(
+            "Token scope does not permit {action:?} on {collection}"
+        )))
     }
 }
 
@@ -153,7 +152,11 @@ pub enum ApiError {
     InvalidRequest(String),
     ExpiredToken,
     InvalidToken,
+    /// A scope-limited token that does not cover the requested write.
+    InsufficientScope(String),
     RecordNotFound,
+    /// RecordNotFound carrying the requested at-uri in the message.
+    RecordNotFoundUri(String),
     InvalidHandle,
     InvalidEmail,
     InvalidPassword,
@@ -260,6 +263,36 @@ impl<'r, 'o: 'r> ::rocket::response::Responder<'r, 'o> for ApiError {
                 let body = Json(ErrorBody {
                     error: "InvalidToken".to_string(),
                     message: "Token is invalid".to_string(),
+                });
+                let mut res =
+                    <Json<ErrorBody> as ::rocket::response::Responder>::respond_to(body, __req)?;
+                res.set_header(ContentType(rocket::http::MediaType::const_new(
+                    "application",
+                    "json",
+                    &[],
+                )));
+                res.set_status(Status { code: 400u16 });
+                Ok(res)
+            }
+            ApiError::InsufficientScope(message) => {
+                let body = Json(ErrorBody {
+                    error: "InsufficientScope".to_string(),
+                    message: message.clone(),
+                });
+                let mut res =
+                    <Json<ErrorBody> as ::rocket::response::Responder>::respond_to(body, __req)?;
+                res.set_header(ContentType(rocket::http::MediaType::const_new(
+                    "application",
+                    "json",
+                    &[],
+                )));
+                res.set_status(Status { code: 403u16 });
+                Ok(res)
+            }
+            ApiError::RecordNotFoundUri(message) => {
+                let body = Json(ErrorBody {
+                    error: "RecordNotFound".to_string(),
+                    message: message.clone(),
                 });
                 let mut res =
                     <Json<ErrorBody> as ::rocket::response::Responder>::respond_to(body, __req)?;

--- a/rsky-pds/src/auth_verifier.rs
+++ b/rsky-pds/src/auth_verifier.rs
@@ -266,6 +266,10 @@ pub async fn access_check(
                 Status::BadRequest,
                 AuthError::AccountTakedown(error.to_string()),
             )),
+            Some(AuthError::AuthRequired(error)) => Outcome::Error((
+                Status::Unauthorized,
+                AuthError::AuthRequired(error.to_string()),
+            )),
             _ if is_expired_jwt(&error) => {
                 Outcome::Error((Status::BadRequest, AuthError::ExpiredToken))
             }
@@ -1009,7 +1013,12 @@ async fn validate_dpop_access_token(
                     )),
                 },
             );
-            bail!("{}", error.error_description())
+            // A rejected access token (invalid signature, or revoked/unknown
+            // in the token store) is an authentication failure, surfaced as
+            // 401 rather than a 400 client error.
+            return Err(anyhow::Error::new(AuthError::AuthRequired(
+                error.error_description().to_string(),
+            )));
         }
     };
     let scope = oauth_scopes_to_auth_scope(&verified.scopes)?;

--- a/rsky-pds/src/oauth_scope.rs
+++ b/rsky-pds/src/oauth_scope.rs
@@ -47,11 +47,69 @@ pub enum OAuthScope {
     Unknown(String),
 }
 
+/// A repository write action named in a `repo:` scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepoAction {
+    Create,
+    Update,
+    Delete,
+}
+
+/// Parse a `repo:` scope suffix into its collections and actions, applying
+/// the proposal's defaults (no collection = all, no action = all three).
+fn parse_repo_scope(suffix: &str) -> (Vec<String>, Vec<RepoAction>) {
+    let (positional, params) = match suffix.find('?') {
+        Some(pos) => (
+            Some(&suffix[..pos]).filter(|p| !p.is_empty()),
+            Some(&suffix[pos + 1..]),
+        ),
+        None => (Some(suffix).filter(|p| !p.is_empty()), None),
+    };
+    let mut collections: Vec<String> = Vec::new();
+    if let Some(nsid) = positional {
+        collections.push(nsid.to_string());
+    }
+    let mut actions: Vec<RepoAction> = Vec::new();
+    if let Some(params) = params {
+        for pair in params.split('&') {
+            let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+            match key {
+                "collection" if !value.is_empty() => collections.push(value.to_string()),
+                "action" => match value {
+                    "create" => actions.push(RepoAction::Create),
+                    "update" => actions.push(RepoAction::Update),
+                    "delete" => actions.push(RepoAction::Delete),
+                    "*" => {
+                        actions.extend([RepoAction::Create, RepoAction::Update, RepoAction::Delete])
+                    }
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+    }
+    if collections.is_empty() {
+        collections.push("*".to_string());
+    }
+    if actions.is_empty() {
+        actions.extend([RepoAction::Create, RepoAction::Update, RepoAction::Delete]);
+    }
+    (collections, actions)
+}
+
 impl OAuthScope {
     #[must_use]
     pub fn parse(token: &str) -> Self {
         if token == SCOPE_ATPROTO {
             return OAuthScope::Atproto;
+        }
+        // `repo` accepts three surface forms: bare `repo`, `repo:<nsid>`
+        // shorthand, and `repo?<params>` query form.
+        if token == "repo" {
+            return OAuthScope::Repo(String::new());
+        }
+        if let Some(rest) = token.strip_prefix("repo?") {
+            return OAuthScope::Repo(format!("?{rest}"));
         }
         for (prefix, ctor) in [
             (
@@ -138,6 +196,35 @@ impl GrantedScopes {
     #[must_use]
     pub fn has_permission_grant(&self) -> bool {
         self.scopes.iter().any(OAuthScope::is_permission_grant)
+    }
+
+    /// Whether a granular OAuth session (one carrying `repo:`/permission
+    /// grants but no `transition:generic`) governs this write. Legacy
+    /// transition sessions and app passwords are `None` here and enforced by
+    /// the existing scope model instead.
+    #[must_use]
+    pub fn is_granular_repo_session(&self) -> bool {
+        !self.has_transition("generic")
+            && self.scopes.iter().any(|s| matches!(s, OAuthScope::Repo(_)))
+    }
+
+    /// Whether some granted `repo:` scope permits `action` on `collection`.
+    ///
+    /// `repo:<nsid>` is shorthand for `repo?collection=<nsid>`; a missing
+    /// collection means all collections, a missing action means all three
+    /// actions, and `*` is the wildcard in either position (proposal 0016
+    /// §Scopes, matching the reference `allows_repo`).
+    #[must_use]
+    pub fn allows_repo(&self, collection: &str, action: RepoAction) -> bool {
+        self.scopes.iter().any(|s| match s {
+            OAuthScope::Repo(suffix) => {
+                let (collections, actions) = parse_repo_scope(suffix);
+                let collection_ok = collections.iter().any(|c| c == "*" || c == collection);
+                let action_ok = actions.iter().any(|a| *a == action);
+                collection_ok && action_ok
+            }
+            _ => false,
+        })
     }
 
     /// The `space:` grant strings, for [`crate::space_scope`] to evaluate.
@@ -248,6 +335,42 @@ mod tests {
             scopes.space_grants(),
             vec!["space:app.bulleted.space?manage=create&action=read_self".to_string()]
         );
+    }
+
+    #[test]
+    fn repo_scope_confines_collections_and_actions() {
+        let post = "app.bsky.feed.post";
+        let like = "app.bsky.feed.like";
+
+        // A collection-limited grant permits only that collection.
+        let g = GrantedScopes::parse(&["atproto".into(), format!("repo:{post}")]);
+        assert!(g.is_granular_repo_session());
+        assert!(g.allows_repo(post, RepoAction::Create));
+        assert!(g.allows_repo(post, RepoAction::Delete));
+        assert!(!g.allows_repo(like, RepoAction::Create));
+
+        // An action-limited grant permits only that action.
+        let g = GrantedScopes::parse(&["atproto".into(), format!("repo:{post}?action=create")]);
+        assert!(g.allows_repo(post, RepoAction::Create));
+        assert!(!g.allows_repo(post, RepoAction::Delete));
+
+        // `repo:*` covers every collection.
+        let g = GrantedScopes::parse(&["atproto".into(), "repo:*".into()]);
+        assert!(g.allows_repo(like, RepoAction::Update));
+
+        // A legacy transition session is not a granular repo session and is
+        // enforced by the app-password model instead.
+        let g = GrantedScopes::parse(&["atproto".into(), "transition:generic".into()]);
+        assert!(!g.is_granular_repo_session());
+
+        // Multi-valued collections in query form.
+        let g = GrantedScopes::parse(&[
+            "atproto".into(),
+            format!("repo?collection={post}&collection={like}&action=create"),
+        ]);
+        assert!(g.allows_repo(post, RepoAction::Create));
+        assert!(g.allows_repo(like, RepoAction::Create));
+        assert!(!g.allows_repo("app.bsky.feed.repost", RepoAction::Create));
     }
 
     #[test]

--- a/rsky-pds/src/space_auth.rs
+++ b/rsky-pds/src/space_auth.rs
@@ -118,6 +118,9 @@ pub async fn verify_bound_proof(
 pub const NOTIFY_WRITE_LXM: &str = "com.atproto.space.notifyWrite";
 pub const NOTIFY_SPACE_DELETED_LXM: &str = "com.atproto.space.notifySpaceDeleted";
 pub const SPACE_SERVICE_TOKEN_TTL_SECS: u64 = 60;
+/// Allowance for clock drift between the issuer and this PDS when checking
+/// `iat`/`exp` on inbound service tokens.
+pub const SPACE_SERVICE_CLOCK_SKEW_SECS: u64 = 30;
 
 pub fn now_secs() -> u64 {
     SystemTime::now()
@@ -431,6 +434,7 @@ pub fn mint_delegation_token(keypair: &Keypair, user_did: &str, space: &SpaceId)
 pub struct SpaceServiceClaims {
     pub iss: String,
     pub aud: String,
+    pub iat: u64,
     pub exp: u64,
     pub lxm: String,
     pub jti: String,
@@ -445,10 +449,12 @@ pub fn mint_space_service_token(
 ) -> Result<String> {
     let header =
         serde_json::json!({"typ": "JWT", "alg": rsky_crypto::constants::SECP256K1_JWT_ALG});
+    let now = now_secs();
     let claims = SpaceServiceClaims {
         iss: iss.to_string(),
         aud: aud.to_string(),
-        exp: now_secs() + SPACE_SERVICE_TOKEN_TTL_SECS,
+        iat: now,
+        exp: now + SPACE_SERVICE_TOKEN_TTL_SECS,
         lxm: lxm.to_string(),
         jti: get_random_str(),
     };
@@ -471,14 +477,33 @@ pub async fn verify_space_service_token(
     id_resolver: &SharedIdResolver,
     token: &str,
     expected_lxm: &str,
+    expected_aud: &str,
 ) -> Result<SpaceServiceClaims> {
     let parts: Vec<&str> = token.split('.').collect();
     if parts.len() != 3 {
         bail!("poorly formatted jwt");
     }
     let claims: SpaceServiceClaims = serde_json::from_slice(&URL_SAFE_NO_PAD.decode(parts[1])?)?;
-    if claims.exp <= now_secs() {
+    let now = now_secs();
+    if claims.exp <= now {
         bail!("jwt expired");
+    }
+    // iat must be present and recent: not from the future (small skew) and
+    // not older than the token's own lifetime (XRPC service-auth semantics).
+    if claims.iat > now + SPACE_SERVICE_CLOCK_SKEW_SECS {
+        bail!("jwt iat in the future");
+    }
+    if now.saturating_sub(claims.iat) > SPACE_SERVICE_TOKEN_TTL_SECS + SPACE_SERVICE_CLOCK_SKEW_SECS
+    {
+        bail!("jwt iat too old");
+    }
+    // aud must name the recipient (recipient audience validation): the bare
+    // DID of the token audience must be the recipient this PDS acts as, or
+    // any account this PDS hosts (broadcast notifications name a specific
+    // local subscriber rather than the caller's expected recipient).
+    let aud_did = claims.aud.split('#').next().unwrap_or(&claims.aud);
+    if aud_did != expected_aud && !actor_store.exists(aud_did).await.unwrap_or(false) {
+        bail!("bad jwt audience");
     }
     if claims.lxm != expected_lxm {
         bail!("bad lxm: expected {expected_lxm}");
@@ -746,10 +771,15 @@ mod tests {
             NOTIFY_WRITE_LXM,
         )
         .unwrap();
-        let claims =
-            verify_space_service_token(&actor_store, &id_resolver, &token, NOTIFY_WRITE_LXM)
-                .await
-                .unwrap();
+        let claims = verify_space_service_token(
+            &actor_store,
+            &id_resolver,
+            &token,
+            NOTIFY_WRITE_LXM,
+            "did:plc:auth",
+        )
+        .await
+        .unwrap();
         assert_eq!(claims.iss, "did:plc:writer");
         assert_eq!(claims.aud, "did:plc:auth#atproto_space_host");
 
@@ -759,22 +789,28 @@ mod tests {
             &id_resolver,
             &token,
             NOTIFY_SPACE_DELETED_LXM,
+            "did:plc:auth",
         )
         .await
         .unwrap_err();
         assert!(err.to_string().contains("bad lxm"));
 
         // malformed
-        assert!(
-            verify_space_service_token(&actor_store, &id_resolver, "a.b", NOTIFY_WRITE_LXM)
-                .await
-                .is_err()
-        );
+        assert!(verify_space_service_token(
+            &actor_store,
+            &id_resolver,
+            "a.b",
+            NOTIFY_WRITE_LXM,
+            "did:plc:auth"
+        )
+        .await
+        .is_err());
 
         // expired
         let expired_claims = SpaceServiceClaims {
             iss: "did:plc:writer".to_string(),
             aud: "did:plc:auth".to_string(),
+            iat: 900,
             exp: 1000,
             lxm: NOTIFY_WRITE_LXM.to_string(),
             jti: "expired".to_string(),
@@ -787,10 +823,15 @@ mod tests {
         );
         let sig = sign_with_keypair(&keypair, signing_input.as_bytes()).unwrap();
         let expired = format!("{signing_input}.{}", URL_SAFE_NO_PAD.encode(sig));
-        let err =
-            verify_space_service_token(&actor_store, &id_resolver, &expired, NOTIFY_WRITE_LXM)
-                .await
-                .unwrap_err();
+        let err = verify_space_service_token(
+            &actor_store,
+            &id_resolver,
+            &expired,
+            NOTIFY_WRITE_LXM,
+            "did:plc:auth",
+        )
+        .await
+        .unwrap_err();
         assert!(err.to_string().contains("expired"));
 
         // tampered signature
@@ -802,7 +843,8 @@ mod tests {
             &actor_store,
             &id_resolver,
             &parts.join("."),
-            NOTIFY_WRITE_LXM
+            NOTIFY_WRITE_LXM,
+            "did:plc:auth",
         )
         .await
         .is_err());
@@ -815,11 +857,15 @@ mod tests {
             NOTIFY_WRITE_LXM,
         )
         .unwrap();
-        assert!(
-            verify_space_service_token(&actor_store, &id_resolver, &other, NOTIFY_WRITE_LXM)
-                .await
-                .is_err()
-        );
+        assert!(verify_space_service_token(
+            &actor_store,
+            &id_resolver,
+            &other,
+            NOTIFY_WRITE_LXM,
+            "did:plc:auth"
+        )
+        .await
+        .is_err());
 
         // local key resolution shortcut yields the account key
         let did_key =

--- a/rsky-pds/src/space_scope.rs
+++ b/rsky-pds/src/space_scope.rs
@@ -206,13 +206,21 @@ impl SpaceScope {
         }
     }
 
-    fn permits_collection(&self, collection: &str) -> bool {
-        match &self.collections {
-            Some(collections) => collections.iter().any(|c| c == "*" || c == collection),
-            // declared-collections default; see the module note. Wildcard
-            // space types have no declaration, so the default is empty.
-            None => self.space_type != "*",
-        }
+    /// Collection check for a **write**: an omitted collection defaults to the
+    /// space-type declaration's list, which is not resolvable here, so we fail
+    /// closed rather than grant every collection.
+    fn permits_write_collection(&self, collection: &str) -> bool {
+        matches!(&self.collections, Some(collections)
+            if collections.iter().any(|c| c == "*" || c == collection))
+    }
+
+    /// Whether a read_self grant is limited to specific collections. An
+    /// unconstrained read_self covers the holder's whole own repo (reading
+    /// your own data is not a cross-repo leak); a collection-limited one must
+    /// not reach beyond those collections.
+    fn is_collection_limited(&self) -> bool {
+        matches!(&self.collections, Some(collections)
+            if !collections.iter().any(|c| c == "*"))
     }
 
     /// Whole-space read (covers every repo, ignores `collection`).
@@ -230,8 +238,16 @@ impl SpaceScope {
             return false;
         }
         match collection {
-            Some(collection) => self.permits_collection(collection),
-            None => true,
+            // A named collection: authorized when the grant is unconstrained
+            // (covers all own collections) or explicitly lists it.
+            Some(collection) => {
+                !self.is_collection_limited()
+                    || matches!(&self.collections, Some(collections)
+                        if collections.iter().any(|c| c == "*" || c == collection))
+            }
+            // A whole-repo read names no single collection; a collection-
+            // limited read_self must not satisfy it and leak the rest.
+            None => !self.is_collection_limited(),
         }
     }
 
@@ -241,7 +257,7 @@ impl SpaceScope {
             action,
             SpaceAction::Create | SpaceAction::Update | SpaceAction::Delete
         ) && self.has_action(action)
-            && self.permits_collection(collection)
+            && self.permits_write_collection(collection)
     }
 
     /// A space-management operation. Ignores `collection`; omitted by default.
@@ -372,9 +388,18 @@ mod tests {
         // authority defaults to self
         assert!(allowed(s, SELF_DID, &SpaceRequest::Read));
         assert!(!allowed(s, OTHER_AUTH, &SpaceRequest::Read));
-        // write access to declared collections (allow-all interim semantics)
-        assert!(allowed(s, SELF_DID, &write(SpaceAction::Create, THREAD)));
-        assert!(allowed(s, SELF_DID, &write(SpaceAction::Delete, REPLY)));
+        // Writes need an explicit collection: an omitted collection defaults
+        // to the space-type declaration, which is not resolvable here, so
+        // writes fail closed until the grant names its collections.
+        assert!(!allowed(s, SELF_DID, &write(SpaceAction::Create, THREAD)));
+        assert!(!allowed(s, SELF_DID, &write(SpaceAction::Delete, REPLY)));
+        // Naming the collection grants the write.
+        let s_col = "space:com.atmoboards.forum?collection=com.atmoboards.thread";
+        assert!(allowed(
+            s_col,
+            SELF_DID,
+            &write(SpaceAction::Create, THREAD)
+        ));
         // no manage capability by default
         assert!(!allowed(
             s,
@@ -389,7 +414,8 @@ mod tests {
         let s = "space:com.atmoboards.forum?authority=*";
         assert!(allowed(s, OTHER_AUTH, &SpaceRequest::Read));
         assert!(allowed(s, SELF_DID, &SpaceRequest::Read));
-        assert!(allowed(s, OTHER_AUTH, &write(SpaceAction::Create, THREAD)));
+        // write needs an explicit collection (fail-closed default)
+        assert!(!allowed(s, OTHER_AUTH, &write(SpaceAction::Create, THREAD)));
         // a different space type is not covered
         assert!(!authorize(
             &[scope(s)],
@@ -533,8 +559,9 @@ mod tests {
         assert!(!allowed(s, OTHER_AUTH, &write(SpaceAction::Create, THREAD)));
         assert!(!allowed(s, OTHER_AUTH, &SpaceRequest::Read));
 
-        // manage alongside default full record access
-        let s = "space:com.atmoboards.forum?authority=*&manage=update&manage=delete";
+        // manage alongside record access; the write needs an explicit
+        // collection (fail-closed default) while read is unconstrained
+        let s = "space:com.atmoboards.forum?authority=*&collection=com.atmoboards.thread&manage=update&manage=delete";
         assert!(allowed(
             s,
             OTHER_AUTH,

--- a/rsky-pds/tests/oauth_tests.rs
+++ b/rsky-pds/tests/oauth_tests.rs
@@ -334,7 +334,8 @@ async fn oauth_full_flow_with_dpop_bound_resource_access() {
         ))
         .dispatch()
         .await;
-    assert_eq!(response.status(), Status::BadRequest);
+    // RFC 9449 §8: a missing DPoP nonce is challenged with 401 use_dpop_nonce.
+    assert_eq!(response.status(), Status::Unauthorized);
     let resource_nonce = response
         .headers()
         .get_one("DPoP-Nonce")
@@ -377,7 +378,8 @@ async fn oauth_full_flow_with_dpop_bound_resource_access() {
         ))
         .dispatch()
         .await;
-    assert_eq!(response.status(), Status::BadRequest);
+    // A proof signed by the wrong DPoP key is an authentication failure (401).
+    assert_eq!(response.status(), Status::Unauthorized);
     assert!(response
         .headers()
         .get_one("WWW-Authenticate")
@@ -481,7 +483,8 @@ async fn oauth_revocation() {
         ))
         .dispatch()
         .await;
-    assert_eq!(response.status(), Status::BadRequest);
+    // A revoked token is an authentication failure (401), not a client error.
+    assert_eq!(response.status(), Status::Unauthorized);
     assert!(response
         .headers()
         .get_one("WWW-Authenticate")

--- a/rsky-pds/tests/space_integration_tests.rs
+++ b/rsky-pds/tests/space_integration_tests.rs
@@ -1341,13 +1341,10 @@ async fn inbound_notify_space_deleted_flags_local_repos() {
         .keypair(AUTHOR_DID)
         .await
         .unwrap();
-    let token = mint_space_service_token(
-        &keypair,
-        AUTHOR_DID,
-        "did:web:somesyncer.example",
-        NOTIFY_SPACE_DELETED_LXM,
-    )
-    .unwrap();
+    // aud names the recipient (the local authority), per audience validation.
+    let token =
+        mint_space_service_token(&keypair, AUTHOR_DID, AUTHOR_DID, NOTIFY_SPACE_DELETED_LXM)
+            .unwrap();
     let (status, _) = post_json(
         &client,
         "/xrpc/com.atproto.space.notifySpaceDeleted",


### PR DESCRIPTION
Closes the authorization blockers from the Codex / Check Cirrus conformance review (all wire-verified on the dev PDS):

- Critical: repo: scopes were parsed but never enforced — a token scoped to one collection could write any other. Now enforced on create/put/delete/applyWrites (out-of-scope write returns 403 InsufficientScope).
- Space read_self no longer leaks the whole repo for a collection-limited grant; omitted-collection writes fail closed.
- Space notification service-auth carries iat and verifies recipient aud, iat recency, and jti replay.
- Rejected/revoked tokens return 401 (not 400 BadJwt); getRecord not-found carries the at-uri; JWKS advertises kid + alg.

Cirrus PDS + OAuth-flow checks are at zero failures / zero warnings. Residuals documented and non-blocking: PAR-with-application/json returns 500 instead of 400/415; upload-time blob promotion lacks record-level constraints.