### PR TITLE
fix(rsky-repo): verify commit signatures with digest semantics on both curves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8339,7 +8339,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-repo"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -8353,6 +8353,7 @@ dependencies = [
  "ipld-core",
  "iroh-car",
  "lazy_static",
+ "p256 0.13.2",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rsky-identity = {path = "rsky-identity", version = "0.2.0"}
 rsky-crypto = {path = "rsky-crypto", version = "0.2.1"}
 rsky-syntax = {path = "rsky-syntax", version = "0.1.0"}
 rsky-common = {path = "rsky-common", version = "0.1.3"}
-rsky-repo = {path = "rsky-repo", version = "0.0.6"}
+rsky-repo = {path = "rsky-repo", version = "0.0.7"}
 rsky-firehose = {path = "rsky-firehose", version = "0.2.1"}
 
 [profile.release]

--- a/rsky-repo/Cargo.toml
+++ b/rsky-repo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-repo"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust crate for atproto repositories, an in particular the Merkle Search Tree (MST) data structure."
 license = "Apache-2.0"
@@ -43,3 +43,4 @@ lazy_static = "1.4.0"
 [dev-dependencies]
 glob = "0.3"
 indexmap = "2"
+p256 = { version = "0.13.2", features = ["ecdsa", "arithmetic"] }

--- a/rsky-repo/src/util.rs
+++ b/rsky-repo/src/util.rs
@@ -41,7 +41,7 @@ pub fn verify_commit_sig(commit: Commit, did_key: &String) -> Result<bool> {
     };
     let encoded = serde_ipld_dagcbor::to_vec(&rest)?;
     let hash = Sha256::digest(&*encoded);
-    rsky_crypto::verify::verify_signature(did_key, hash.as_ref(), sig.as_slice(), None)
+    rsky_crypto::verify::verify_signature_digest(did_key, hash.as_ref(), sig.as_slice(), None)
 }
 
 pub fn format_data_key<T: FromStr + Display>(collection: T, rkey: T) -> String {
@@ -302,6 +302,52 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// verify_commit_sig hands a precomputed sha256 digest to rsky-crypto. The
+    /// p256 plugin behind verify_signature hashes its input again, so a valid
+    /// ES256 commit signature verified against SHA256(SHA256(bytes)) fails.
+    #[test]
+    fn verify_commit_sig_accepts_p256_signature() {
+        use p256::ecdsa::signature::hazmat::PrehashSigner;
+        use p256::ecdsa::{Signature, SigningKey};
+        use rsky_crypto::constants::P256_JWT_ALG;
+        use rsky_crypto::did::format_did_key;
+
+        let key = SigningKey::from_slice(&[0x2au8; 32]).unwrap();
+        let did_key = format_did_key(
+            P256_JWT_ALG.to_string(),
+            key.verifying_key()
+                .to_encoded_point(false)
+                .as_bytes()
+                .to_vec(),
+        )
+        .unwrap();
+
+        let unsigned = UnsignedCommit {
+            did: "did:plc:p256commitfixture".to_string(),
+            rev: "3kaaaaaaaaa2z".to_string(),
+            data: "bafkreiey6e2xp4ncufvsyfmubucbsz5xujbc7lguospuziohtgfdik3pr4"
+                .parse()
+                .unwrap(),
+            prev: None,
+            version: 3,
+        };
+        let encoded = serde_ipld_dagcbor::to_vec(&unsigned).unwrap();
+        let sig: Signature = key
+            .sign_prehash(Sha256::digest(&*encoded).as_ref())
+            .unwrap();
+        let sig = sig.normalize_s().unwrap_or(sig);
+
+        let commit = Commit {
+            did: unsigned.did,
+            version: unsigned.version,
+            data: unsigned.data,
+            rev: unsigned.rev,
+            prev: unsigned.prev,
+            sig: sig.to_vec(),
+        };
+        assert!(verify_commit_sig(commit, &did_key).unwrap());
+    }
 
     /// The encode direction: a `Lex::Blob` written to DAG-CBOR must emit a
     /// real tag-42 CID link and re-encode byte-for-byte to what a compliant


### PR DESCRIPTION
rsky-crypto exposes two verification entrypoints whose `data` argument means different things per curve: `verify_signature` treats it as a digest on secp256k1 but hashes it internally on p256, while `verify_signature_digest` gives both curves digest semantics. `verify_commit_sig` computes a sha256 digest and called the former, so ES256 commit signatures were checked against a double hash and never verified. It failed closed, returning `Ok(false)` rather than an error, so it read as a bad signature. The secp256k1 path is unchanged.

Test plan:
- [ ] `cargo test -p rsky-repo` passes, including the existing secp256k1 commit tests
- [ ] the new p256 test fails when the call is reverted to `verify_signature`
- [ ] `cargo build --release -p rsky-repo` succeeds