### PR TITLE
Revert "perf(wintermute): create bulk staging tables once per connection"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8512,7 +8512,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-wintermute"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/rsky-wintermute/Cargo.toml
+++ b/rsky-wintermute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-wintermute"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Monolithic indexer combining ingester, backfiller, and indexer"

--- a/rsky-wintermute/src/bin/car_loader.rs
+++ b/rsky-wintermute/src/bin/car_loader.rs
@@ -12,13 +12,14 @@ use std::time::{Duration, Instant};
 
 use clap::Parser;
 use color_eyre::Result;
-use deadpool_postgres::Pool;
+use deadpool_postgres::{Config, ManagerConfig, Pool, RecyclingMethod, Runtime};
 use iroh_car::CarReader;
 use rsky_repo::parse::get_and_parse_record;
 use rsky_repo::readable_repo::ReadableRepo;
 use rsky_repo::storage::memory_blockstore::MemoryBlockstore;
 use rsky_syntax::aturi::AtUri;
 use rusqlite::OpenFlags;
+use tokio_postgres::NoTls;
 
 use rsky_wintermute::backfiller::convert_record_to_ipld;
 use rsky_wintermute::config::ingest_collection_allowed;
@@ -159,10 +160,13 @@ async fn main() -> Result<()> {
 
 /// Build the Postgres connection pool.
 fn build_pg_pool(args: &Args) -> Result<Pool> {
-    Ok(rsky_wintermute::config::create_pg_pool(
-        &args.database_url,
-        rsky_wintermute::config::pg_pool_config(args.db_pool_size),
-    )?)
+    let mut cfg = Config::new();
+    cfg.url = Some(args.database_url.clone());
+    cfg.pool = Some(rsky_wintermute::config::pg_pool_config(args.db_pool_size));
+    cfg.manager = Some(ManagerConfig {
+        recycling_method: RecyclingMethod::Fast,
+    });
+    Ok(cfg.create_pool(Some(Runtime::Tokio1), NoTls)?)
 }
 
 /// Read a repo's CAR, walk its MST, and build index jobs for allowed collections.

--- a/rsky-wintermute/src/bin/direct_index.rs
+++ b/rsky-wintermute/src/bin/direct_index.rs
@@ -3,12 +3,14 @@ use std::sync::Arc;
 
 use clap::Parser;
 use color_eyre::Result;
+use deadpool_postgres::{Config, ManagerConfig, RecyclingMethod, Runtime};
 use iroh_car::CarReader;
 use rsky_identity::IdResolver;
 use rsky_identity::types::IdentityResolverOpts;
 use rsky_repo::readable_repo::ReadableRepo;
 use rsky_repo::storage::memory_blockstore::MemoryBlockstore;
 use rsky_syntax::aturi::AtUri;
+use tokio_postgres::NoTls;
 
 use rsky_repo::parse::get_and_parse_record;
 use rsky_wintermute::backfiller::convert_record_to_ipld;
@@ -51,10 +53,13 @@ async fn main() -> Result<()> {
     println!("Will index {} DIDs directly to PostgreSQL", dids.len());
 
     // Setup database pool
-    let pool = rsky_wintermute::config::create_pg_pool(
-        &args.database_url,
-        rsky_wintermute::config::pg_pool_config(16),
-    )?;
+    let mut cfg = Config::new();
+    cfg.url = Some(args.database_url.clone());
+    cfg.manager = Some(ManagerConfig {
+        recycling_method: RecyclingMethod::Fast,
+    });
+
+    let pool = cfg.create_pool(Some(Runtime::Tokio1), NoTls)?;
     let http_client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(120))
         .build()?;

--- a/rsky-wintermute/src/bin/firehose_catchup.rs
+++ b/rsky-wintermute/src/bin/firehose_catchup.rs
@@ -4,8 +4,10 @@ use std::time::{Duration, Instant};
 
 use clap::Parser;
 use color_eyre::Result;
+use deadpool_postgres::{Config, ManagerConfig, RecyclingMethod, Runtime};
 use futures::StreamExt;
 use tokio::sync::Semaphore;
+use tokio_postgres::NoTls;
 use tokio_tungstenite::tungstenite::Message;
 
 use rsky_wintermute::indexer::IndexerManager;
@@ -72,13 +74,17 @@ async fn main() -> Result<()> {
     );
 
     // Setup database pool
-    let pool = Arc::new(rsky_wintermute::config::create_pg_pool(
-        &args.database_url,
-        deadpool_postgres::PoolConfig {
-            max_size: args.pool_size,
-            ..Default::default()
-        },
-    )?);
+    let mut cfg = Config::new();
+    cfg.url = Some(args.database_url);
+    cfg.pool = Some(deadpool_postgres::PoolConfig {
+        max_size: args.pool_size,
+        ..Default::default()
+    });
+    cfg.manager = Some(ManagerConfig {
+        recycling_method: RecyclingMethod::Fast,
+    });
+
+    let pool = Arc::new(cfg.create_pool(Some(Runtime::Tokio1), NoTls)?);
 
     // Test DB connection
     let test_client = pool.get().await?;

--- a/rsky-wintermute/src/bin/label_sync.rs
+++ b/rsky-wintermute/src/bin/label_sync.rs
@@ -63,12 +63,7 @@ async fn main() -> Result<()> {
     pg_config.manager = Some(ManagerConfig {
         recycling_method: RecyclingMethod::Fast,
     });
-    // Two connections per concurrent task, so a task rarely waits on a free slot.
-    // Sizing this from `--concurrency` rather than a fixed number keeps the flag
-    // honest: at a higher concurrency a fixed pool leaves the extra tasks blocking
-    // on `DB_WAIT_TIMEOUT_SECS` and then failing.
-    let pool_size = args.concurrency * 2;
-    pg_config.pool = Some(rsky_wintermute::config::pg_pool_config(pool_size));
+    pg_config.pool = Some(rsky_wintermute::config::pg_pool_config(16));
 
     let pool = Arc::new(
         pg_config

--- a/rsky-wintermute/src/config.rs
+++ b/rsky-wintermute/src/config.rs
@@ -261,63 +261,6 @@ pub fn pg_pool_config(max_size: usize) -> deadpool_postgres::PoolConfig {
     }
 }
 
-/// Session setup run once per pooled connection, before any staging DDL.
-///
-/// `client_min_messages=warning` is required because the bulk indexer issues
-/// `CREATE TEMP TABLE IF NOT EXISTS` for its staging tables, while pools recycle with
-/// `RecyclingMethod::Fast` and so never discard them. Every batch after the first
-/// therefore raises a `duplicate_table` NOTICE, which tokio-postgres logs at INFO; that
-/// stream dominates the journal and collapses log retention. Setting it on the session
-/// means the server never generates or transmits the notice, which a client-side log
-/// filter cannot achieve.
-///
-/// This is a `SET` rather than a libpq `options` string on purpose. `Config::options`
-/// replaces whatever the connection URL carried, and the URL is where the deployment
-/// supplies `-csearch_path=...`; setting it here would silently drop the schema and
-/// resolve every unqualified name against `public`.
-pub const SESSION_SETUP_SQL: &str = "SET client_min_messages TO warning;";
-
-/// Build a pool whose connections are ready for `indexer::bulk`.
-///
-/// The staging-table DDL runs once per connection in a `post_create` hook instead of on
-/// every batch. Pools that reach those functions must be built here or they fail with
-/// `undefined_table`; a pool built any other way has no staging tables.
-pub fn create_pg_pool(
-    database_url: &str,
-    pool_config: deadpool_postgres::PoolConfig,
-) -> Result<deadpool_postgres::Pool, crate::types::WintermuteError> {
-    use crate::types::WintermuteError;
-
-    let mut cfg = deadpool_postgres::Config::new();
-    cfg.url = Some(database_url.to_owned());
-    cfg.manager = Some(deadpool_postgres::ManagerConfig {
-        recycling_method: deadpool_postgres::RecyclingMethod::Fast,
-    });
-    cfg.pool = Some(pool_config);
-
-    cfg.builder(deadpool_postgres::tokio_postgres::NoTls)
-        .map_err(|e| WintermuteError::Other(format!("pool config invalid: {e}")))?
-        .runtime(deadpool_postgres::Runtime::Tokio1)
-        .post_create(deadpool_postgres::Hook::async_fn(|client, _| {
-            Box::pin(async move {
-                client
-                    .batch_execute(&format!(
-                        "{SESSION_SETUP_SQL}{}",
-                        crate::indexer::bulk::BULK_STAGING_DDL
-                    ))
-                    .await
-                    .map_err(|e| {
-                        deadpool_postgres::HookError::message(format!(
-                            "bulk staging DDL failed: {e}"
-                        ))
-                    })?;
-                Ok(())
-            })
-        }))
-        .build()
-        .map_err(|e| WintermuteError::Other(format!("pool creation failed: {e}")))
-}
-
 // Backfiller direct write mode - bypass Fjall queue and write directly to PostgreSQL
 // This eliminates the Fjall dequeue bottleneck (~3.5s per batch) for backfill operations
 pub static BACKFILLER_DIRECT_WRITE: LazyLock<bool> = LazyLock::new(|| {
@@ -528,18 +471,5 @@ mod tests {
         assert_eq!(cfg.timeouts.wait, pg_pool_timeouts().wait);
         assert_eq!(cfg.timeouts.create, pg_pool_timeouts().create);
         assert_eq!(cfg.timeouts.recycle, pg_pool_timeouts().recycle);
-    }
-
-    #[test]
-    fn session_setup_sets_client_min_messages() {
-        assert!(SESSION_SETUP_SQL.contains("client_min_messages"));
-        assert!(SESSION_SETUP_SQL.trim_end().ends_with(';'));
-    }
-
-    #[test]
-    fn session_setup_does_not_touch_search_path() {
-        // Config::options replaces what the URL carried, and the URL is where the
-        // deployment supplies -csearch_path. This must never move back there.
-        assert!(!SESSION_SETUP_SQL.contains("search_path"));
     }
 }

--- a/rsky-wintermute/src/indexer/bulk.rs
+++ b/rsky-wintermute/src/indexer/bulk.rs
@@ -8,107 +8,6 @@
 //! Pattern: `COPY` into temp table, then `INSERT...ON CONFLICT` from temp.
 
 use crate::types::WintermuteError;
-
-/// Every staging table the bulk paths in this module `COPY` into.
-///
-/// Installed once per pooled connection by `config::create_pg_pool`, not per batch:
-/// pools recycle with `RecyclingMethod::Fast`, which never discards temp tables, so
-/// re-issuing the DDL on every batch only raised a `duplicate_table` NOTICE. Any pool
-/// whose connections reach these functions must run this first.
-pub const BULK_STAGING_DDL: &str = "\
- CREATE TEMP TABLE IF NOT EXISTS _bulk_record (
-     uri text NOT NULL,
-     cid text NOT NULL,
-     did text NOT NULL,
-     json text,
-     rev text NOT NULL,
-     indexed_at text NOT NULL
- );
- CREATE TEMP TABLE IF NOT EXISTS _bulk_actor (
-     did text NOT NULL
- );
- CREATE TEMP TABLE IF NOT EXISTS _bulk_post (
-     uri text NOT NULL,
-     cid text NOT NULL,
-     creator text NOT NULL,
-     text text,
-     reply_root text,
-     reply_root_cid text,
-     reply_parent text,
-     reply_parent_cid text,
-     created_at text NOT NULL,
-     indexed_at text NOT NULL,
-     langs text[],
-     tags text[]
- );
- CREATE TEMP TABLE IF NOT EXISTS _bulk_feed_item (
-     type text NOT NULL,
-     uri text NOT NULL,
-     cid text NOT NULL,
-     post_uri text NOT NULL,
-     originator_did text NOT NULL,
-     sort_at text NOT NULL
- );
- CREATE TEMP TABLE IF NOT EXISTS _bulk_like (
-     uri text NOT NULL,
-     cid text NOT NULL,
-     creator text NOT NULL,
-     subject text NOT NULL,
-     subject_cid text NOT NULL,
-     created_at text NOT NULL,
-     indexed_at text NOT NULL,
-     via text,
-     via_cid text
- );
- CREATE TEMP TABLE IF NOT EXISTS _bulk_follow (
-     uri text NOT NULL,
-     cid text NOT NULL,
-     creator text NOT NULL,
-     subject_did text NOT NULL,
-     created_at text NOT NULL,
-     indexed_at text NOT NULL,
-     via text,
-     via_cid text
- );
- CREATE TEMP TABLE IF NOT EXISTS _bulk_repost (
-     uri text NOT NULL,
-     cid text NOT NULL,
-     creator text NOT NULL,
-     subject text NOT NULL,
-     subject_cid text NOT NULL,
-     created_at text NOT NULL,
-     indexed_at text NOT NULL,
-     via text,
-     via_cid text
- );
- CREATE TEMP TABLE IF NOT EXISTS _bulk_quote (
-     uri text NOT NULL,
-     cid text NOT NULL,
-     subject text NOT NULL,
-     subject_cid text NOT NULL,
-     created_at text NOT NULL,
-     indexed_at text NOT NULL
- );
- CREATE TEMP TABLE IF NOT EXISTS _bulk_block (
-     uri text NOT NULL,
-     cid text NOT NULL,
-     creator text NOT NULL,
-     subject text NOT NULL,
-     created_at text NOT NULL,
-     indexed_at text NOT NULL
- );
- CREATE TEMP TABLE IF NOT EXISTS _bulk_post_embed_image (
-     post_uri text NOT NULL,
-     position text NOT NULL,
-     image_cid text NOT NULL,
-     alt text NOT NULL
- );
- CREATE TEMP TABLE IF NOT EXISTS _bulk_post_embed_video (
-     post_uri text NOT NULL,
-     video_cid text NOT NULL,
-     alt text
- );";
-
 use futures::SinkExt;
 use futures::pin_mut;
 use std::io::Write;
@@ -419,7 +318,19 @@ pub async fn copy_insert_records(
 
     // Phase 1: Table setup
     let setup_start = Instant::now();
-    client.batch_execute("TRUNCATE _bulk_record").await?;
+    client
+        .batch_execute(
+            "CREATE TEMP TABLE IF NOT EXISTS _bulk_record (
+                uri text NOT NULL,
+                cid text NOT NULL,
+                did text NOT NULL,
+                json text,
+                rev text NOT NULL,
+                indexed_at text NOT NULL
+            );
+            TRUNCATE _bulk_record",
+        )
+        .await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     // Phase 2: COPY data into temp table
@@ -516,7 +427,14 @@ pub async fn copy_ensure_actors(
 
     // Phase 1: Table setup
     let setup_start = Instant::now();
-    client.batch_execute("TRUNCATE _bulk_actor").await?;
+    client
+        .batch_execute(
+            "CREATE TEMP TABLE IF NOT EXISTS _bulk_actor (
+                did text NOT NULL
+            );
+            TRUNCATE _bulk_actor",
+        )
+        .await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     // Phase 2: COPY dids
@@ -584,7 +502,25 @@ pub async fn copy_insert_posts(
 
     // Phase 1: Table setup
     let setup_start = Instant::now();
-    client.batch_execute("TRUNCATE _bulk_post").await?;
+    client
+        .batch_execute(
+            "CREATE TEMP TABLE IF NOT EXISTS _bulk_post (
+                uri text NOT NULL,
+                cid text NOT NULL,
+                creator text NOT NULL,
+                text text,
+                reply_root text,
+                reply_root_cid text,
+                reply_parent text,
+                reply_parent_cid text,
+                created_at text NOT NULL,
+                indexed_at text NOT NULL,
+                langs text[],
+                tags text[]
+            );
+            TRUNCATE _bulk_post",
+        )
+        .await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     // Phase 2: COPY data. text is NOT NULL so empty string is preserved; reply_*/langs/tags
@@ -701,7 +637,19 @@ pub async fn copy_insert_feed_items(
 
     // Phase 1: Table setup
     let setup_start = Instant::now();
-    client.batch_execute("TRUNCATE _bulk_feed_item").await?;
+    client
+        .batch_execute(
+            "CREATE TEMP TABLE IF NOT EXISTS _bulk_feed_item (
+                type text NOT NULL,
+                uri text NOT NULL,
+                cid text NOT NULL,
+                post_uri text NOT NULL,
+                originator_did text NOT NULL,
+                sort_at text NOT NULL
+            );
+            TRUNCATE _bulk_feed_item",
+        )
+        .await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     // Phase 2: COPY data
@@ -777,7 +725,22 @@ pub async fn copy_insert_likes(
 
     // Phase 1: Table setup
     let setup_start = Instant::now();
-    client.batch_execute("TRUNCATE _bulk_like").await?;
+    client
+        .batch_execute(
+            "CREATE TEMP TABLE IF NOT EXISTS _bulk_like (
+                uri text NOT NULL,
+                cid text NOT NULL,
+                creator text NOT NULL,
+                subject text NOT NULL,
+                subject_cid text NOT NULL,
+                created_at text NOT NULL,
+                indexed_at text NOT NULL,
+                via text,
+                via_cid text
+            );
+            TRUNCATE _bulk_like",
+        )
+        .await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     // Phase 2: COPY data
@@ -871,7 +834,21 @@ pub async fn copy_insert_follows(
 
     // Phase 1: Table setup
     let setup_start = Instant::now();
-    client.batch_execute("TRUNCATE _bulk_follow").await?;
+    client
+        .batch_execute(
+            "CREATE TEMP TABLE IF NOT EXISTS _bulk_follow (
+                uri text NOT NULL,
+                cid text NOT NULL,
+                creator text NOT NULL,
+                subject_did text NOT NULL,
+                created_at text NOT NULL,
+                indexed_at text NOT NULL,
+                via text,
+                via_cid text
+            );
+            TRUNCATE _bulk_follow",
+        )
+        .await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     // Phase 2: COPY data
@@ -991,7 +968,22 @@ pub async fn copy_insert_reposts(
 
     // Phase 1: Table setup
     let setup_start = Instant::now();
-    client.batch_execute("TRUNCATE _bulk_repost").await?;
+    client
+        .batch_execute(
+            "CREATE TEMP TABLE IF NOT EXISTS _bulk_repost (
+                uri text NOT NULL,
+                cid text NOT NULL,
+                creator text NOT NULL,
+                subject text NOT NULL,
+                subject_cid text NOT NULL,
+                created_at text NOT NULL,
+                indexed_at text NOT NULL,
+                via text,
+                via_cid text
+            );
+            TRUNCATE _bulk_repost",
+        )
+        .await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     // Phase 2: COPY data
@@ -1084,7 +1076,19 @@ pub async fn copy_insert_quotes(
     let count = data.len();
 
     let setup_start = Instant::now();
-    client.batch_execute("TRUNCATE _bulk_quote").await?;
+    client
+        .batch_execute(
+            "CREATE TEMP TABLE IF NOT EXISTS _bulk_quote (
+                uri text NOT NULL,
+                cid text NOT NULL,
+                subject text NOT NULL,
+                subject_cid text NOT NULL,
+                created_at text NOT NULL,
+                indexed_at text NOT NULL
+            );
+            TRUNCATE _bulk_quote",
+        )
+        .await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     let copy_start = Instant::now();
@@ -1169,7 +1173,19 @@ pub async fn copy_insert_blocks(
 
     // Phase 1: Table setup
     let setup_start = Instant::now();
-    client.batch_execute("TRUNCATE _bulk_block").await?;
+    client
+        .batch_execute(
+            "CREATE TEMP TABLE IF NOT EXISTS _bulk_block (
+                uri text NOT NULL,
+                cid text NOT NULL,
+                creator text NOT NULL,
+                subject text NOT NULL,
+                created_at text NOT NULL,
+                indexed_at text NOT NULL
+            );
+            TRUNCATE _bulk_block",
+        )
+        .await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
     // Phase 2: COPY data
@@ -1245,7 +1261,15 @@ pub async fn copy_insert_post_embed_images(
     // Phase 1: Table setup
     let setup_start = Instant::now();
     client
-        .batch_execute("TRUNCATE _bulk_post_embed_image")
+        .batch_execute(
+            "CREATE TEMP TABLE IF NOT EXISTS _bulk_post_embed_image (
+                post_uri text NOT NULL,
+                position text NOT NULL,
+                image_cid text NOT NULL,
+                alt text NOT NULL
+            );
+            TRUNCATE _bulk_post_embed_image",
+        )
         .await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
@@ -1317,7 +1341,14 @@ pub async fn copy_insert_post_embed_videos(
     // Phase 1: Table setup
     let setup_start = Instant::now();
     client
-        .batch_execute("TRUNCATE _bulk_post_embed_video")
+        .batch_execute(
+            "CREATE TEMP TABLE IF NOT EXISTS _bulk_post_embed_video (
+                post_uri text NOT NULL,
+                video_cid text NOT NULL,
+                alt text
+            );
+            TRUNCATE _bulk_post_embed_video",
+        )
         .await?;
     let setup_ms = setup_start.elapsed().as_millis();
 
@@ -1376,40 +1407,6 @@ pub async fn copy_insert_post_embed_videos(
 
 #[cfg(test)]
 mod tests {
-    // A table truncated but not declared fails on a fresh connection, not in review.
-    #[test]
-    fn every_truncated_staging_table_is_declared() {
-        // Split so the needle never appears verbatim in this file and match itself.
-        let needle = concat!("TRUNCATE", " _bulk_");
-        let src = include_str!("bulk.rs");
-        let mut tables: Vec<&str> = src
-            .match_indices(needle)
-            .map(|(i, _)| {
-                let rest = &src[i + "TRUNCATE ".len()..];
-                &rest[..rest.find('"').expect("closing quote")]
-            })
-            .collect();
-        tables.sort_unstable();
-        tables.dedup();
-        assert_eq!(tables.len(), 11);
-        for t in tables {
-            assert!(
-                super::BULK_STAGING_DDL.contains(&format!("CREATE TEMP TABLE IF NOT EXISTS {t} (")),
-                "{t} is truncated but not declared in the staging DDL"
-            );
-        }
-    }
-
-    #[test]
-    fn staging_ddl_declares_exactly_the_expected_tables() {
-        assert_eq!(
-            super::BULK_STAGING_DDL
-                .matches("CREATE TEMP TABLE IF NOT EXISTS")
-                .count(),
-            11
-        );
-    }
-
     use super::{escape_copy_field, escape_copy_opt, pg_text_array_literal};
 
     #[test]

--- a/rsky-wintermute/src/indexer/mod.rs
+++ b/rsky-wintermute/src/indexer/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod bulk;
+mod bulk;
 mod tests;
 
 use crate::SHUTDOWN;
@@ -16,7 +16,7 @@ use crate::storage::Storage;
 use crate::types::LabelEvent;
 use crate::types::{IndexJob, WintermuteError, WriteAction};
 use dashmap::DashMap;
-use deadpool_postgres::Pool;
+use deadpool_postgres::{Config, ManagerConfig, Pool, RecyclingMethod, Runtime};
 use futures::FutureExt;
 use futures::stream::{FuturesUnordered, StreamExt};
 use rsky_identity::IdResolver;
@@ -26,6 +26,7 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tokio::sync::Semaphore;
+use tokio_postgres::NoTls;
 
 // Global semaphore to serialize like inserts across all workers.
 // The like table has a 133GB index that causes severe contention when
@@ -140,7 +141,16 @@ impl IndexerManager {
     }
 
     fn create_pool(database_url: &str, size: usize) -> Result<Pool, WintermuteError> {
-        crate::config::create_pg_pool(database_url, crate::config::pg_pool_config(size))
+        let mut pg_config = Config::new();
+        pg_config.url = Some(database_url.to_owned());
+        pg_config.manager = Some(ManagerConfig {
+            recycling_method: RecyclingMethod::Fast,
+        });
+        pg_config.pool = Some(crate::config::pg_pool_config(size));
+
+        pg_config
+            .create_pool(Some(Runtime::Tokio1), NoTls)
+            .map_err(|e| WintermuteError::Other(format!("pool creation failed: {e}")))
     }
 
     pub fn run(self) -> Result<(), WintermuteError> {

--- a/rsky-wintermute/src/indexer/tests.rs
+++ b/rsky-wintermute/src/indexer/tests.rs
@@ -11,9 +11,10 @@ mod indexer_tests {
     use crate::indexer::IndexerManager;
     use crate::storage::Storage;
     use crate::types::{BackfillJob, LabelEvent, WriteAction};
-    use deadpool_postgres::Pool;
+    use deadpool_postgres::{Config, ManagerConfig, Pool, RecyclingMethod, Runtime};
     use std::sync::Arc;
     use tempfile::TempDir;
+    use tokio_postgres::NoTls;
 
     fn setup_test_storage() -> (Storage, TempDir) {
         let temp_dir = TempDir::with_prefix("indexer_test_").unwrap();
@@ -27,8 +28,13 @@ mod indexer_tests {
             "postgresql://postgres:postgres@localhost:5432/bsky_test".to_owned()
         });
 
-        crate::config::create_pg_pool(&database_url, crate::config::pg_pool_config(16))
-            .expect("test pool builds")
+        let mut pg_config = Config::new();
+        pg_config.url = Some(database_url);
+        pg_config.manager = Some(ManagerConfig {
+            recycling_method: RecyclingMethod::Fast,
+        });
+
+        pg_config.create_pool(Some(Runtime::Tokio1), NoTls).unwrap()
     }
 
     async fn cleanup_test_data(pool: &Pool, did: &str) {


### PR DESCRIPTION
Reverts #240. Deployed and rolled back the same night: indexing dropped to roughly a tenth of its normal rate, the live queue grew to ~265k, and feeds stopped refreshing. Reverting so `main` is deployable again while the cause is found.

The change produced no errors at all — no failed writes, nothing in the journal, health endpoint green throughout. Only throughput moved:

```
this change:  44/s
reverted:     6,100-6,900/s while draining the backlog
steady state: ~400/s
```

The mechanism is not yet identified. Round trips are unchanged at eleven `batch_execute` calls per batch either way, the SQL is strictly smaller after the change, and the pool wiring in `indexer/mod.rs` is a pure refactor with identical settings. So the obvious explanations do not hold and it is something subtler — connection churn making the `post_create` hook expensive, or a `TRUNCATE`-versus-`CREATE` interaction under sharding, are the current leads.

Worth noting for whoever picks this up: the full test suite passes 75/0 against a correctly built schema both with and without this change, in the same wall-clock time. Nothing in the suite measures throughput, so no test would have caught this.

The `search_path` fix that rode along in #240 goes away with it. That is correct — the bug it fixed was introduced by #240's own `Config::options` usage, so reverting removes both. Nothing on `main` depends on it.

## Test plan

- [ ] `cargo clippy -p rsky-wintermute --all-targets --no-deps -- -D warnings`
- [ ] `cargo test -p rsky-wintermute` against a database with the appview schema
- [ ] `cargo build --release -p rsky-wintermute`
- [ ] Deployed indexing rate returns to its normal steady state