### PR TITLE
fix(pds): consolidate NSID validation onto rsky-syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-pds"
-version = "0.13.17"
+version = "0.13.18"
 dependencies = [
  "anyhow",
  "argon2",

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-pds"
-version = "0.13.17"
+version = "0.13.18"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust reference implementation of an atproto PDS."
 license = "Apache-2.0"

--- a/rsky-pds/src/apis/com/atproto/simplespace/create_space.rs
+++ b/rsky-pds/src/apis/com/atproto/simplespace/create_space.rs
@@ -3,7 +3,7 @@ use crate::actor_store::space::SpaceDefRow;
 use crate::actor_store::ActorStore;
 use crate::apis::com::atproto::simplespace::{merge_config, require_manage, space_error};
 use crate::apis::com::atproto::space::host::{APP_ACCESS_OPEN, POLICY_MEMBER_LIST};
-use crate::apis::com::atproto::space::{valid_key_part, valid_nsid};
+use crate::apis::com::atproto::space::valid_key_part;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessSpace;
 use crate::space_scope::ManageOp;
@@ -12,6 +12,7 @@ use rocket::State;
 use rsky_common::tid::TID;
 use rsky_lexicon::com::atproto::simplespace::{CreateSpaceInput, CreateSpaceOutput};
 use rsky_space::space_id::SpaceId;
+use rsky_syntax::nsid::ensure_valid_nsid;
 
 /// Create a space anchored on the caller's DID: the caller becomes the
 /// authority. Defaults: `member-list` policy, `open` app access.
@@ -34,7 +35,7 @@ pub async fn simplespace_create_space(
     } = body.into_inner();
     let credentials = auth.access.credentials.expect("credentials populated");
     let did = credentials.did.clone().expect("did populated");
-    if !valid_nsid(&space_type) {
+    if ensure_valid_nsid(&space_type).is_err() {
         return Err(ApiError::InvalidRequest(format!(
             "invalid space type: {space_type}"
         )));

--- a/rsky-pds/src/apis/com/atproto/space/apply_writes.rs
+++ b/rsky-pds/src/apis/com/atproto/space/apply_writes.rs
@@ -3,7 +3,6 @@ use crate::actor_store::space::SpaceWrite;
 use crate::actor_store::ActorStore;
 use crate::apis::com::atproto::space::{
     apply_space_writes, commit_meta, parse_space_uri, require_repo_matches_subject, valid_key_part,
-    valid_nsid,
 };
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessSpace;
@@ -17,6 +16,7 @@ use rsky_lexicon::com::atproto::space::{
     ApplyWritesInput, ApplyWritesOutput, ApplyWritesResult, CreateResult, DeleteResult,
     UpdateResult,
 };
+use rsky_syntax::nsid::ensure_valid_nsid;
 
 const MAX_WRITES: usize = 200;
 
@@ -81,7 +81,7 @@ pub async fn space_apply_writes(
                 ))
             }
         };
