### PR TITLE
fix(wintermute): suppress duplicate_table NOTICE flood from bulk staging tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8512,7 +8512,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/src/bin/car_loader.rs
+++ b/rsky-wintermute/src/bin/car_loader.rs
@@ -162,6 +162,7 @@ async fn main() -> Result<()> {
 fn build_pg_pool(args: &Args) -> Result<Pool> {
     let mut cfg = Config::new();
     cfg.url = Some(args.database_url.clone());
+    cfg.options = Some(rsky_wintermute::config::pg_connect_options());
     cfg.pool = Some(rsky_wintermute::config::pg_pool_config(args.db_pool_size));
     cfg.manager = Some(ManagerConfig {
         recycling_method: RecyclingMethod::Fast,

--- a/rsky-wintermute/src/bin/cleanup_stale_deactivated.rs
+++ b/rsky-wintermute/src/bin/cleanup_stale_deactivated.rs
@@ -64,6 +64,7 @@ async fn main() -> Result<()> {
 
     let mut cfg = Config::new();
     cfg.url = Some(args.database_url.clone());
+    cfg.options = Some(rsky_wintermute::config::pg_connect_options());
     cfg.manager = Some(ManagerConfig {
         recycling_method: RecyclingMethod::Fast,
     });

--- a/rsky-wintermute/src/bin/direct_index.rs
+++ b/rsky-wintermute/src/bin/direct_index.rs
@@ -55,6 +55,7 @@ async fn main() -> Result<()> {
     // Setup database pool
     let mut cfg = Config::new();
     cfg.url = Some(args.database_url.clone());
+    cfg.options = Some(rsky_wintermute::config::pg_connect_options());
     cfg.manager = Some(ManagerConfig {
         recycling_method: RecyclingMethod::Fast,
     });

--- a/rsky-wintermute/src/bin/firehose_catchup.rs
+++ b/rsky-wintermute/src/bin/firehose_catchup.rs
@@ -76,6 +76,7 @@ async fn main() -> Result<()> {
     // Setup database pool
     let mut cfg = Config::new();
     cfg.url = Some(args.database_url);
+    cfg.options = Some(rsky_wintermute::config::pg_connect_options());
     cfg.pool = Some(deadpool_postgres::PoolConfig {
         max_size: args.pool_size,
         ..Default::default()

--- a/rsky-wintermute/src/bin/fix_blob_refs.rs
+++ b/rsky-wintermute/src/bin/fix_blob_refs.rs
@@ -150,6 +150,7 @@ async fn create_pool(
 ) -> Result<Pool, Box<dyn std::error::Error>> {
     let mut cfg = Config::new();
     cfg.url = Some(database_url.to_string());
+    cfg.options = Some(rsky_wintermute::config::pg_connect_options());
     cfg.manager = Some(ManagerConfig {
         recycling_method: RecyclingMethod::Fast,
     });

--- a/rsky-wintermute/src/bin/label_sync.rs
+++ b/rsky-wintermute/src/bin/label_sync.rs
@@ -60,6 +60,7 @@ async fn main() -> Result<()> {
 
     let mut pg_config = Config::new();
     pg_config.url = Some(args.database_url);
+    pg_config.options = Some(rsky_wintermute::config::pg_connect_options());
     pg_config.manager = Some(ManagerConfig {
         recycling_method: RecyclingMethod::Fast,
     });

--- a/rsky-wintermute/src/config.rs
+++ b/rsky-wintermute/src/config.rs
@@ -261,6 +261,20 @@ pub fn pg_pool_config(max_size: usize) -> deadpool_postgres::PoolConfig {
     }
 }
 
+/// The libpq `options` string every Postgres pool in this crate shares.
+///
+/// `client_min_messages=warning` is required because the bulk indexer issues
+/// `CREATE TEMP TABLE IF NOT EXISTS` for its staging tables on every batch, while pools
+/// recycle with `RecyclingMethod::Fast` and so never discard them. Every batch after the
+/// first therefore raises a `duplicate_table` NOTICE, which tokio-postgres logs at INFO;
+/// that stream dominates the journal and collapses log retention. Suppressing it at the
+/// server means the notice is never generated or transmitted, which a client-side log
+/// filter cannot achieve.
+#[must_use]
+pub fn pg_connect_options() -> String {
+    "-c client_min_messages=warning".to_owned()
+}
+
 // Backfiller direct write mode - bypass Fjall queue and write directly to PostgreSQL
 // This eliminates the Fjall dequeue bottleneck (~3.5s per batch) for backfill operations
 pub static BACKFILLER_DIRECT_WRITE: LazyLock<bool> = LazyLock::new(|| {
@@ -471,5 +485,20 @@ mod tests {
         assert_eq!(cfg.timeouts.wait, pg_pool_timeouts().wait);
         assert_eq!(cfg.timeouts.create, pg_pool_timeouts().create);
         assert_eq!(cfg.timeouts.recycle, pg_pool_timeouts().recycle);
+    }
+
+    #[test]
+    fn pg_connect_options_suppresses_notices() {
+        let opts = pg_connect_options();
+        assert_eq!(opts, "-c client_min_messages=warning");
+    }
+
+    #[test]
+    fn pg_connect_options_is_accepted_by_deadpool_config() {
+        let mut cfg = deadpool_postgres::Config::new();
+        cfg.url = Some("postgres://u@127.0.0.1:1/d".to_owned());
+        cfg.options = Some(pg_connect_options());
+        let pg = cfg.get_pg_config().expect("config builds");
+        assert_eq!(pg.get_options(), Some("-c client_min_messages=warning"));
     }
 }

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -143,6 +143,7 @@ impl IndexerManager {
     fn create_pool(database_url: &str, size: usize) -> Result<Pool, WintermuteError> {
         let mut pg_config = Config::new();
         pg_config.url = Some(database_url.to_owned());
+        pg_config.options = Some(crate::config::pg_connect_options());
         pg_config.manager = Some(ManagerConfig {
             recycling_method: RecyclingMethod::Fast,
         });

--- a/rsky-wintermute/src/ingester/backfill_queue.rs
+++ b/rsky-wintermute/src/ingester/backfill_queue.rs
@@ -61,6 +61,7 @@ pub async fn populate_backfill_queue(
     } else {
         let mut pg_config = Config::new();
         pg_config.url = Some(database_url);
+        pg_config.options = Some(crate::config::pg_connect_options());
         pg_config.manager = Some(ManagerConfig {
             recycling_method: RecyclingMethod::Fast,
         });

--- a/rsky-wintermute/src/ingester/labels.rs
+++ b/rsky-wintermute/src/ingester/labels.rs
@@ -23,6 +23,7 @@ pub async fn subscribe_labels(
     tracing::info!("label DB pool size: {pool_size}");
     let mut pg_config = Config::new();
     pg_config.url = Some(database_url);
+    pg_config.options = Some(crate::config::pg_connect_options());
     pg_config.manager = Some(ManagerConfig {
         recycling_method: RecyclingMethod::Fast,
     });

--- a/rsky-wintermute/src/ingester/mod.rs
+++ b/rsky-wintermute/src/ingester/mod.rs
@@ -131,6 +131,7 @@ impl IngesterManager {
         tracing::info!("firehose DB pool size: {pool_size}");
         let mut pg_config = Config::new();
         pg_config.url = Some(database_url);
+        pg_config.options = Some(crate::config::pg_connect_options());
         pg_config.manager = Some(ManagerConfig {
             recycling_method: RecyclingMethod::Fast,
         });


### PR DESCRIPTION
The bulk indexer creates its `_bulk_*` staging tables with `CREATE TEMP TABLE IF NOT
EXISTS` on every batch. Pools recycle with `RecyclingMethod::Fast`, which never discards
temp tables, so they persist for the life of a connection and every batch after the first
raises a `duplicate_table` NOTICE that tokio-postgres logs at INFO. That stream dominates
the log output and shortens how far back the journal reaches, which makes incident
forensics harder.

This adds `config::pg_connect_options()` and sets it on every pool, so the server is told
`client_min_messages=warning` and never generates or transmits the notice. A client-side
log filter would still pay for generating and sending it.

The redundant DDL itself is left in place here and addressed separately, because removing
it requires every pool that reaches the bulk path to pre-create the staging tables.

## Test plan

- [ ] `cargo clippy -p rsky-wintermute --all-targets --no-deps -- -D warnings`
- [ ] `cargo test -p rsky-wintermute`
- [ ] `cargo build --release -p rsky-wintermute`
- [ ] Indexer logs show no `tokio_postgres` NOTICE lines after restart
- [ ] Indexing throughput and error rates unchanged
- [ ] `direct_index` and `car_loader` still index a repo end to end
