### PR TITLE
fix(wintermute): propagate batch copy failures to per-job results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -2145,6 +2145,10 @@ impl IndexerManager {
 
         // Collect timing results (only include non-empty collections)
         let mut collection_timings: Vec<(String, u128, usize)> = Vec::new();
+        // Jobs from a failed collection copy must surface as per-job errors so
+        // the caller can requeue them; a dropped error here loses the events.
+        let mut failed_jobs: std::collections::HashMap<&[u8], String> =
+            std::collections::HashMap::new();
 
         let (ms, count, err) = posts_result;
         if count > 0 {
@@ -2153,6 +2157,9 @@ impl IndexerManager {
         if let Some(e) = err {
             tracing::error!("COPY batch insert for posts failed: {e}");
             batch_failed = true;
+            for pj in &posts {
+                failed_jobs.insert(pj.key.as_slice(), e.to_string());
+            }
         }
 
         let (ms, count, err) = likes_result;
@@ -2162,6 +2169,9 @@ impl IndexerManager {
         if let Some(e) = err {
             tracing::error!("COPY batch insert for likes failed: {e}");
             batch_failed = true;
+            for pj in &likes {
+                failed_jobs.insert(pj.key.as_slice(), e.to_string());
+            }
         }
 
         let (ms, count, err) = follows_result;
@@ -2171,6 +2181,9 @@ impl IndexerManager {
         if let Some(e) = err {
             tracing::error!("COPY batch insert for follows failed: {e}");
             batch_failed = true;
+            for pj in &follows {
+                failed_jobs.insert(pj.key.as_slice(), e.to_string());
+            }
         }
 
         let (ms, count, err) = reposts_result;
@@ -2180,6 +2193,9 @@ impl IndexerManager {
         if let Some(e) = err {
             tracing::error!("COPY batch insert for reposts failed: {e}");
             batch_failed = true;
+            for pj in &reposts {
+                failed_jobs.insert(pj.key.as_slice(), e.to_string());
+            }
         }
 
         let (ms, count, err) = blocks_result;
@@ -2189,6 +2205,9 @@ impl IndexerManager {
         if let Some(e) = err {
             tracing::error!("COPY batch insert for blocks failed: {e}");
             batch_failed = true;
+            for pj in &blocks {
+                failed_jobs.insert(pj.key.as_slice(), e.to_string());
+            }
         }
 
         let (ms, count, err) = profiles_result;
@@ -2198,6 +2217,9 @@ impl IndexerManager {
         if let Some(e) = err {
             tracing::error!("COPY batch insert for profiles failed: {e}");
             batch_failed = true;
+            for pj in &profiles {
+                failed_jobs.insert(pj.key.as_slice(), e.to_string());
+            }
         }
 
         // Process "other" collection types sequentially (less common)
@@ -2231,10 +2253,13 @@ impl IndexerManager {
         }
         let collections_ms = collections_start.elapsed().as_millis();
 
-        // All creates succeeded (or were stale)
         for pj in &parsed_jobs {
             metrics::INDEXER_RECORDS_PROCESSED_TOTAL.inc();
-            results.push(((*pj.key).clone(), Ok(())));
+            let result = failed_jobs.get(pj.key.as_slice()).map_or_else(
+                || Ok(()),
+                |msg| Err(WintermuteError::Other(format!("batch copy failed: {msg}"))),
+            );
+            results.push(((*pj.key).clone(), result));
         }
 
         let total_ms = batch_start.elapsed().as_millis();

--- a/rsky-wintermute/src/metrics.rs
+++ b/rsky-wintermute/src/metrics.rs
@@ -474,7 +474,9 @@ pub fn register_pool(name: impl Into<String>, pool: &deadpool_postgres::Pool) {
     let name = name.into();
     // A panicking holder must not take pool observability down with it; the data
     // behind this lock is a plain Vec that cannot be left half-updated.
-    let mut pools = POOLS.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut pools = POOLS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     if let Some(slot) = pools.iter_mut().find(|(n, _)| *n == name) {
         slot.1 = pool.clone();
     } else {
@@ -489,7 +491,9 @@ pub fn register_pool(name: impl Into<String>, pool: &deadpool_postgres::Pool) {
 /// and doing it at scrape time means what is exported is what was true when
 /// Prometheus asked rather than up to a tick earlier.
 pub fn sample_pools() {
-    let pools = POOLS.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let pools = POOLS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     for (name, pool) in pools.iter() {
         let s = pool.status();
         let labels = &[name.as_str()];
@@ -593,8 +597,18 @@ mod pool_metric_tests {
         register_pool("test:distinct_b", &a_pool(4));
         sample_pools();
 
-        assert_eq!(DB_POOL_MAX_SIZE.with_label_values(&["test:distinct_a"]).get(), 3);
-        assert_eq!(DB_POOL_MAX_SIZE.with_label_values(&["test:distinct_b"]).get(), 4);
+        assert_eq!(
+            DB_POOL_MAX_SIZE
+                .with_label_values(&["test:distinct_a"])
+                .get(),
+            3
+        );
+        assert_eq!(
+            DB_POOL_MAX_SIZE
+                .with_label_values(&["test:distinct_b"])
+                .get(),
+            4
+        );
     }
 
     /// A fresh pool holds nothing and nobody is blocked on it. The point of the
@@ -607,7 +621,10 @@ mod pool_metric_tests {
         sample_pools();
 
         assert_eq!(DB_POOL_SIZE.with_label_values(&["test:fresh"]).get(), 0);
-        assert_eq!(DB_POOL_AVAILABLE.with_label_values(&["test:fresh"]).get(), 0);
+        assert_eq!(
+            DB_POOL_AVAILABLE.with_label_values(&["test:fresh"]).get(),
+            0
+        );
         assert_eq!(DB_POOL_WAITING.with_label_values(&["test:fresh"]).get(), 0);
     }
 }


### PR DESCRIPTION
A failed collection COPY logged the error but pushed Ok for every job in the batch, so the drain removed the events from the queue and they were lost. Failed collections now mark their jobs failed so the caller requeues them.

## Test plan
- [x] cargo fmt, clippy clean
- [x] full test suite green (158 lib + integration)
- [x] running in production since 2026-08-13; requeue path observed handling transient failures correctly