-        if !valid_nsid(&collection) {
+        if ensure_valid_nsid(&collection).is_err() {
             return Err(ApiError::InvalidRequest(format!(
                 "invalid collection: {collection}"
             )));

--- a/rsky-pds/src/apis/com/atproto/space/create_record.rs
+++ b/rsky-pds/src/apis/com/atproto/space/create_record.rs
@@ -12,8 +12,8 @@ use crate::space_scope::{SpaceAction, SpaceRequest};
 use rocket::serde::json::Json;
 use rocket::State;
 use rsky_common::tid::TID;
-use rsky_syntax::nsid::ensure_valid_nsid;
 use rsky_lexicon::com::atproto::space::{CreateRecordInput, CreateRecordOutput};
+use rsky_syntax::nsid::ensure_valid_nsid;
 
 #[tracing::instrument(skip_all)]
 #[rocket::post(

--- a/rsky-pds/src/apis/com/atproto/space/create_record.rs
+++ b/rsky-pds/src/apis/com/atproto/space/create_record.rs
@@ -3,7 +3,6 @@ use crate::actor_store::space::SpaceWrite;
 use crate::actor_store::ActorStore;
 use crate::apis::com::atproto::space::{
     apply_space_writes, commit_meta, parse_space_uri, require_repo_matches_subject, valid_key_part,
-    valid_nsid,
 };
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessSpace;
@@ -13,6 +12,7 @@ use crate::space_scope::{SpaceAction, SpaceRequest};
 use rocket::serde::json::Json;
 use rocket::State;
 use rsky_common::tid::TID;
+use rsky_syntax::nsid::ensure_valid_nsid;
 use rsky_lexicon::com::atproto::space::{CreateRecordInput, CreateRecordOutput};
 
 #[tracing::instrument(skip_all)]
@@ -40,7 +40,7 @@ pub async fn space_create_record(
     let credentials = auth.access.credentials.expect("credentials populated");
     let did = credentials.did.clone().expect("did populated");
     require_repo_matches_subject(&repo, &did)?;
-    if !valid_nsid(&collection) {
+    if ensure_valid_nsid(&collection).is_err() {
         return Err(ApiError::InvalidRequest(format!(
             "invalid collection: {collection}"
         )));

--- a/rsky-pds/src/apis/com/atproto/space/mod.rs
+++ b/rsky-pds/src/apis/com/atproto/space/mod.rs
@@ -499,14 +499,6 @@ pub fn valid_key_part(part: &str, max_len: usize) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | ':' | '~'))
 }
 
-pub fn valid_nsid(s: &str) -> bool {
-    s.matches('.').count() >= 2
-        && s.len() <= 317
-        && s.split('.').all(|seg| {
-            !seg.is_empty() && seg.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
-        })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rsky-pds/src/apis/com/atproto/space/put_record.rs
+++ b/rsky-pds/src/apis/com/atproto/space/put_record.rs
@@ -3,7 +3,7 @@ use crate::actor_store::space::SpaceWrite;
 use crate::actor_store::ActorStore;
 use crate::apis::com::atproto::space::{
     apply_space_writes, commit_meta, parse_space_uri, require_repo_matches_subject, space_error,
-    valid_key_part, valid_nsid,
+    valid_key_part,
 };
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessSpace;
@@ -13,6 +13,7 @@ use crate::space_scope::{SpaceAction, SpaceRequest};
 use rocket::serde::json::Json;
 use rocket::State;
 use rsky_lexicon::com::atproto::space::{PutRecordInput, PutRecordOutput};
+use rsky_syntax::nsid::ensure_valid_nsid;
 
 /// Create or update a record in the caller's permissioned repo.
 #[tracing::instrument(skip_all)]
@@ -37,7 +38,7 @@ pub async fn space_put_record(
     let credentials = auth.access.credentials.expect("credentials populated");
     let did = credentials.did.clone().expect("did populated");
     require_repo_matches_subject(&repo, &did)?;
-    if !valid_nsid(&collection) {
+    if ensure_valid_nsid(&collection).is_err() {
         return Err(ApiError::InvalidRequest(format!(
             "invalid collection: {collection}"
         )));

--- a/rsky-pds/src/space_auth.rs
+++ b/rsky-pds/src/space_auth.rs
@@ -340,7 +340,7 @@ pub fn session_space_scopes(credentials: &Credentials) -> Option<Vec<SpaceScope>
             .filter_map(|grant| match SpaceScope::parse(grant) {
                 Ok(scope) => Some(scope),
                 Err(error) => {
-                    tracing::debug!(%grant, %error, "ignoring unparseable space scope");
+                    tracing::warn!(%grant, %error, "ignoring unparseable space scope");
                     None
                 }
             })

--- a/rsky-pds/src/space_scope.rs
+++ b/rsky-pds/src/space_scope.rs
@@ -16,7 +16,7 @@
 //! wildcard space type has no declaration to draw from, so its default stays
 //! empty and confers no write targets, per spec.
 
-use rsky_syntax::nsid::Nsid;
+use rsky_syntax::nsid::ensure_valid_nsid;
 use std::fmt;
 
 pub const SPACE_SCOPE_PREFIX: &str = "space:";
@@ -99,7 +99,7 @@ impl SpaceScope {
             Some((st, q)) => (st, Some(q)),
             None => (rest, None),
         };
-        if space_type != "*" && Nsid::parse(space_type).is_err() {
+        if space_type != "*" && ensure_valid_nsid(space_type).is_err() {
             return Err(ScopeParseError(format!(
                 "space type `{space_type}` is not an NSID or `*`"
             )));
@@ -139,7 +139,7 @@ impl SpaceScope {
                         skey = Some(value.to_string());
                     }
                     "collection" => {
-                        if value != "*" && Nsid::parse(value).is_err() {
+                        if value != "*" && ensure_valid_nsid(value).is_err() {
                             return Err(ScopeParseError(format!(
                                 "collection `{value}` is not an NSID or `*`"
                             )));
@@ -316,6 +316,10 @@ mod tests {
         SpaceScope::parse(s).unwrap()
     }
 
+    fn rejects(s: &str) -> bool {
+        SpaceScope::parse(s).is_err()
+    }
+
     fn allowed(s: &str, authority: &str, request: &SpaceRequest) -> bool {
         authorize(&[scope(s)], SELF_DID, authority, FORUM, "default", request)
     }
@@ -375,6 +379,67 @@ mod tests {
         assert!(SpaceScope::parse(&long_skey).is_err());
         let ok_skey = format!("space:com.example.forum?skey={}", "a".repeat(512));
         assert!(SpaceScope::parse(&ok_skey).is_ok());
+    }
+
+    // Spec-invalid NSIDs must fail at the scope parser, not at the route.
+    // Cases drawn from the atproto-interop-tests nsid syntax vectors.
+    #[test]
+    fn parse_enforces_spec_nsid_syntax() {
+        let long_label = format!("com.{}.foo", "o".repeat(64));
+        let bad = [
+            "com.example.foo-bar",
+            "com.example.3",
+            "a-0.b-1.c-3",
+            "com.example-.foo",
+            "0two.example.foo",
+            "1.0.0.127.record",
+            "com.exa\u{1f4a9}ple.thing",
+            "com.atproto.feed.p_st",
+            "com.atproto.feed.p@st",
+            "com.example",
+            "one.two.three ",
+            long_label.as_str(),
+        ];
+        for nsid in bad {
+            let as_type = format!("space:{nsid}");
+            assert!(rejects(&as_type), "{as_type} should fail");
+            let as_coll = format!("space:{FORUM}?collection={nsid}");
+            assert!(rejects(&as_coll), "{as_coll} should fail");
+        }
+    }
+
+    // The permission spec allows a bare `*` but no partial wildcard.
+    #[test]
+    fn parse_rejects_partial_nsid_wildcards() {
+        for bad in [
+            "com.atmoboards.*",
+            "com.atmoboards.for*",
+            "*.atmoboards.forum",
+        ] {
+            let as_type = format!("space:{bad}");
+            assert!(rejects(&as_type), "{as_type} should fail");
+            let as_coll = format!("space:{FORUM}?collection={bad}");
+            assert!(rejects(&as_coll), "{as_coll} should fail");
+        }
+        assert!(SpaceScope::parse("space:*").is_ok());
+        assert!(SpaceScope::parse(&format!("space:{FORUM}?collection=*")).is_ok());
+    }
+
+    #[test]
+    fn parse_accepts_spec_valid_nsids() {
+        for good in [
+            "com.example.fooBar",
+            "com.example.fooBarV2",
+            "a.b.c",
+            "a-0.b-1.c",
+            "cn.8.lex.stuff",
+            "net.users.bob.ping",
+        ] {
+            let as_type = format!("space:{good}");
+            assert!(!rejects(&as_type), "{as_type} should parse");
+            let as_coll = format!("space:{FORUM}?collection={good}");
+            assert!(!rejects(&as_coll), "{as_coll} should parse");
+        }
     }
 
     // §Examples: `space:com.example.bookmarks`

--- a/rsky-pds/src/space_scope.rs
+++ b/rsky-pds/src/space_scope.rs
@@ -16,6 +16,7 @@
 //! wildcard space type has no declaration to draw from, so its default stays
 //! empty and confers no write targets, per spec.
 
+use rsky_syntax::nsid::Nsid;
 use std::fmt;
 
 pub const SPACE_SCOPE_PREFIX: &str = "space:";
@@ -89,11 +90,6 @@ pub struct SpaceScope {
     pub manage: Vec<ManageOp>,
 }
 
-fn valid_nsid(s: &str) -> bool {
-    // an NSID has at least two dots and non-empty segments
-    s.matches('.').count() >= 2 && s.split('.').all(|seg| !seg.is_empty())
-}
-
 impl SpaceScope {
     pub fn parse(scope: &str) -> Result<Self, ScopeParseError> {
         let rest = scope
@@ -103,7 +99,7 @@ impl SpaceScope {
             Some((st, q)) => (st, Some(q)),
             None => (rest, None),
         };
-        if space_type != "*" && !valid_nsid(space_type) {
+        if space_type != "*" && Nsid::parse(space_type).is_err() {
             return Err(ScopeParseError(format!(
                 "space type `{space_type}` is not an NSID or `*`"
             )));
@@ -143,7 +139,7 @@ impl SpaceScope {
                         skey = Some(value.to_string());
                     }
                     "collection" => {
-                        if value != "*" && !valid_nsid(value) {
+                        if value != "*" && Nsid::parse(value).is_err() {
                             return Err(ScopeParseError(format!(
                                 "collection `{value}` is not an NSID or `*`"
                             )));


### PR DESCRIPTION
Closes #237.

## Summary

`rsky-pds` carried two `valid_nsid` helpers with divergent rules — one private to
the `space:` OAuth scope parser, one public to the `com.atproto.space.*` write
handlers — and neither matched the NSID spec. Both are replaced with
`rsky_syntax::nsid::ensure_valid_nsid`, already used by `permission_set.rs` and
by `rsky-syntax`'s own at-uri validation.

Against the `atproto-interop-tests` NSID vectors (25 valid, 27 invalid), the
scope-parser helper accepted 22 of the 27 invalid ones and the route-handler
helper accepted 8; `ensure_valid_nsid` accepts none and passes all 25 valid ones.
One case was a live bug rather than untidiness: the permission spec allows a bare
`*` but no partial wildcard, and the scope parser accepted `space:com.example.*`
as a literal space type that could never match, silently conferring nothing.

The consolidation commit is @jalcine's, from the fork referenced in #237.

## Notes for review

- A grant naming a non-conforming NSID now confers nothing.
  `session_space_scopes` already dropped unparseable grants and denied, which is
  the right direction, but logged at debug — raised to warn so the denial is
  diagnosable.
- `valid_key_part` is deliberately untouched: rkey/skey follow the record-key
  spec, whose charset is genuinely different.

## CI note

This PR touches `rsky-pds`, which un-skips the `coverage-pds` job. That gate is
already red on `main`: 85.78% lines against a 95% threshold, with 6212 lines
missed. This branch reports 85.79% with the same 6212 missed, so it does not move
the gate either way — `space_scope.rs` itself stays at 100%. Every run where the
job actually executed has failed; recent pushes skipped it because the
changed-members script saw no PDS change. Worth deciding separately whether the
threshold or the coverage moves.

## Test plan

- [ ] `cargo fmt -- --check`
- [ ] `cargo test --release -p rsky-pds`
- [ ] `cargo llvm-cov --fail-under-lines 95 -p rsky-pds -p rsky-oauth -p rsky-space -p rsky-space-host -p rsky-daemon`
- [ ] Confirm no space type already in use is rejected: `SELECT DISTINCT
      space_type FROM space_def;` per actor store, checked against the spec
      regex. A non-conforming pre-existing type would lose access, not fail loudly.
- [ ] Create a space, grant a `space:` scope for it, write a record.

## Follow-ups not in this change

- `repo:` and `rpc:` scope NSIDs are not validated at all; `parse_repo_scope`
  stores them raw and matches by string equality.
- Scope strings are validated only at enforcement, never at authorize/token time,
  so a client can be issued a grant that silently confers nothing.
- Authority case is not normalized, so two space types differing only in
  authority casing are distinct spaces under exact-equality matching.
