### PR TITLE
perf(wintermute): log per-batch indexer timing at DEBUG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8512,7 +8512,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -1913,7 +1913,8 @@ impl IndexerManager {
             }
         }
 
-        tracing::info!(
+        // Per-batch, same as the timing line above: DEBUG, not INFO.
+        tracing::debug!(
             "batch deletes: total={}ms, n={}, applied={}",
             start.elapsed().as_millis(),
             parsed.len(),
@@ -2265,24 +2266,31 @@ impl IndexerManager {
         let total_ms = batch_start.elapsed().as_millis();
         let applied_count = applied_jobs.len();
 
-        // Log timing breakdown
-        let col_breakdown: String = collection_timings
-            .iter()
-            .map(|(c, ms, n)| format!("{}={}ms({})", c.rsplit('.').next().unwrap_or(c), ms, n))
-            .collect::<Vec<_>>()
-            .join(", ");
+        // Log timing breakdown. One line per batch, so it is DEBUG rather than INFO: a
+        // sharded drain with no sleep floor emits these at the batch rate, which crowds
+        // out every other line and shortens how far back the journal reaches.
+        // `col_breakdown` allocates per collection, so build it inside the level check
+        // rather than before it — otherwise the formatting cost is paid on every batch
+        // whether or not anything records the event.
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            let col_breakdown: String = collection_timings
+                .iter()
+                .map(|(c, ms, n)| format!("{}={}ms({})", c.rsplit('.').next().unwrap_or(c), ms, n))
+                .collect::<Vec<_>>()
+                .join(", ");
 
-        tracing::info!(
-            "batch timing: total={}ms, parse={}ms, actors={}ms, records={}ms, collections={}ms [{}] | jobs={}, applied={}",
-            total_ms,
-            parse_ms,
-            actors_ms,
-            records_ms,
-            collections_ms,
-            col_breakdown,
-            jobs.len(),
-            applied_count
-        );
+            tracing::debug!(
+                "batch timing: total={}ms, parse={}ms, actors={}ms, records={}ms, collections={}ms [{}] | jobs={}, applied={}",
+                total_ms,
+                parse_ms,
+                actors_ms,
+                records_ms,
+                collections_ms,
+                col_breakdown,
+                jobs.len(),
+                applied_count
+            );
+        }
 
         (results, batch_failed)
     }


### PR DESCRIPTION
The indexer emits a timing line and a delete-summary line once per batch. A sharded live drain woken by enqueue produces batches far faster than the fixed sleep it replaced, so at INFO these two lines dominate the journal and shorten how far back it reaches — which is what incident forensics depends on.

Both move to `DEBUG`. The timing line's `col_breakdown` is now built inside a `tracing::enabled!` check rather than before the macro, so the per-collection formatting and the join are skipped entirely when `DEBUG` is not recorded. A level change alone would still pay that cost on every batch, because the string is a separate statement the macro's level check never gates.

No behaviour outside logging changes, and the timing fields themselves are unchanged for anyone who turns `DEBUG` on.

## Test plan

- [ ] `cargo clippy -p rsky-wintermute --all-targets --no-deps -- -D warnings`
- [ ] `cargo test -p rsky-wintermute` against a database with the appview schema
- [ ] `cargo build --release -p rsky-wintermute`
- [ ] With default `RUST_LOG`, the indexer emits no per-batch timing lines
- [ ] With `RUST_LOG=rsky_wintermute::indexer=debug`, the timing and delete lines return unchanged
- [ ] Indexing throughput and error rates unchanged