### PR TITLE
fix(palomar-sync): cast followersCount to int4 for cross-schema compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6539,7 +6539,7 @@ dependencies = [
 
 [[package]]
 name = "palomar-sync"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "color-eyre",
@@ -8192,7 +8192,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-oauth"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-pds"
-version = "0.13.16"
+version = "0.13.17"
 dependencies = [
  "anyhow",
  "argon2",

--- a/palomar-sync/Cargo.toml
+++ b/palomar-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "palomar-sync"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Sync followersFuzzy and PageRank from PostgreSQL to OpenSearch for Palomar search"

--- a/palomar-sync/src/main.rs
+++ b/palomar-sync/src/main.rs
@@ -180,7 +180,7 @@ async fn sync_followers(config: &Config) -> Result<()> {
     loop {
         let rows = pg
             .query(
-                r#"SELECT did, "followersCount" FROM bsky.profile_agg
+                r#"SELECT did, "followersCount"::int4 FROM bsky.profile_agg
                    WHERE "followersCount" > 0 AND did > $1
                    ORDER BY did
                    LIMIT $2"#,


### PR DESCRIPTION
profile_agg count columns are integer on some deployments and bigint on others; the uncast read panicked on bigint. Cast in SQL so the crate works against both.

## Test plan
- [x] cargo build clean
- [x] full followers sync running in production against a bigint schema at ~3.4K profiles/s