### PR TITLE
fix(pds): space reads before the first write are empty, not missing

### DIFF
--- a/rsky-pds/src/actor_store/space/mod.rs
+++ b/rsky-pds/src/actor_store/space/mod.rs
@@ -364,6 +364,25 @@ impl SpaceStore {
         Ok(state)
     }
 
+    /// Repo state for a *read*: `Ok(None)` before the member's first write.
+    ///
+    /// The `space_repo` row is created by [`apply_writes_tx`], so a member who
+    /// has been added to a space but has not written to it yet has no row. That
+    /// is the ordinary pre-first-write state rather than a missing space — the
+    /// same ordering `simplespace::add_member` documents when it indexes a
+    /// membership "before their first write creates a repo row".
+    ///
+    /// A tombstoned repo still errors, which is the half of
+    /// [`Self::live_repo_state`] a read actually needs.
+    pub async fn readable_repo_state(&self, space_uri: &str) -> Result<Option<SpaceRepoState>> {
+        match self.repo_state(space_uri).await? {
+            Some(state) if state.deleted => {
+                Err(SpaceStoreError::SpaceDeleted(space_uri.to_string()).into())
+            }
+            other => Ok(other),
+        }
+    }
+
     pub async fn get_record(
         &self,
         space_uri: &str,
@@ -453,7 +472,12 @@ impl SpaceStore {
         cursor: Option<i64>,
         limit: usize,
     ) -> Result<(Vec<SpaceOplogRow>, bool)> {
-        let state = self.live_repo_state(space_uri).await?;
+        // No repo yet means no ops yet — an empty page rather than a refusal, so a
+        // syncer walking a member from `since = None` gets a clean answer instead of
+        // an error it has to special-case.
+        let Some(state) = self.readable_repo_state(space_uri).await? else {
+            return Ok((Vec::new(), false));
+        };
         if let Some(floor) = state.oplog_floor_rev {
             match since {
                 Some(ref since) if since.as_str() >= floor.as_str() => {}

--- a/rsky-pds/src/actor_store/space/tests.rs
+++ b/rsky-pds/src/actor_store/space/tests.rs
@@ -494,11 +494,11 @@ async fn repo_lifecycle_flags_and_listing() {
         err.downcast_ref::<SpaceStoreError>(),
         Some(SpaceStoreError::SpaceNotFound(_))
     ));
-    let err = store.list_repo_ops(&uri, None, None, 10).await.unwrap_err();
-    assert!(matches!(
-        err.downcast_ref::<SpaceStoreError>(),
-        Some(SpaceStoreError::SpaceNotFound(_))
-    ));
+    // An unwritten repo has no ops rather than no space. This used to assert
+    // `SpaceNotFound`, which made the pre-first-write window unreadable.
+    let (ops, more) = store.list_repo_ops(&uri, None, None, 10).await.unwrap();
+    assert!(ops.is_empty());
+    assert!(!more);
 
     store
         .apply_writes(&space, vec![create("a", "one")], DEFAULT_OPLOG_WINDOW)
@@ -819,4 +819,75 @@ async fn oplog_window_env_override() {
     std::env::set_var("PDS_SPACE_OPLOG_WINDOW", "0");
     assert_eq!(oplog_window(), 1);
     std::env::remove_var("PDS_SPACE_OPLOG_WINDOW");
+}
+
+/// A member added to a space, before they have written anything, reads as empty.
+///
+/// Every member passes through this state exactly once, and an application that
+/// syncs on page load meets them in it. `space_repo` is created by the first
+/// write (see `apply_writes_tx`), so a read that requires the row refuses the
+/// one moment it is guaranteed to be absent.
+#[tokio::test]
+async fn reads_before_the_first_write_are_empty_not_missing() {
+    let (_dir, store) = store().await;
+    let space = space();
+    let uri = space.uri();
+
+    // No write has happened, so there is no repo row.
+    assert!(store.repo_state(&uri).await.unwrap().is_none());
+
+    // ...which a read reports as "nothing here", not as a missing space.
+    assert!(store.readable_repo_state(&uri).await.unwrap().is_none());
+    assert!(store
+        .list_records(&uri, None, 50, None)
+        .await
+        .unwrap()
+        .is_empty());
+    let (ops, more) = store.list_repo_ops(&uri, None, None, 50).await.unwrap();
+    assert!(ops.is_empty());
+    assert!(!more);
+    assert!(store
+        .list_space_blobs(&uri, None, 50)
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(store
+        .get_record(&uri, "com.example.post", "a")
+        .await
+        .unwrap()
+        .is_none());
+
+    // The first write creates the row, and reads keep working afterwards.
+    store
+        .apply_writes(&space, vec![create("a", "one")], DEFAULT_OPLOG_WINDOW)
+        .await
+        .unwrap();
+    assert!(store.readable_repo_state(&uri).await.unwrap().is_some());
+    assert_eq!(
+        store
+            .list_records(&uri, None, 50, None)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+/// A tombstoned repo still errors — the half of `live_repo_state` reads need.
+#[tokio::test]
+async fn readable_repo_state_still_refuses_a_deleted_repo() {
+    let (_dir, store) = store().await;
+    let space = space();
+    let uri = space.uri();
+    store
+        .apply_writes(&space, vec![create("a", "one")], DEFAULT_OPLOG_WINDOW)
+        .await
+        .unwrap();
+    assert!(store.flag_repo_deleted(&uri).await.unwrap());
+
+    let err = store.readable_repo_state(&uri).await.unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<SpaceStoreError>(),
+        Some(SpaceStoreError::SpaceDeleted(_))
+    ));
 }

--- a/rsky-pds/src/apis/com/atproto/space/get_blob.rs
+++ b/rsky-pds/src/apis/com/atproto/space/get_blob.rs
@@ -45,9 +45,10 @@ pub async fn space_get_blob(
         false,
     )
     .await?;
+    // Tombstone gate only. An unreferenced blob yields `BlobNotFound` below.
     reader
         .space
-        .live_repo_state(&space_id.uri())
+        .readable_repo_state(&space_id.uri())
         .await
         .map_err(space_error)?;
     let referenced = reader

--- a/rsky-pds/src/apis/com/atproto/space/get_record.rs
+++ b/rsky-pds/src/apis/com/atproto/space/get_record.rs
@@ -43,9 +43,11 @@ pub async fn space_get_record(
         false,
     )
     .await?;
+    // Tombstone gate only. A repo with no rows yields `RecordNotFound` below,
+    // which is the honest answer for a record that was never written.
     reader
         .space
-        .live_repo_state(&space_id.uri())
+        .readable_repo_state(&space_id.uri())
         .await
         .map_err(space_error)?;
     let record = reader

--- a/rsky-pds/src/apis/com/atproto/space/list_blobs.rs
+++ b/rsky-pds/src/apis/com/atproto/space/list_blobs.rs
@@ -43,10 +43,11 @@ pub async fn space_list_blobs(
         false,
     )
     .await?;
-    // Proves the repo exists in this space before any listing is returned.
+    // A repo with no rows has no blobs to list, which is an empty page rather
+    // than a missing space.
     reader
         .space
-        .live_repo_state(&space_id.uri())
+        .readable_repo_state(&space_id.uri())
         .await
         .map_err(space_error)?;
     let page = reader

--- a/rsky-pds/src/apis/com/atproto/space/list_records.rs
+++ b/rsky-pds/src/apis/com/atproto/space/list_records.rs
@@ -48,9 +48,11 @@ pub async fn space_list_records(
         false,
     )
     .await?;
+    // An unwritten repo is empty, not absent: `listRecords` is exactly the
+    // call an app makes to discover that a member has not written yet.
     reader
         .space
-        .live_repo_state(&space_id.uri())
+        .readable_repo_state(&space_id.uri())
         .await
         .map_err(space_error)?;
     let rows = reader

--- a/rsky-pds/src/apis/com/atproto/space/register_notify.rs
+++ b/rsky-pds/src/apis/com/atproto/space/register_notify.rs
@@ -117,9 +117,10 @@ pub async fn space_register_notify(
                 .map_err(|error| {
                     ApiError::BadRequest("RepoNotFound".to_string(), error.to_string())
                 })?;
+            // A member may subscribe to a space before writing into it.
             reader
                 .space
-                .live_repo_state(&space_id.uri())
+                .readable_repo_state(&space_id.uri())
                 .await
                 .map_err(space_error)?;
             reader


### PR DESCRIPTION
### The problem

`SpaceStore::live_repo_state` answers two questions at once — is this repo tombstoned, and does a `space_repo` row exist — and six space read handlers call it as a precondition. The row is created by the member's **first write** in `apply_writes_tx`, so a member who has been added to a space and has not written yet gets `400 SpaceNotFound` from every read of their repo.

Every member passes through that window exactly once, and an app that syncs a member's repo on page load meets them in it. Observed against a live space whose authority runs a different implementation: `addMember` succeeded, and every subsequent `com.atproto.space.listRecords` for that member returned `SpaceNotFound` until they wrote — which they could not usefully do while the app could not read them back.

`simplespace/add_member.rs` already names the ordering:

> A membership must be discoverable through the member's own listSpaces **before their first write creates a repo row**.

### The change

A new `SpaceStore::readable_repo_state` answers only what a read needs: `Ok(None)` before the first write, and the same `SpaceDeleted` error for a tombstoned repo. Five handlers swap to it and fall through to their naturally empty results; `list_repo_ops` returns an empty page so an incremental syncer can start from `since = None`.

| | before | after |
|---|---|---|
| `listRecords` | `400 SpaceNotFound` | `200 { records: [] }` |
| `getRecord` | `400 SpaceNotFound` | `RecordNotFound` |
| `listBlobs` | `400 SpaceNotFound` | empty page |
| `getBlob` | `400 SpaceNotFound` | `BlobNotFound` |
| `registerNotify` | `400 SpaceNotFound` | registers |
| `listRepoOps` | `400 SpaceNotFound` | empty page |
| tombstoned repo | `SpaceDeleted` | `SpaceDeleted` (unchanged) |

**Deliberately unchanged:** `getRepo` and `getLatestCommit` both sign a commit from `state.rev`/`state.hash()`, and an unwritten repo has no commit to sign. Erroring there is defensible — it just should not be the same error that says the space is missing. Happy to follow up separately if you'd like a distinct code.

**One existing assertion changed:** `repo_lifecycle_flags_and_listing` pinned the old `list_repo_ops` behaviour. That is the one behavioural change worth a second look.

The write path is untouched — `applyWrites` and `putRecord` never required the row and already create it on first commit.

### Verification

- `cargo test -p rsky-pds --lib` — 286 passed
- `cargo fmt --check`, `cargo clippy -p rsky-pds --lib` clean
- New `reads_before_the_first_write_are_empty_not_missing` fails without the fix (verified by reverting `readable_repo_state` to delegate to `live_repo_state`)
- New `readable_repo_state_still_refuses_a_deleted_repo` covers the tombstone half

### Suggested conformance check

*An invited member with no records reads as empty.* Every implementation passes through that state, and it is easy to never test — anything that writes before it reads skips the window entirely.