### PR TITLE
feat(rsky-pds)!: give every account its own repo signing key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-pds"
-version = "0.13.18"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "argon2",

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-pds"
-version = "0.13.18"
+version = "1.0.0"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust reference implementation of an atproto PDS."
 license = "Apache-2.0"

--- a/rsky-pds/MIGRATING-1.0.md
+++ b/rsky-pds/MIGRATING-1.0.md
@@ -1,0 +1,78 @@
+# Migrating to rsky-pds 1.0
+
+1.0 gives every account its own repo signing key. Before it, one process-wide keypair
+(`PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX`) signed every account's commits, so a single leaked
+secret could forge commits — and mint service-auth tokens — for every account on the server.
+
+New accounts get their own key automatically. **Accounts that already exist keep using the shared
+key until you rotate them**, which is a deliberate operator step because it publishes a PLC
+operation per account.
+
+## What changed
+
+- `createAccount` generates a fresh secp256k1 keypair per account and stamps it into that account's
+  PLC operation.
+- `getRecommendedDidCredentials`, `submitPlcOperation` and `activateAccount` validate against the
+  account's own key instead of the global one.
+- Service-auth JWTs are signed with the issuing account's key. This had to change in the same
+  release: once an account's DID document names its own key, a token signed with the global key no
+  longer verifies.
+- New binary `rotate-keys`, built alongside the server.
+
+`PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX` is still required. No request path reads it any more,
+but `rotate-keys` uses it to tell a rotated account from an unrotated one. Keep it set until every
+account has been rotated.
+
+## Upgrading
+
+**1. Deploy 1.0.** No config change. Existing accounts keep working on the shared key; new accounts
+get their own from this point on.
+
+**2. See what needs rotating.**
+
+    rotate-keys --dry-run
+
+Reports what would change and touches nothing.
+
+**3. Rotate.** Run against a quiesced PDS — see the warning below.
+
+    rotate-keys                  # every account
+    rotate-keys --did did:plc:…  # one account, repeatable
+
+Per account, in order: write the new key file, publish the PLC operation, write an empty commit so
+the repo head is signed by the new key, then sequence `#identity` and `#sync`.
+
+**4. Verify.** Re-run `rotate-keys --dry-run`; a clean run reports nothing left to do.
+
+## Before you run it
+
+**Stop the server first.** The per-DID write lock is process-local, so `rotate-keys` cannot
+serialise against a live server's in-flight commits. The key write itself is atomic — a concurrent
+reader sees whole-old or whole-new, never a truncated file — but a commit signed in the window
+between the key write and the PLC operation would be signed with the old key while the DID document
+already advertises the new one.
+
+**Back up the actor store.** After rotation each account's key is unique and exists in exactly one
+place. Before 1.0 a lost key file could be reconstructed from the environment variable; afterwards
+it cannot, and losing one means that account can no longer sign commits.
+
+**It is resumable and idempotent.** An account whose DID document already names its own key is
+skipped. An account whose key was written but whose PLC operation did not land — a crash between
+steps — is republished rather than re-keyed, so a second key is never minted. Interrupting the run
+is safe; re-run it.
+
+**Rotation is one-way.** Downgrading the binary afterwards does not restore the old key, and a
+rotated account will not verify against a pre-1.0 server.
+
+**`did:web` accounts are skipped** with a reason. There is no PLC operation to publish for them;
+their signing key has to be updated wherever their DID document is served.
+
+## If something fails
+
+The run is sequential and per-account: a failure is counted, logged with its DID, and the run
+continues. The binary exits non-zero if any account failed. Re-running retries only what did not
+finish.
+
+An account left between steps 1 and 2 — new key on disk, DID document not yet updated — cannot sign
+commits that relays will accept until the operation is published. Re-running `rotate-keys` for that
+DID resolves it.

--- a/rsky-pds/README.md
+++ b/rsky-pds/README.md
@@ -119,6 +119,12 @@ Mount a volume at `PDS_DATA_DIRECTORY` to persist data.
 | `PDS_OAUTH_SIGNUP_URL` | Signup URL shown on the authorization page |
 | `PDS_OAUTH_TRUSTED_CLIENTS` | Comma-separated client IDs shown by name on the consent page |
 
+## Upgrading to 1.0
+
+Every account now signs its repo with its own key. New accounts get one automatically; existing
+accounts keep using the previously shared key until an operator runs `rotate-keys`, which publishes
+a PLC operation per account. See [MIGRATING-1.0.md](MIGRATING-1.0.md).
+
 ## License
 
 rsky is released under the [Apache License 2.0](../LICENSE).

--- a/rsky-pds/src/account_manager/helpers/auth.rs
+++ b/rsky-pds/src/account_manager/helpers/auth.rs
@@ -1,5 +1,4 @@
 use crate::auth_verifier::{AuthScope, PDS_JWT_KEYPAIR};
-use crate::context::PDS_REPO_SIGNING_KEYPAIR;
 use crate::db::sqlite::Db;
 use crate::models;
 use anyhow::Result;
@@ -7,7 +6,7 @@ use chrono::DateTime;
 use jwt_simple::prelude::*;
 use rsky_common::{get_random_str, json_to_b64url, RFC3339_VARIANT};
 use rusqlite::{params, OptionalExtension};
-use secp256k1::Message;
+use secp256k1::{Keypair, Message};
 use sha2::{Digest, Sha256};
 use std::time::SystemTime;
 use thiserror::Error;
@@ -143,7 +142,9 @@ pub fn create_refresh_token(opts: CreateTokensOpts) -> Result<String> {
     PDS_JWT_KEYPAIR.sign(claims)
 }
 
-pub async fn create_service_jwt(params: ServiceJwtParams) -> Result<String> {
+/// `keypair` must be the signing key of the account named in `params.iss`:
+/// verifiers resolve `iss` to its DID document and check the signature there.
+pub async fn create_service_jwt(params: ServiceJwtParams, keypair: &Keypair) -> Result<String> {
     let ServiceJwtParams { iss, aud, .. } = params;
     // `exp` is seconds since the epoch (RFC 7519 §4.1.4).
     let now = SystemTime::now()
@@ -171,7 +172,7 @@ pub async fn create_service_jwt(params: ServiceJwtParams) -> Result<String> {
     );
     let hash = Sha256::digest(to_sign_str.clone());
     let message = Message::from_digest_slice(hash.as_ref())?;
-    let mut sig = PDS_REPO_SIGNING_KEYPAIR.secret_key().sign_ecdsa(message);
+    let mut sig = keypair.secret_key().sign_ecdsa(message);
     // Convert to low-s
     sig.normalize_s();
     // ASN.1 encoded per decode_dss_signature

--- a/rsky-pds/src/account_manager/tests.rs
+++ b/rsky-pds/src/account_manager/tests.rs
@@ -512,13 +512,17 @@ async fn auth_helper_edge_cases() {
         .is_none());
 
     // service jwts look like three dot-separated segments
-    let service_jwt = auth::create_service_jwt(auth::ServiceJwtParams {
-        iss: "did:web:pds.test".to_owned(),
-        aud: "did:web:appview.test".to_owned(),
-        exp: None,
-        lxm: Some("com.atproto.repo.uploadBlob".to_owned()),
-        jti: None,
-    })
+    let keypair = secp256k1::Keypair::new(&secp256k1::Secp256k1::new(), &mut rand::thread_rng());
+    let service_jwt = auth::create_service_jwt(
+        auth::ServiceJwtParams {
+            iss: "did:web:pds.test".to_owned(),
+            aud: "did:web:appview.test".to_owned(),
+            exp: None,
+            lxm: Some("com.atproto.repo.uploadBlob".to_owned()),
+            jti: None,
+        },
+        &keypair,
+    )
     .await
     .unwrap();
     assert_eq!(service_jwt.split('.').count(), 3);

--- a/rsky-pds/src/actor_store/mod.rs
+++ b/rsky-pds/src/actor_store/mod.rs
@@ -11,7 +11,7 @@ use crate::actor_store::repo::types::SyncEvtData;
 use crate::actor_store::space::SpaceStore;
 use crate::background::BackgroundQueue;
 use crate::config::ActorStoreConfig;
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use lexicon_cid::Cid;
 use lru::LruCache;
 use rsky_common;
@@ -35,6 +35,7 @@ use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
+use tokio::io::AsyncWriteExt;
 use tokio::sync::{OwnedMutexGuard, RwLock};
 
 pub mod aws;
@@ -116,6 +117,28 @@ async fn load_key(location: &Path) -> Result<Option<Keypair>> {
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(err) => Err(err.into()),
     }
+}
+
+/// A truncating in-place rewrite of a key file destroys an unrecoverable
+/// secret if the process dies mid-write, so stage and rename instead.
+pub(crate) async fn atomic_write_key(location: &Path, bytes: &[u8]) -> Result<()> {
+    let directory = location
+        .parent()
+        .ok_or_else(|| anyhow!("key location has no parent directory"))?;
+    let file_name = location
+        .file_name()
+        .ok_or_else(|| anyhow!("key location has no file name"))?;
+    let mut tmp_name = file_name.to_os_string();
+    tmp_name.push(".tmp");
+    let tmp_location = directory.join(tmp_name);
+    {
+        let mut file = tokio::fs::File::create(&tmp_location).await?;
+        file.write_all(bytes).await?;
+        file.sync_all().await?;
+    }
+    tokio::fs::rename(&tmp_location, location).await?;
+    tokio::fs::File::open(directory).await?.sync_all().await?;
+    Ok(())
 }
 
 #[derive(Debug, Clone)]
@@ -261,6 +284,15 @@ impl ActorStore {
         let mut cache = self.cache.lock().expect("actor store cache poisoned");
         cache.put(did.to_string(), db);
         Ok(())
+    }
+
+    /// Replace an actor's signing key on disk. Holds the per-DID write lock so
+    /// no commit is signed with the outgoing key part-way through the swap.
+    pub async fn set_keypair(&self, did: &str, keypair: &Keypair) -> Result<()> {
+        let location = self.get_location(did)?;
+        let _guard = self.did_lock(did).lock_owned().await;
+        tokio::fs::create_dir_all(&location.directory).await?;
+        atomic_write_key(&location.key_location, &keypair.secret_bytes()).await
     }
 
     pub async fn destroy(&self, did: &str, blobstore: Arc<dyn BlobStore>) -> Result<()> {

--- a/rsky-pds/src/actor_store/tests.rs
+++ b/rsky-pds/src/actor_store/tests.rs
@@ -4,6 +4,8 @@ use rsky_repo::types::PreparedDelete;
 
 const TEST_DID: &str = "did:example:alice";
 const TEST_SECRET_HEX: &str = "1d2f8064213bd212453fa93943c084dbbf42104d02f1f02b23a638f9a48f925a";
+const REPLACEMENT_SECRET_HEX: &str =
+    "5d2f8064213bd212453fa93943c084dbbf42104d02f1f02b23a638f9a48f925a";
 
 fn cid(value: &str) -> Cid {
     Cid::from_str(value).unwrap()
@@ -762,4 +764,67 @@ async fn moved_record_keeps_shared_blocks() {
         .unwrap()
         .unwrap();
     assert_eq!(got.cid, original.cid.to_string());
+}
+
+#[tokio::test]
+async fn set_keypair_replaces_the_key_and_the_next_commit_uses_it() {
+    let (_dir, store) = test_store(10);
+    store.create(TEST_DID, &test_keypair()).await.unwrap();
+    {
+        let actor_txn = store
+            .transact(TEST_DID.to_owned(), blobstore())
+            .await
+            .unwrap();
+        actor_txn.create_repo(Vec::new()).await.unwrap();
+    }
+
+    let replacement = import_keypair(&hex::decode(REPLACEMENT_SECRET_HEX).unwrap()).unwrap();
+    store.set_keypair(TEST_DID, &replacement).await.unwrap();
+
+    assert_eq!(
+        store.keypair(TEST_DID).await.unwrap().secret_bytes(),
+        replacement.secret_bytes()
+    );
+    // the transactor snapshots the key at open time, so it picks up the swap
+    let actor_txn = store
+        .transact(TEST_DID.to_owned(), blobstore())
+        .await
+        .unwrap();
+    assert_eq!(actor_txn.keypair.secret_bytes(), replacement.secret_bytes());
+}
+
+#[tokio::test]
+async fn set_keypair_leaves_no_temp_file_behind() {
+    let (_dir, store) = test_store(10);
+    store.create(TEST_DID, &test_keypair()).await.unwrap();
+    let location = store.get_location(TEST_DID).unwrap();
+    store
+        .set_keypair(
+            TEST_DID,
+            &import_keypair(&hex::decode(REPLACEMENT_SECRET_HEX).unwrap()).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let mut entries = tokio::fs::read_dir(&location.directory).await.unwrap();
+    let mut names = Vec::new();
+    while let Some(entry) = entries.next_entry().await.unwrap() {
+        names.push(entry.file_name().to_string_lossy().to_string());
+    }
+    assert!(names.contains(&"key".to_owned()), "{names:?}");
+    assert!(
+        !names.iter().any(|name| name.ends_with(".tmp")),
+        "{names:?}"
+    );
+}
+
+#[tokio::test]
+async fn set_keypair_rejects_an_unsafe_did() {
+    let (_dir, store) = test_store(10);
+    assert!(store.set_keypair("bad/did", &test_keypair()).await.is_err());
+}
+
+#[tokio::test]
+async fn atomic_write_key_rejects_a_pathless_location() {
+    assert!(atomic_write_key(Path::new("/"), b"bytes").await.is_err());
 }

--- a/rsky-pds/src/apis/app/bsky/feed/get_feed.rs
+++ b/rsky-pds/src/apis/app/bsky/feed/get_feed.rs
@@ -1,3 +1,4 @@
+use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
 use crate::auth_verifier::{AccessOutput, AccessStandard};
 use crate::config::ServerConfig;
@@ -112,6 +113,7 @@ impl<'r> FromRequest<'r> for GetFeedPipeThrough {
                                         .await
                                         .unwrap(),
                                     cfg: req.guard::<&State<ServerConfig>>().await.unwrap(),
+                                    actor_store: req.guard::<&State<ActorStore>>().await.unwrap(),
                                 };
                                 match pipethrough(
                                     &proxy_req,

--- a/rsky-pds/src/apis/app/bsky/feed/get_post_thread.rs
+++ b/rsky-pds/src/apis/app/bsky/feed/get_post_thread.rs
@@ -53,10 +53,11 @@ pub async fn inner_get_post_thread(
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<GetPostThreadOutput>> {
-    let requester: String = match auth.access.credentials {
-        None => "".to_string(),
-        Some(credentials) => credentials.did.unwrap_or("".to_string()),
-    };
+    let requester: String = auth
+        .access
+        .credentials
+        .and_then(|credentials| credentials.did)
+        .ok_or_else(|| anyhow!("Missing account did on authenticated request"))?;
     match res {
         Ok(res) => {
             let read_afer_write_response = handle_read_after_write(
@@ -402,8 +403,12 @@ pub async fn read_after_write_not_found(
                                                 let nsid = Ids::AppBskyFeedGetPostThread
                                                     .as_str()
                                                     .to_string();
+                                                let keypair =
+                                                    local_viewer.actor_store.keypair().await?;
                                                 let headers = cfg
-                                                    .appview_auth_headers(&requester, &nsid)
+                                                    .appview_auth_headers(
+                                                        &requester, &nsid, &keypair,
+                                                    )
                                                     .await?;
                                                 let client = ReqwestClientBuilder::new(
                                                     bsky_app_view.url.clone(),

--- a/rsky-pds/src/apis/app/bsky/notification/register_push.rs
+++ b/rsky-pds/src/apis/app/bsky/notification/register_push.rs
@@ -1,3 +1,4 @@
+use crate::actor_store::ActorStore;
 use crate::apis::app::bsky::util::get_did_doc;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandardSignupQueued;
@@ -23,6 +24,7 @@ pub async fn inner_register_push(
     cfg: &State<ServerConfig>,
     app_view_url: String,
     id_resolver: &State<SharedIdResolver>,
+    actor_store: &State<ActorStore>,
 ) -> Result<()> {
     let RegisterPushInput {
         service_did,
@@ -30,12 +32,14 @@ pub async fn inner_register_push(
         platform,
         app_id,
     } = body.into_inner();
-    let did: String = match auth.access.credentials {
-        None => "".to_string(),
-        Some(credentials) => credentials.did.unwrap_or("".to_string()),
-    };
+    let did: String = auth
+        .access
+        .credentials
+        .and_then(|credentials| credentials.did)
+        .ok_or_else(|| anyhow!("Missing account did on authenticated request"))?;
     let nsid = Ids::AppBskyNotificationRegisterPush.as_str().to_string();
-    let auth_headers = context::service_auth_headers(&did, &service_did, &nsid).await?;
+    let auth_headers =
+        context::service_auth_headers(actor_store, &did, &service_did, &nsid).await?;
 
     let client = ReqwestClientBuilder::new(app_view_url)
         .client(
@@ -110,6 +114,7 @@ pub async fn register_push(
     auth: AccessStandardSignupQueued,
     cfg: &State<ServerConfig>,
     id_resolver: &State<SharedIdResolver>,
+    actor_store: &State<ActorStore>,
 ) -> Result<(), ApiError> {
     if !["ios", "android", "web"].contains(&body.platform.as_str()) {
         return Err(ApiError::InvalidRequest("invalid platform".to_string()));
@@ -117,7 +122,15 @@ pub async fn register_push(
     match &cfg.bsky_app_view {
         None => return Err(ApiError::RuntimeError),
         Some(bsky_app_view) => {
-            match inner_register_push(body, auth, cfg, bsky_app_view.url.clone(), id_resolver).await
+            match inner_register_push(
+                body,
+                auth,
+                cfg,
+                bsky_app_view.url.clone(),
+                id_resolver,
+                actor_store,
+            )
+            .await
             {
                 Ok(_) => Ok(()),
                 Err(_) => {

--- a/rsky-pds/src/apis/app/bsky/notification/unregister_push.rs
+++ b/rsky-pds/src/apis/app/bsky/notification/unregister_push.rs
@@ -1,9 +1,10 @@
+use crate::actor_store::ActorStore;
 use crate::apis::app::bsky::notification::register_push::get_endpoint;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandard;
 use crate::config::ServerConfig;
 use crate::{context, SharedIdResolver, APP_USER_AGENT};
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use rocket::serde::json::Json;
 use rocket::State;
 use rsky_lexicon::app::bsky::notification::RegisterPushInput;
@@ -15,14 +16,17 @@ pub async fn inner_unregister_push(
     cfg: &State<ServerConfig>,
     app_view_url: String,
     id_resolver: &State<SharedIdResolver>,
+    actor_store: &State<ActorStore>,
 ) -> Result<()> {
     let input = body.into_inner();
-    let did: String = match auth.access.credentials {
-        None => "".to_string(),
-        Some(credentials) => credentials.did.unwrap_or("".to_string()),
-    };
+    let did: String = auth
+        .access
+        .credentials
+        .and_then(|credentials| credentials.did)
+        .ok_or_else(|| anyhow!("Missing account did on authenticated request"))?;
     let nsid = Ids::AppBskyNotificationUnregisterPush.as_str().to_string();
-    let auth_headers = context::service_auth_headers(&did, &input.service_did, &nsid).await?;
+    let auth_headers =
+        context::service_auth_headers(actor_store, &did, &input.service_did, &nsid).await?;
 
     let url = if let Some(ref bsky_app_view) = cfg.bsky_app_view {
         if bsky_app_view.did == input.service_did {
@@ -63,6 +67,7 @@ pub async fn unregister_push(
     auth: AccessStandard,
     cfg: &State<ServerConfig>,
     id_resolver: &State<SharedIdResolver>,
+    actor_store: &State<ActorStore>,
 ) -> Result<(), ApiError> {
     if !["ios", "android", "web"].contains(&body.platform.as_str()) {
         return Err(ApiError::InvalidRequest("invalid platform".to_string()));
@@ -70,8 +75,15 @@ pub async fn unregister_push(
     match &cfg.bsky_app_view {
         None => Err(ApiError::RuntimeError),
         Some(bsky_app_view) => {
-            match inner_unregister_push(body, auth, cfg, bsky_app_view.url.clone(), id_resolver)
-                .await
+            match inner_unregister_push(
+                body,
+                auth,
+                cfg,
+                bsky_app_view.url.clone(),
+                id_resolver,
+                actor_store,
+            )
+            .await
             {
                 Ok(_) => Ok(()),
                 Err(error) => {

--- a/rsky-pds/src/apis/com/atproto/identity/get_recommended_did_credentials.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/get_recommended_did_credentials.rs
@@ -1,10 +1,10 @@
 use crate::account_manager::helpers::account::AvailabilityFlags;
 use crate::account_manager::AccountManager;
+use crate::actor_store::ActorStore;
 use crate::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandard;
 use crate::config::ServerConfig;
-use crate::context::PDS_REPO_SIGNING_KEYPAIR;
 use rocket::serde::json::Json;
 use rocket::State;
 use rsky_crypto::utils::encode_did_key;
@@ -16,6 +16,7 @@ use serde_json::json;
 pub async fn get_recommended_did_credentials(
     auth: AccessStandard,
     cfg: &State<ServerConfig>,
+    actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<Json<GetRecommendedDidCredentialsResponse>, ApiError> {
     let requester = auth.access.credentials.unwrap().did.unwrap();
@@ -36,7 +37,13 @@ pub async fn get_recommended_did_credentials(
         }
     }
 
-    let signing_key = encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key());
+    let signing_key = match actor_store.keypair(&requester).await {
+        Ok(keypair) => encode_did_key(&keypair.public_key()),
+        Err(error) => {
+            tracing::error!("Failed to load signing key for {requester}\n{error}");
+            return Err(ApiError::RuntimeError);
+        }
+    };
     let verification_methods = json!({
         "atproto": signing_key
     });

--- a/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
@@ -1,10 +1,10 @@
 use crate::account_manager::helpers::account::AvailabilityFlags;
 use crate::account_manager::AccountManager;
+use crate::actor_store::ActorStore;
 use crate::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandard;
 use crate::config::ServerConfig;
-use crate::context::PDS_REPO_SIGNING_KEYPAIR;
 use crate::plc::types::{OpOrTombstone, Operation};
 use crate::{plc, SharedIdResolver, SharedSequencer};
 use rocket::serde::json::Json;
@@ -34,6 +34,7 @@ async fn validate_plc_request(
     did: &str,
     op: &Operation,
     public_endpoint: &str,
+    actor_store: &ActorStore,
     account_manager: &AccountManager,
 ) -> Result<(), ApiError> {
     let public_rotation_key = encode_did_key(&PDS_PLC_ROTATION_KEYPAIR.public_key());
@@ -43,7 +44,13 @@ async fn validate_plc_request(
         ));
     }
 
-    let public_signing_key = encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key());
+    let public_signing_key = match actor_store.keypair(did).await {
+        Ok(keypair) => encode_did_key(&keypair.public_key()),
+        Err(error) => {
+            tracing::error!("Failed to load signing key for {did}\n{error}");
+            return Err(ApiError::RuntimeError);
+        }
+    };
     match op.verification_methods.get("atproto") {
         None => {
             return Err(ApiError::InvalidRequest(
@@ -162,6 +169,7 @@ pub async fn submit_plc_operation(
     sequencer: &State<SharedSequencer>,
     id_resolver: &State<SharedIdResolver>,
     server_config: &State<ServerConfig>,
+    actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     let did = get_requester_did(&auth)?;
@@ -174,6 +182,7 @@ pub async fn submit_plc_operation(
         did.as_str(),
         &op,
         server_config.service.public_url.as_str(),
+        actor_store,
         &account_manager,
     )
     .await?;

--- a/rsky-pds/src/apis/com/atproto/server/activate_account.rs
+++ b/rsky-pds/src/apis/com/atproto/server/activate_account.rs
@@ -18,7 +18,7 @@ async fn inner_activate_account(
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     let requester = auth.access.credentials.unwrap().did.unwrap();
-    assert_valid_did_documents_for_service(requester.clone()).await?;
+    assert_valid_did_documents_for_service(actor_store, requester.clone()).await?;
 
     let account = account_manager
         .get_account(

--- a/rsky-pds/src/apis/com/atproto/server/check_account_status.rs
+++ b/rsky-pds/src/apis/com/atproto/server/check_account_status.rs
@@ -18,29 +18,29 @@ async fn inner_check_account_status(
 ) -> Result<CheckAccountStatusOutput> {
     let requester = auth.access.credentials.unwrap().did.unwrap();
 
-    let mut actor_store = actor_store
+    let mut reader = actor_store
         .read(
             requester.clone(),
             blobstore_factory.blobstore(requester.clone()),
         )
         .await?;
     let repo_root = {
-        let storage_guard = actor_store.storage.read().await;
+        let storage_guard = reader.storage.read().await;
         storage_guard.get_root_detailed().await?
     };
     let repo_blocks = {
-        let storage_guard = actor_store.storage.read().await;
+        let storage_guard = reader.storage.read().await;
         storage_guard.count_blocks().await?
     };
     let (indexed_records, imported_blobs, expected_blobs) = try_join!(
-        actor_store.record.record_count(),
-        actor_store.blob.blob_count(),
-        actor_store.blob.record_blob_count(),
+        reader.record.record_count(),
+        reader.blob.blob_count(),
+        reader.blob.record_blob_count(),
     )?;
 
     let (activated, valid_did) = try_join!(
         account_manager.is_account_activated(&requester),
-        is_valid_did_doc_for_service(requester.clone())
+        is_valid_did_doc_for_service(actor_store, requester.clone())
     )?;
 
     Ok(CheckAccountStatusOutput {

--- a/rsky-pds/src/apis/com/atproto/server/create_account.rs
+++ b/rsky-pds/src/apis/com/atproto/server/create_account.rs
@@ -7,7 +7,6 @@ use crate::apis::ApiError;
 use crate::auth_verifier::UserDidAuthOptional;
 use crate::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::config::ServerConfig;
-use crate::context::PDS_REPO_SIGNING_KEYPAIR;
 use crate::handle::{normalize_and_validate_handle, HandleValidationContext, HandleValidationOpts};
 use crate::plc::operations::{create_op, CreateAtprotoOpInput};
 use crate::plc::types::{OpOrTombstone, Operation};
@@ -20,9 +19,10 @@ use rocket::State;
 use rsky_common::env::env_str;
 use rsky_crypto::utils::encode_did_key;
 use rsky_lexicon::com::atproto::server::{CreateAccountInput, CreateAccountOutput};
+use secp256k1::{Keypair, Secp256k1};
 use std::env;
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Clone)]
 pub struct TransformedCreateAccountInput {
     pub email: String,
     pub handle: String,
@@ -31,6 +31,8 @@ pub struct TransformedCreateAccountInput {
     pub password: String,
     pub plc_op: Option<Operation>,
     pub deactivated: bool,
+    /// Generated per account, and already named by `plc_op` when there is one.
+    pub signing_key: Keypair,
 }
 
 //TODO: Potential for taking advantage of async better
@@ -67,6 +69,7 @@ pub async fn server_create_account(
         password,
         deactivated,
         plc_op,
+        signing_key,
     } = validate_inputs_for_local_pds(
         cfg,
         id_resolver,
@@ -79,7 +82,7 @@ pub async fn server_create_account(
 
     // Create new actor repo TODO: Proper rollback
     let blobstore = blobstore_factory.blobstore(did.clone());
-    if let Err(error) = actor_store.create(&did, &PDS_REPO_SIGNING_KEYPAIR).await {
+    if let Err(error) = actor_store.create(&did, &signing_key).await {
         tracing::error!("Failed to create actor store\n{:?}", error);
         return Err(ApiError::RuntimeError);
     }
@@ -318,6 +321,10 @@ pub async fn validate_inputs_for_local_pds(
         Some(ref pass) => pass.clone(),
     };
 
+    // One key per account, generated before the PLC create op so the op and
+    // the actor store's key file name the same key.
+    let signing_key = Keypair::new(&Secp256k1::new(), &mut rand::thread_rng());
+
     match input.did {
         Some(input_did) => {
             if !is_admin && Some(&input_did) != requester.as_ref() {
@@ -330,7 +337,7 @@ pub async fn validate_inputs_for_local_pds(
             deactivated = true;
         }
         None => {
-            let res = format_did_and_plc_op(input).await?;
+            let res = format_did_and_plc_op(input, &signing_key).await?;
             did = res.0;
             plc_op = Some(res.1);
             deactivated = false;
@@ -345,11 +352,15 @@ pub async fn validate_inputs_for_local_pds(
         password,
         plc_op,
         deactivated,
+        signing_key,
     })
 }
 
 #[tracing::instrument(skip_all)]
-async fn format_did_and_plc_op(input: CreateAccountInput) -> Result<(String, Operation), ApiError> {
+async fn format_did_and_plc_op(
+    input: CreateAccountInput,
+    signing_key: &Keypair,
+) -> Result<(String, Operation), ApiError> {
     let mut rotation_keys: Vec<String> = Vec::new();
 
     //Add user provided rotation key
@@ -363,7 +374,7 @@ async fn format_did_and_plc_op(input: CreateAccountInput) -> Result<(String, Ope
     //Build PLC Create Operation
 
     let create_op_input = CreateAtprotoOpInput {
-        signing_key: encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key()),
+        signing_key: encode_did_key(&signing_key.public_key()),
         handle: input.handle,
         pds: format!(
             "https://{}",

--- a/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
+++ b/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
@@ -1,4 +1,5 @@
 use crate::account_manager::helpers::auth::{create_service_jwt, ServiceJwtParams};
+use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessFull;
 use crate::pipethrough::{PRIVILEGED_METHODS, PROTECTED_METHODS};
@@ -6,6 +7,7 @@ use anyhow::{bail, Result};
 use chrono::offset::Utc as UtcOffset;
 use chrono::DateTime;
 use rocket::serde::json::Json;
+use rocket::State;
 use rsky_common::time::{from_micros_to_utc, HOUR, MINUTE};
 use rsky_lexicon::com::atproto::server::GetServiceAuthOutput;
 use std::time::SystemTime;
@@ -15,6 +17,7 @@ pub async fn inner_get_service_auth(
     exp: Option<u64>,
     lxm: Option<String>,
     auth: AccessFull,
+    actor_store: &State<ActorStore>,
 ) -> Result<String> {
     let credentials = auth.access.credentials.unwrap();
     let did = credentials.clone().did.unwrap();
@@ -39,13 +42,17 @@ pub async fn inner_get_service_auth(
             bail!("insufficient access to request a service auth token for the following method: {lxm}");
         }
     }
-    create_service_jwt(ServiceJwtParams {
-        iss: did,
-        aud,
-        exp,
-        lxm,
-        jti: None,
-    })
+    let keypair = actor_store.keypair(&did).await?;
+    create_service_jwt(
+        ServiceJwtParams {
+            iss: did,
+            aud,
+            exp,
+            lxm,
+            jti: None,
+        },
+        &keypair,
+    )
     .await
 }
 
@@ -61,8 +68,9 @@ pub async fn get_service_auth(
     // Lexicon (XRPC) method to bind the requested token to
     lxm: Option<String>,
     auth: AccessFull,
+    actor_store: &State<ActorStore>,
 ) -> Result<Json<GetServiceAuthOutput>, ApiError> {
-    match inner_get_service_auth(aud, exp, lxm, auth).await {
+    match inner_get_service_auth(aud, exp, lxm, auth, actor_store).await {
         Ok(token) => Ok(Json(GetServiceAuthOutput { token })),
         Err(error) => {
             tracing::error!("Internal Error: {error}");

--- a/rsky-pds/src/apis/com/atproto/server/mod.rs
+++ b/rsky-pds/src/apis/com/atproto/server/mod.rs
@@ -1,4 +1,4 @@
-use crate::context::PDS_REPO_SIGNING_KEYPAIR;
+use crate::actor_store::ActorStore;
 use crate::{plc, SharedIdResolver};
 use anyhow::{bail, Result};
 use rand::{distributions::Alphanumeric, Rng};
@@ -91,14 +91,18 @@ pub fn validate_handle(handle: &str, service_handle_domains: &[String]) -> bool 
     })
 }
 
-pub async fn is_valid_did_doc_for_service(did: String) -> Result<bool> {
-    match assert_valid_did_documents_for_service(did).await {
+pub async fn is_valid_did_doc_for_service(actor_store: &ActorStore, did: String) -> Result<bool> {
+    match assert_valid_did_documents_for_service(actor_store, did).await {
         Ok(()) => Ok(true),
         Err(_) => Ok(false),
     }
 }
 
-pub async fn assert_valid_did_documents_for_service(did: String) -> Result<()> {
+pub async fn assert_valid_did_documents_for_service(
+    actor_store: &ActorStore,
+    did: String,
+) -> Result<()> {
+    let expected_signing_key = encode_did_key(&actor_store.keypair(&did).await?.public_key());
     if did.starts_with("did:plc") {
         let plc_url = env_str("PDS_DID_PLC_URL").unwrap_or("https://plc.directory".to_owned());
         let plc_client = plc::Client::new(plc_url);
@@ -108,11 +112,14 @@ pub async fn assert_valid_did_documents_for_service(did: String) -> Result<()> {
             .get("atproto_pds")
             .map(|service| service.endpoint.clone());
         let signing_key = resolved.verification_methods.get("atproto").cloned();
-        assert_valid_doc_contents(AssertionContents {
-            pds_endpoint,
-            signing_key,
-            rotation_keys: Some(resolved.rotation_keys),
-        })
+        assert_valid_doc_contents(
+            AssertionContents {
+                pds_endpoint,
+                signing_key,
+                rotation_keys: Some(resolved.rotation_keys),
+            },
+            &expected_signing_key,
+        )
         .await?;
     } else if let Some(host) = did.strip_prefix("did:web:") {
         // Bare-host did:web: the document lives at the well-known path. No
@@ -131,11 +138,14 @@ pub async fn assert_valid_did_documents_for_service(did: String) -> Result<()> {
         });
         let signing_key = get_verification_material(&doc, "atproto")
             .and_then(|material| get_did_key_from_multibase(material).ok().flatten());
-        assert_valid_doc_contents(AssertionContents {
-            pds_endpoint,
-            signing_key,
-            rotation_keys: None,
-        })
+        assert_valid_doc_contents(
+            AssertionContents {
+                pds_endpoint,
+                signing_key,
+                rotation_keys: None,
+            },
+            &expected_signing_key,
+        )
         .await?;
     } else {
         bail!("Unsupported did method: {did}")
@@ -143,7 +153,10 @@ pub async fn assert_valid_did_documents_for_service(did: String) -> Result<()> {
     Ok(())
 }
 
-pub async fn assert_valid_doc_contents(contents: AssertionContents) -> Result<()> {
+pub async fn assert_valid_doc_contents(
+    contents: AssertionContents,
+    expected_signing_key: &str,
+) -> Result<()> {
     let AssertionContents {
         signing_key,
         pds_endpoint,
@@ -169,9 +182,7 @@ pub async fn assert_valid_doc_contents(contents: AssertionContents) -> Result<()
         bail!("DID document atproto_pds service endpoint does not match PDS public url")
     }
 
-    if signing_key.is_none()
-        || signing_key.unwrap() != encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key())
-    {
+    if signing_key.is_none() || signing_key.unwrap() != expected_signing_key {
         bail!("DID document verification method does not match expected signing key")
     }
     Ok(())

--- a/rsky-pds/src/bin/rotate-keys.rs
+++ b/rsky-pds/src/bin/rotate-keys.rs
@@ -1,0 +1,168 @@
+//! Moves existing accounts off the shared repo signing key onto their own.
+//!
+//! Publishes a PLC operation and emits firehose events per account, so it is
+//! never run automatically — an operator runs it deliberately. It is
+//! resumable: a DID whose document already names its own key is skipped.
+//! Run it against a quiesced PDS; the per-DID write lock is process-local.
+//!
+//!     rotate-keys [--dry-run] [--did <did>]...
+
+use anyhow::{bail, Result};
+use rsky_pds::account_manager::AccountManager;
+use rsky_pds::actor_store::blobstore::BlobstoreFactory;
+use rsky_pds::actor_store::ActorStore;
+use rsky_pds::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
+use rsky_pds::background::BackgroundQueue;
+use rsky_pds::config::env_to_cfg;
+use rsky_pds::context::PDS_REPO_SIGNING_KEYPAIR;
+use rsky_pds::crawlers::Crawlers;
+use rsky_pds::rotate_keys::{rotate_keys, RotateKeysContext, RotateKeysOpts};
+use rsky_pds::sequencer::Sequencer;
+use rsky_pds::{account_manager, plc, sequencer};
+use std::env;
+use tokio::sync::RwLock;
+
+const USAGE: &str = "usage: rotate-keys [--dry-run] [--did <did>]...";
+
+#[derive(Debug)]
+struct Args {
+    dids: Option<Vec<String>>,
+    dry_run: bool,
+    help: bool,
+}
+
+fn parse_args(argv: impl IntoIterator<Item = String>) -> Result<Args> {
+    let mut dids: Vec<String> = Vec::new();
+    let mut dry_run = false;
+    let mut help = false;
+    let mut argv = argv.into_iter();
+    while let Some(arg) = argv.next() {
+        match arg.as_str() {
+            "--dry-run" => dry_run = true,
+            "--did" => match argv.next() {
+                Some(did) => dids.push(did),
+                None => bail!("--did requires a value"),
+            },
+            "--help" | "-h" => help = true,
+            other => bail!("unrecognised argument: {other}"),
+        }
+    }
+    Ok(Args {
+        dids: if dids.is_empty() { None } else { Some(dids) },
+        dry_run,
+        help,
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    dotenvy::dotenv().ok();
+    tracing::subscriber::set_global_default(tracing_subscriber::FmtSubscriber::new())?;
+
+    let args = parse_args(env::args().skip(1))?;
+    if args.help {
+        tracing::info!("{USAGE}");
+        return Ok(());
+    }
+
+    // fail on a missing key here rather than part-way through a sweep
+    let shared_signing_key = *PDS_REPO_SIGNING_KEYPAIR;
+    let plc_rotation_key = PDS_PLC_ROTATION_KEYPAIR.secret_key();
+
+    let cfg = env_to_cfg();
+    let account_manager = AccountManager::new(
+        account_manager::db::get_migrated_db(&cfg.service_db.account_db_location).await?,
+    );
+    let sequencer = RwLock::new(Sequencer::new(
+        sequencer::db::get_migrated_db(&cfg.service_db.sequencer_db_location).await?,
+        Crawlers::new(cfg.service.hostname.clone(), cfg.crawlers.clone()),
+        None,
+    ));
+    let actor_store = ActorStore::new(&cfg.actor_store, BackgroundQueue::default());
+    let aws_sdk_config = aws_config::from_env()
+        .endpoint_url(env::var("AWS_ENDPOINT").unwrap_or("localhost".to_owned()))
+        .load()
+        .await;
+    let blobstore_factory = BlobstoreFactory::new(cfg.blobstore.clone(), aws_sdk_config);
+    let plc_client = plc::Client::new(cfg.identity.plc_url.clone());
+
+    let report = rotate_keys(
+        &RotateKeysContext {
+            actor_store: &actor_store,
+            account_manager: &account_manager,
+            blobstore_factory: &blobstore_factory,
+            sequencer: &sequencer,
+            plc_client: &plc_client,
+            plc_rotation_key: &plc_rotation_key,
+            shared_signing_key: &shared_signing_key,
+        },
+        RotateKeysOpts {
+            dids: args.dids,
+            dry_run: args.dry_run,
+        },
+    )
+    .await?;
+    tracing::info!(
+        scanned = report.scanned,
+        rotated = report.rotated,
+        skipped = report.skipped,
+        failed = report.failed,
+        dry_run = args.dry_run,
+        "signing key rotation finished"
+    );
+    if report.failed > 0 {
+        bail!("{} account(s) failed to rotate", report.failed);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(argv: &[&str]) -> Args {
+        parse_args(argv.iter().map(|arg| (*arg).to_owned())).unwrap()
+    }
+
+    #[test]
+    fn no_arguments_sweeps_every_account() {
+        let parsed = args(&[]);
+        assert!(parsed.dids.is_none());
+        assert!(!parsed.dry_run);
+        assert!(!parsed.help);
+    }
+
+    #[test]
+    fn repeated_did_flags_accumulate() {
+        let parsed = args(&[
+            "--did",
+            "did:plc:alice",
+            "--dry-run",
+            "--did",
+            "did:plc:bob",
+        ]);
+        assert_eq!(
+            parsed.dids,
+            Some(vec!["did:plc:alice".to_owned(), "did:plc:bob".to_owned()])
+        );
+        assert!(parsed.dry_run);
+    }
+
+    #[test]
+    fn help_is_recognised() {
+        assert!(args(&["-h"]).help);
+        assert!(args(&["--help"]).help);
+    }
+
+    #[test]
+    fn a_did_flag_without_a_value_is_rejected() {
+        let error = parse_args(["--did".to_owned()]).unwrap_err().to_string();
+        assert_eq!(error, "--did requires a value");
+    }
+
+    #[test]
+    fn an_unknown_flag_is_rejected() {
+        let error = parse_args(["--nope".to_owned()]).unwrap_err().to_string();
+        assert_eq!(error, "unrecognised argument: --nope");
+    }
+}

--- a/rsky-pds/src/config/mod.rs
+++ b/rsky-pds/src/config/mod.rs
@@ -1,8 +1,10 @@
-use crate::context;
+use crate::account_manager::helpers::auth::ServiceJwtParams;
+use crate::xrpc_server::auth::create_service_auth_headers;
 use anyhow::{bail, Result};
 use reqwest::header::HeaderMap;
 use rsky_common::env::{env_bool, env_int, env_list, env_str};
 use rsky_common::time::{DAY, HOUR, SECOND};
+use secp256k1::Keypair;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ServerConfig {
@@ -252,11 +254,28 @@ pub fn env_to_cfg() -> ServerConfig {
 }
 
 impl ServerConfig {
-    pub async fn appview_auth_headers(&self, did: &str, lxm: &str) -> Result<HeaderMap> {
+    /// `keypair` must be the signing key of `did`, the account the token is
+    /// issued on behalf of.
+    pub async fn appview_auth_headers(
+        &self,
+        did: &str,
+        lxm: &str,
+        keypair: &Keypair,
+    ) -> Result<HeaderMap> {
         match &self.bsky_app_view {
             None => bail!("No appview configured."),
             Some(bsky_app_view) => {
-                context::service_auth_headers(did, &bsky_app_view.did, lxm).await
+                create_service_auth_headers(
+                    ServiceJwtParams {
+                        iss: did.to_owned(),
+                        aud: bsky_app_view.did.clone(),
+                        exp: None,
+                        lxm: Some(lxm.to_owned()),
+                        jti: None,
+                    },
+                    keypair,
+                )
+                .await
             }
         }
     }
@@ -334,16 +353,56 @@ mod tests {
         );
 
         // no appview configured means no auth headers
-        let mut no_appview = cfg;
+        let mut no_appview = cfg.clone();
         no_appview.bsky_app_view = None;
         let rt = tokio::runtime::Builder::new_current_thread()
             .build()
             .unwrap();
+        let secret = secp256k1::SecretKey::from_slice(&[0x29u8; 32]).unwrap();
+        let keypair = Keypair::from_secret_key(&secp256k1::Secp256k1::new(), &secret);
         assert!(rt
-            .block_on(
-                no_appview.appview_auth_headers("did:example:alice", "app.bsky.feed.getTimeline")
-            )
+            .block_on(no_appview.appview_auth_headers(
+                "did:example:alice",
+                "app.bsky.feed.getTimeline",
+                &keypair
+            ))
             .is_err());
+
+        // with one configured, the header is signed by the key it was handed
+        let mut with_appview = cfg;
+        with_appview.bsky_app_view = Some(ServiceConfig {
+            url: "https://appview.example.com".to_owned(),
+            did: "did:web:appview.example.com".to_owned(),
+            cdn_url_pattern: None,
+        });
+        let headers = rt
+            .block_on(with_appview.appview_auth_headers(
+                "did:example:alice",
+                "app.bsky.feed.getTimeline",
+                &keypair,
+            ))
+            .unwrap();
+        let jwt = headers
+            .get(reqwest::header::AUTHORIZATION)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .strip_prefix("Bearer ")
+            .unwrap()
+            .to_owned();
+        let did_key = rsky_crypto::utils::encode_did_key(&keypair.public_key());
+        let payload = rt
+            .block_on(crate::xrpc_server::auth::verify_jwt(
+                jwt,
+                Some("did:web:appview.example.com".to_owned()),
+                Some("app.bsky.feed.getTimeline"),
+                move |_iss, _refresh| {
+                    let did_key = did_key.clone();
+                    async move { Ok(did_key) }
+                },
+            ))
+            .unwrap();
+        assert_eq!(payload.iss, "did:example:alice");
     }
 
     #[test]

--- a/rsky-pds/src/context.rs
+++ b/rsky-pds/src/context.rs
@@ -1,4 +1,5 @@
 use crate::account_manager::helpers::auth::ServiceJwtParams;
+use crate::actor_store::ActorStore;
 use crate::xrpc_server::auth::create_service_auth_headers;
 use anyhow::Result;
 use reqwest::header::HeaderMap;
@@ -13,13 +14,22 @@ pub static PDS_REPO_SIGNING_KEYPAIR: LazyLock<Keypair> = LazyLock::new(|| {
     Keypair::from_secret_key(&secp, &secret_key)
 });
 
-pub async fn service_auth_headers(did: &str, aud: &str, lxm: &str) -> Result<HeaderMap> {
-    create_service_auth_headers(ServiceJwtParams {
-        iss: did.to_owned(),
-        aud: aud.to_owned(),
-        exp: None,
-        lxm: Some(lxm.to_owned()),
-        jti: None,
-    })
+pub async fn service_auth_headers(
+    actor_store: &ActorStore,
+    did: &str,
+    aud: &str,
+    lxm: &str,
+) -> Result<HeaderMap> {
+    let keypair = actor_store.keypair(did).await?;
+    create_service_auth_headers(
+        ServiceJwtParams {
+            iss: did.to_owned(),
+            aud: aud.to_owned(),
+            exp: None,
+            lxm: Some(lxm.to_owned()),
+            jti: None,
+        },
+        &keypair,
+    )
     .await
 }

--- a/rsky-pds/src/lib.rs
+++ b/rsky-pds/src/lib.rs
@@ -30,6 +30,7 @@ pub mod pipethrough;
 pub mod plc;
 pub mod read_after_write;
 pub mod repo;
+pub mod rotate_keys;
 pub mod sequencer;
 pub mod space_auth;
 pub mod space_scope;

--- a/rsky-pds/src/pipethrough.rs
+++ b/rsky-pds/src/pipethrough.rs
@@ -1,3 +1,4 @@
+use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
 use crate::auth_verifier::{AccessOutput, AccessStandard};
 use crate::config::{ServerConfig, ServiceConfig};
@@ -43,6 +44,7 @@ pub struct ProxyRequest<'r> {
     pub method: Method,
     pub id_resolver: &'r State<SharedIdResolver>,
     pub cfg: &'r State<ServerConfig>,
+    pub actor_store: &'r State<ActorStore>,
 }
 
 #[rocket::async_trait]
@@ -72,6 +74,7 @@ impl<'r> FromRequest<'r> for HandlerPipeThrough {
                     method: req.method(),
                     id_resolver: req.guard::<&State<SharedIdResolver>>().await.unwrap(),
                     cfg: req.guard::<&State<ServerConfig>>().await.unwrap(),
+                    actor_store: req.guard::<&State<ActorStore>>().await.unwrap(),
                 };
                 match pipethrough(
                     &proxy_req,
@@ -131,6 +134,7 @@ impl<'r> FromRequest<'r> for ProxyRequest<'r> {
             method: req.method(),
             id_resolver: req.guard::<&State<SharedIdResolver>>().await.unwrap(),
             cfg: req.guard::<&State<ServerConfig>>().await.unwrap(),
+            actor_store: req.guard::<&State<ActorStore>>().await.unwrap(),
         })
     }
 }
@@ -286,7 +290,9 @@ pub async fn format_headers(
     requester: Option<String>,
 ) -> Result<HeaderMap> {
     let mut headers: HeaderMap = match requester {
-        Some(requester) => context::service_auth_headers(&requester, &aud, &lxm).await?,
+        Some(requester) => {
+            context::service_auth_headers(req.actor_store, &requester, &aud, &lxm).await?
+        }
         None => HeaderMap::new(),
     };
     // forward select headers to upstream services

--- a/rsky-pds/src/plc/mod.rs
+++ b/rsky-pds/src/plc/mod.rs
@@ -1,4 +1,4 @@
-use crate::plc::operations::update_handle_op;
+use crate::plc::operations::{update_atproto_key_op, update_handle_op};
 use crate::plc::types::{CompatibleOp, OpOrTombstone};
 use crate::APP_USER_AGENT;
 use anyhow::{bail, Result};
@@ -109,7 +109,85 @@ impl Client {
         self.send_operation(did, &OpOrTombstone::Operation(op))
             .await
     }
+
+    pub async fn update_atproto_key(
+        &self,
+        did: &String,
+        signer: &SecretKey,
+        signing_key: &str,
+    ) -> Result<()> {
+        let last_op: CompatibleOp = match self.ensure_last_op(did).await? {
+            CompatibleOpOrTombstone::CreateOpV1(last_op) => CompatibleOp::CreateOpV1(last_op),
+            CompatibleOpOrTombstone::Operation(last_op) => CompatibleOp::Operation(last_op),
+            CompatibleOpOrTombstone::Tombstone(_) => {
+                panic!("ensure_last_op() didn't prevent tombstone")
+            }
+        };
+        let op = update_atproto_key_op(last_op, signer, signing_key.to_owned()).await?;
+        self.send_operation(did, &OpOrTombstone::Operation(op))
+            .await
+    }
 }
 
 pub mod operations;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub mod types;
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::MockPlc;
+    use super::*;
+    use crate::plc::types::Operation;
+    use rsky_crypto::utils::encode_did_key;
+    use secp256k1::{Keypair, Secp256k1};
+    use std::collections::BTreeMap;
+
+    fn keypair(byte: u8) -> Keypair {
+        let secret = secp256k1::SecretKey::from_slice(&[byte; 32]).unwrap();
+        Keypair::from_secret_key(&Secp256k1::new(), &secret)
+    }
+
+    #[tokio::test]
+    async fn update_atproto_key_publishes_the_new_verification_method() {
+        let rotation = keypair(0x11);
+        let old_key = encode_did_key(&keypair(0x22).public_key());
+        let new_key = encode_did_key(&keypair(0x33).public_key());
+        let did = "did:plc:alice".to_owned();
+        let plc = MockPlc::start(
+            &encode_did_key(&rotation.public_key()),
+            BTreeMap::from([(did.clone(), old_key.clone())]),
+        );
+        let client = Client::new(plc.url.clone());
+
+        client
+            .update_atproto_key(&did, &rotation.secret_key(), &new_key)
+            .await
+            .unwrap();
+
+        let posted = plc.posted();
+        assert_eq!(posted.len(), 1);
+        let op: Operation = serde_json::from_value(posted[0].clone()).unwrap();
+        assert_eq!(op.verification_methods.get("atproto"), Some(&new_key));
+        assert!(op.prev.is_some());
+        assert!(op.sig.is_some());
+        assert_eq!(plc.published_key(&did), Some(new_key));
+    }
+
+    #[tokio::test]
+    async fn update_atproto_key_propagates_a_directory_error() {
+        let rotation = keypair(0x11);
+        let plc = MockPlc::start(&encode_did_key(&rotation.public_key()), BTreeMap::new());
+        let client = Client::new(format!("{}/missing", plc.url));
+        let error = client
+            .update_atproto_key(
+                &"did:plc:gone".to_owned(),
+                &rotation.secret_key(),
+                "did:key:whatever",
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(!error.is_empty());
+    }
+}

--- a/rsky-pds/src/plc/test_support.rs
+++ b/rsky-pds/src/plc/test_support.rs
@@ -1,0 +1,156 @@
+//! An in-process stand-in for a PLC directory, so the rotation paths can be
+//! exercised without reaching the network.
+
+use std::collections::BTreeMap;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Default)]
+pub(crate) struct MockPlcState {
+    /// did -> the `atproto` verification method the directory currently serves
+    pub keys: BTreeMap<String, String>,
+    /// every operation the directory accepted, in order
+    pub posted: Vec<serde_json::Value>,
+}
+
+pub(crate) struct MockPlc {
+    pub url: String,
+    pub state: Arc<Mutex<MockPlcState>>,
+}
+
+impl MockPlc {
+    pub fn start(rotation_key: &str, keys: BTreeMap<String, String>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock plc directory");
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let state = Arc::new(Mutex::new(MockPlcState {
+            keys,
+            posted: Vec::new(),
+        }));
+        let thread_state = state.clone();
+        let rotation_key = rotation_key.to_owned();
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                handle(&mut stream, &thread_state, &rotation_key);
+            }
+        });
+        MockPlc { url, state }
+    }
+
+    pub fn published_key(&self, did: &str) -> Option<String> {
+        self.state.lock().unwrap().keys.get(did).cloned()
+    }
+
+    pub fn posted(&self) -> Vec<serde_json::Value> {
+        self.state.lock().unwrap().posted.clone()
+    }
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn handle(stream: &mut TcpStream, state: &Arc<Mutex<MockPlcState>>, rotation_key: &str) {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut chunk = [0u8; 1024];
+    let head_end = loop {
+        let n = match stream.read(&mut chunk) {
+            Ok(0) | Err(_) => return,
+            Ok(n) => n,
+        };
+        buf.extend_from_slice(&chunk[..n]);
+        if let Some(pos) = find_subslice(&buf, b"\r\n\r\n") {
+            break pos + 4;
+        }
+    };
+    let head = String::from_utf8_lossy(&buf[..head_end]).to_string();
+    let mut request_line = head.split_whitespace();
+    let method = request_line.next().unwrap_or("").to_owned();
+    let path = request_line.next().unwrap_or("/").to_owned();
+    let content_length = head
+        .lines()
+        .find_map(|line| {
+            let lower = line.to_ascii_lowercase();
+            let value = lower.strip_prefix("content-length:")?;
+            value.trim().parse::<usize>().ok()
+        })
+        .unwrap_or(0);
+    while buf.len() < head_end + content_length {
+        let n = match stream.read(&mut chunk) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => n,
+        };
+        buf.extend_from_slice(&chunk[..n]);
+    }
+    let body = buf[head_end..].to_vec();
+
+    let path = path.replace("%3A", ":").replace("%3a", ":");
+    let segments: Vec<&str> = path.trim_matches('/').split('/').collect();
+    let did = segments.first().copied().unwrap_or_default().to_owned();
+    let current = state
+        .lock()
+        .unwrap()
+        .keys
+        .get(&did)
+        .cloned()
+        .unwrap_or_default();
+
+    let response_body = match (method.as_str(), segments.len()) {
+        ("GET", 2) if segments[1] == "data" => serde_json::json!({
+            "did": did,
+            "rotationKeys": [rotation_key],
+            "verificationMethods": { "atproto": current },
+            "alsoKnownAs": [format!("at://{did}.test")],
+            "services": {
+                "atproto_pds": {
+                    "type": "AtprotoPersonalDataServer",
+                    "endpoint": "https://pds.test"
+                }
+            }
+        })
+        .to_string(),
+        ("GET", 3) if segments[1] == "log" && segments[2] == "last" => serde_json::json!({
+            "type": "plc_operation",
+            "rotationKeys": [rotation_key],
+            "verificationMethods": { "atproto": current },
+            "alsoKnownAs": [format!("at://{did}.test")],
+            "services": {
+                "atproto_pds": {
+                    "type": "AtprotoPersonalDataServer",
+                    "endpoint": "https://pds.test"
+                }
+            },
+            "prev": null,
+            "sig": "c2ln"
+        })
+        .to_string(),
+        ("POST", 1) => {
+            let op: serde_json::Value = serde_json::from_slice(&body).unwrap_or_default();
+            let mut guard = state.lock().unwrap();
+            if let Some(key) = op
+                .get("verificationMethods")
+                .and_then(|methods| methods.get("atproto"))
+                .and_then(|key| key.as_str())
+            {
+                guard.keys.insert(did, key.to_owned());
+            }
+            guard.posted.push(op);
+            "{}".to_owned()
+        }
+        _ => {
+            let _ = stream.write_all(
+                b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            );
+            return;
+        }
+    };
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        response_body.len(),
+        response_body
+    );
+    let _ = stream.write_all(response.as_bytes());
+}

--- a/rsky-pds/src/read_after_write/tests.rs
+++ b/rsky-pds/src/read_after_write/tests.rs
@@ -662,3 +662,72 @@ async fn external_embeds_format_thumb_to_blob_url() {
     assert_eq!(view.external.uri, "https://example.com");
     assert!(view.external.thumb.unwrap().contains(TEST_CID));
 }
+
+/// The viewer signs with its own actor's key, so it may only issue tokens
+/// for that actor.
+#[tokio::test]
+async fn service_auth_headers_refuse_another_accounts_did() {
+    let (_dir, viewer) = test_viewer().await;
+    let error = viewer
+        .service_auth_headers(OTHER_DID, "app.bsky.feed.getTimeline")
+        .await
+        .unwrap_err()
+        .to_string();
+    assert_eq!(
+        error,
+        format!("Cannot issue a service token for {OTHER_DID} from {TEST_DID}")
+    );
+
+    // the requester's own did gets past the guard
+    let error = viewer
+        .service_auth_headers(TEST_DID, "app.bsky.feed.getTimeline")
+        .await
+        .unwrap_err()
+        .to_string();
+    assert_eq!(error, "Could not find bsky appview did");
+}
+
+#[tokio::test]
+async fn service_auth_headers_are_signed_with_the_actors_key() {
+    let (dir, viewer) = test_viewer().await;
+    let viewer = LocalViewer::new(
+        viewer.actor_store,
+        viewer.account_manager,
+        TEST_HOSTNAME.to_owned(),
+        None,
+        None,
+        Some("did:web:appview.test".to_owned()),
+        None,
+    );
+    let headers = viewer
+        .service_auth_headers(TEST_DID, "app.bsky.feed.getTimeline")
+        .await
+        .unwrap();
+    let jwt = headers
+        .get(reqwest::header::AUTHORIZATION)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .strip_prefix("Bearer ")
+        .unwrap()
+        .to_owned();
+
+    let secp = secp256k1::Secp256k1::new();
+    let secret = secp256k1::SecretKey::from_slice(&hex::decode(TEST_SECRET_HEX).unwrap()).unwrap();
+    let did_key = rsky_crypto::utils::encode_did_key(
+        &secp256k1::Keypair::from_secret_key(&secp, &secret).public_key(),
+    );
+    let payload = crate::xrpc_server::auth::verify_jwt(
+        jwt,
+        Some("did:web:appview.test".to_owned()),
+        Some("app.bsky.feed.getTimeline"),
+        move |_iss, _refresh| {
+            let did_key = did_key.clone();
+            async move { Ok(did_key) }
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(payload.iss, TEST_DID);
+    drop(dir);
+}

--- a/rsky-pds/src/read_after_write/viewer.rs
+++ b/rsky-pds/src/read_after_write/viewer.rs
@@ -135,16 +135,24 @@ impl LocalViewer {
     }
 
     pub async fn service_auth_headers(&self, did: &str, lxm: &str) -> Result<HeaderMap> {
+        // the token is signed by this viewer's actor key, so it can only be
+        // issued on that actor's behalf
+        if did != self.did {
+            bail!("Cannot issue a service token for {did} from {}", self.did);
+        }
         match &self.appview_did {
             None => bail!("Could not find bsky appview did"),
             Some(appview_did) => {
-                create_service_auth_headers(ServiceJwtParams {
-                    iss: did.to_owned(),
-                    aud: appview_did.clone(),
-                    exp: None,
-                    lxm: Some(lxm.to_owned()),
-                    jti: None,
-                })
+                create_service_auth_headers(
+                    ServiceJwtParams {
+                        iss: did.to_owned(),
+                        aud: appview_did.clone(),
+                        exp: None,
+                        lxm: Some(lxm.to_owned()),
+                        jti: None,
+                    },
+                    &self.actor_store.keypair().await?,
+                )
                 .await
             }
         }

--- a/rsky-pds/src/rotate_keys.rs
+++ b/rsky-pds/src/rotate_keys.rs
@@ -1,0 +1,179 @@
+// based on https://github.com/bluesky-social/atproto/blob/main/packages/pds/src/scripts/rotate-keys.ts
+// moves existing accounts off the shared repo signing key onto their own
+
+use crate::account_manager::AccountManager;
+use crate::actor_store::blobstore::BlobstoreFactory;
+use crate::actor_store::ActorStore;
+use crate::plc;
+use crate::sequencer::Sequencer;
+use anyhow::{anyhow, Result};
+use rsky_crypto::utils::encode_did_key;
+use secp256k1::{Keypair, Secp256k1, SecretKey};
+use tokio::sync::RwLock;
+
+/// Everything a rotation run needs. Borrowed rather than owned so the job can
+/// run against a live process's stores as well as a standalone binary's.
+pub struct RotateKeysContext<'a> {
+    pub actor_store: &'a ActorStore,
+    pub account_manager: &'a AccountManager,
+    pub blobstore_factory: &'a BlobstoreFactory,
+    pub sequencer: &'a RwLock<Sequencer>,
+    pub plc_client: &'a plc::Client,
+    pub plc_rotation_key: &'a SecretKey,
+    /// The legacy shared repo signing key. An account whose key file still
+    /// holds it has never been rotated.
+    pub shared_signing_key: &'a Keypair,
+}
+
+pub struct RotateKeysOpts {
+    /// Rotate only these DIDs; `None` sweeps every account on this PDS.
+    pub dids: Option<Vec<String>>,
+    /// Report what would change without writing a key, publishing a PLC
+    /// operation or emitting an event.
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct RotateKeysReport {
+    pub scanned: usize,
+    pub rotated: usize,
+    pub skipped: usize,
+    pub failed: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkipReason {
+    /// Only did:plc identities can be re-keyed by this server.
+    NotPlcDid,
+    /// The DID document already names the account's own key.
+    AlreadyRotated,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RotationOutcome {
+    Skipped(SkipReason),
+    Rotated,
+}
+
+pub async fn list_account_dids(account_manager: &AccountManager) -> Result<Vec<String>> {
+    account_manager
+        .db
+        .run(|conn| {
+            let mut stmt = conn.prepare("SELECT did FROM actor ORDER BY did")?;
+            let rows = stmt
+                .query_map([], |row| row.get(0))?
+                .collect::<Result<Vec<String>, rusqlite::Error>>()?;
+            Ok(rows)
+        })
+        .await
+}
+
+/// Re-keys accounts one at a time. Deliberately not batched: each DID's PLC
+/// operation is followed straight away by the commit that re-signs its repo,
+/// so the window where the published key and the repo head disagree stays as
+/// short as possible.
+pub async fn rotate_keys(
+    ctx: &RotateKeysContext<'_>,
+    opts: RotateKeysOpts,
+) -> Result<RotateKeysReport> {
+    let dids = match opts.dids {
+        Some(dids) => dids,
+        None => list_account_dids(ctx.account_manager).await?,
+    };
+    let mut report = RotateKeysReport::default();
+    for did in dids {
+        report.scanned += 1;
+        match rotate_one(ctx, &did, opts.dry_run).await {
+            Ok(RotationOutcome::Skipped(reason)) => {
+                report.skipped += 1;
+                tracing::debug!(%did, ?reason, "skipping signing key rotation");
+            }
+            Ok(RotationOutcome::Rotated) => {
+                report.rotated += 1;
+                tracing::info!(%did, dry_run = opts.dry_run, "rotated signing key");
+            }
+            Err(error) => {
+                report.failed += 1;
+                tracing::error!(%did, %error, "failed to rotate signing key");
+            }
+        }
+    }
+    Ok(report)
+}
+
+pub async fn rotate_one(
+    ctx: &RotateKeysContext<'_>,
+    did: &str,
+    dry_run: bool,
+) -> Result<RotationOutcome> {
+    if !did.starts_with("did:plc:") {
+        return Ok(RotationOutcome::Skipped(SkipReason::NotPlcDid));
+    }
+    let published = ctx
+        .plc_client
+        .get_document_data(&did.to_string())
+        .await?
+        .verification_methods
+        .get("atproto")
+        .cloned()
+        .ok_or_else(|| anyhow!("no atproto verification method published for {did}"))?;
+    let current = ctx.actor_store.keypair(did).await?;
+    let current_did_key = encode_did_key(&current.public_key());
+    let shared_did_key = encode_did_key(&ctx.shared_signing_key.public_key());
+
+    // Resolve and compare: an account whose published key is already its own
+    // is finished. This is what makes a run resumable over thousands of DIDs.
+    if current_did_key != shared_did_key && published == current_did_key {
+        return Ok(RotationOutcome::Skipped(SkipReason::AlreadyRotated));
+    }
+    if dry_run {
+        return Ok(RotationOutcome::Rotated);
+    }
+
+    // A key file that already moved off the shared key came from an
+    // interrupted run; republish it rather than burning another PLC op.
+    let keypair = if current_did_key == shared_did_key {
+        let keypair = Keypair::new(&Secp256k1::new(), &mut rand::thread_rng());
+        ctx.actor_store.set_keypair(did, &keypair).await?;
+        keypair
+    } else {
+        current
+    };
+    let signing_key = encode_did_key(&keypair.public_key());
+    ctx.plc_client
+        .update_atproto_key(&did.to_string(), ctx.plc_rotation_key, &signing_key)
+        .await?;
+
+    // An empty commit re-signs the repo head with the new key.
+    let (commit, sync_data) = {
+        let mut actor_txn = ctx
+            .actor_store
+            .transact(
+                did.to_string(),
+                ctx.blobstore_factory.blobstore(did.to_string()),
+            )
+            .await?;
+        let commit = actor_txn.process_writes(vec![], None).await?;
+        let sync_data = actor_txn.get_sync_event_data().await?;
+        (commit, sync_data)
+    };
+    ctx.account_manager
+        .update_repo_root(
+            did.to_string(),
+            commit.commit_data.cid,
+            commit.commit_data.rev.clone(),
+        )
+        .await?;
+
+    let mut sequencer = ctx.sequencer.write().await;
+    sequencer
+        .sequence_identity_evt(did.to_string(), None)
+        .await?;
+    sequencer
+        .sequence_sync_evt(did.to_string(), sync_data)
+        .await?;
+    Ok(RotationOutcome::Rotated)
+}
+
+#[cfg(test)]
+mod tests;

--- a/rsky-pds/src/rotate_keys/tests.rs
+++ b/rsky-pds/src/rotate_keys/tests.rs
@@ -1,0 +1,380 @@
+use super::*;
+use crate::account_manager::CreateAccountOpts;
+use crate::config::{ActorStoreConfig, BlobstoreConfig};
+use crate::crawlers::Crawlers;
+use crate::plc::test_support::MockPlc;
+use aws_config::SdkConfig;
+use lexicon_cid::Cid;
+use std::collections::BTreeMap;
+use std::str::FromStr;
+use tempfile::TempDir;
+
+const TEST_CID: &str = "bafkreibjfgx2gprinfvicegelk5kosd6y2frmqpqzwqkg7usac74l3t2v4";
+
+fn keypair(byte: u8) -> Keypair {
+    let secret = SecretKey::from_slice(&[byte; 32]).unwrap();
+    Keypair::from_secret_key(&Secp256k1::new(), &secret)
+}
+
+struct Harness {
+    _dir: TempDir,
+    actor_store: ActorStore,
+    account_manager: AccountManager,
+    blobstore_factory: BlobstoreFactory,
+    sequencer: RwLock<Sequencer>,
+    plc: MockPlc,
+    plc_client: plc::Client,
+    plc_rotation_secret: SecretKey,
+    shared_signing_key: Keypair,
+}
+
+impl Harness {
+    fn ctx(&self) -> RotateKeysContext<'_> {
+        RotateKeysContext {
+            actor_store: &self.actor_store,
+            account_manager: &self.account_manager,
+            blobstore_factory: &self.blobstore_factory,
+            sequencer: &self.sequencer,
+            plc_client: &self.plc_client,
+            plc_rotation_key: &self.plc_rotation_secret,
+            shared_signing_key: &self.shared_signing_key,
+        }
+    }
+
+    async fn sequenced_event_types(&self) -> Vec<String> {
+        let sequencer = self.sequencer.read().await;
+        sequencer
+            .db
+            .run(|conn| {
+                let mut stmt = conn.prepare("SELECT \"eventType\" FROM repo_seq ORDER BY seq")?;
+                let rows = stmt
+                    .query_map([], |row| row.get(0))?
+                    .collect::<Result<Vec<String>, rusqlite::Error>>()?;
+                Ok(rows)
+            })
+            .await
+            .unwrap()
+    }
+
+    async fn key_on_disk(&self, did: &str) -> String {
+        encode_did_key(&self.actor_store.keypair(did).await.unwrap().public_key())
+    }
+
+    async fn recorded_repo_root(&self, did: &str) -> Option<String> {
+        let did = did.to_owned();
+        self.account_manager
+            .db
+            .run(move |conn| {
+                let mut stmt = conn.prepare("SELECT cid FROM repo_root WHERE did = ?1")?;
+                let mut rows = stmt.query([did.as_str()])?;
+                Ok(match rows.next()? {
+                    Some(row) => Some(row.get::<_, String>(0)?),
+                    None => None,
+                })
+            })
+            .await
+            .unwrap()
+    }
+}
+
+/// A PDS with `dids` accounts, every one of them still holding the shared
+/// signing key both on disk and in its published DID document.
+async fn harness(dids: &[&str]) -> Harness {
+    crate::account_manager::tests::init_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = |name: &str| dir.path().join(name).to_string_lossy().to_string();
+
+    let actor_store = ActorStore::new(
+        &ActorStoreConfig {
+            directory: path("actors"),
+            cache_size: 8,
+        },
+        crate::background::BackgroundQueue::default(),
+    );
+    let account_manager = AccountManager::new(
+        crate::account_manager::db::get_migrated_db(dir.path().join("account.sqlite"))
+            .await
+            .unwrap(),
+    );
+    let sequencer = RwLock::new(Sequencer::new(
+        crate::sequencer::db::get_migrated_db(dir.path().join("sequencer.sqlite"))
+            .await
+            .unwrap(),
+        Crawlers::new("pds.test".to_owned(), vec![]),
+        None,
+    ));
+    let blobstore_factory = BlobstoreFactory::new(
+        BlobstoreConfig::Disk {
+            location: path("blobs"),
+            tmp_location: None,
+        },
+        SdkConfig::builder().build(),
+    );
+
+    let plc_rotation_key = keypair(0x11);
+    let shared_signing_key = keypair(0x22);
+    let shared_did_key = encode_did_key(&shared_signing_key.public_key());
+    let mut published = BTreeMap::new();
+    for did in dids {
+        published.insert((*did).to_owned(), shared_did_key.clone());
+        actor_store.create(did, &shared_signing_key).await.unwrap();
+        let actor_txn = actor_store
+            .transact(
+                (*did).to_owned(),
+                blobstore_factory.blobstore((*did).to_owned()),
+            )
+            .await
+            .unwrap();
+        actor_txn.create_repo(Vec::new()).await.unwrap();
+        drop(actor_txn);
+        account_manager
+            .create_account(CreateAccountOpts {
+                did: (*did).to_owned(),
+                handle: format!("{}.test", did.replace(':', "-")),
+                email: Some(format!("{}@example.com", did.replace(':', "-"))),
+                password: Some("password123".to_owned()),
+                repo_cid: Cid::from_str(TEST_CID).unwrap(),
+                repo_rev: "3jzfcijpj2z2a".to_owned(),
+                invite_code: None,
+                deactivated: None,
+            })
+            .await
+            .unwrap();
+    }
+    let plc = MockPlc::start(&encode_did_key(&plc_rotation_key.public_key()), published);
+    let plc_client = plc::Client::new(plc.url.clone());
+
+    Harness {
+        _dir: dir,
+        actor_store,
+        account_manager,
+        blobstore_factory,
+        sequencer,
+        plc,
+        plc_client,
+        plc_rotation_secret: plc_rotation_key.secret_key(),
+        shared_signing_key,
+    }
+}
+
+#[tokio::test]
+async fn lists_every_account_did_in_order() {
+    let h = harness(&["did:plc:bob", "did:plc:alice"]).await;
+    assert_eq!(
+        list_account_dids(&h.account_manager).await.unwrap(),
+        vec!["did:plc:alice".to_owned(), "did:plc:bob".to_owned()]
+    );
+}
+
+#[tokio::test]
+async fn rotates_an_account_onto_its_own_key() {
+    let h = harness(&["did:plc:alice"]).await;
+    let shared = encode_did_key(&h.shared_signing_key.public_key());
+    assert_eq!(h.key_on_disk("did:plc:alice").await, shared);
+
+    let report = rotate_keys(
+        &h.ctx(),
+        RotateKeysOpts {
+            dids: None,
+            dry_run: false,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        report,
+        RotateKeysReport {
+            scanned: 1,
+            rotated: 1,
+            skipped: 0,
+            failed: 0,
+        }
+    );
+
+    // the key file, the published document and the PLC operation all agree,
+    // and none of them is the shared key any more
+    let rotated = h.key_on_disk("did:plc:alice").await;
+    assert_ne!(rotated, shared);
+    assert_eq!(h.plc.published_key("did:plc:alice"), Some(rotated.clone()));
+    let posted = h.plc.posted();
+    assert_eq!(posted.len(), 1);
+    assert_eq!(
+        posted[0]["verificationMethods"]["atproto"].as_str(),
+        Some(rotated.as_str())
+    );
+
+    // the empty commit was sequenced as identity + sync, in that order
+    assert_eq!(
+        h.sequenced_event_types().await,
+        vec!["identity".to_owned(), "sync".to_owned()]
+    );
+
+    // the account db's repo root moved off the placeholder written at signup
+    let root = h.recorded_repo_root("did:plc:alice").await;
+    assert!(root.is_some());
+    assert_ne!(root, Some(TEST_CID.to_owned()));
+}
+
+#[tokio::test]
+async fn a_second_run_is_a_no_op() {
+    let h = harness(&["did:plc:alice"]).await;
+    rotate_keys(
+        &h.ctx(),
+        RotateKeysOpts {
+            dids: None,
+            dry_run: false,
+        },
+    )
+    .await
+    .unwrap();
+    let rotated = h.key_on_disk("did:plc:alice").await;
+
+    let report = rotate_keys(
+        &h.ctx(),
+        RotateKeysOpts {
+            dids: None,
+            dry_run: false,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        report,
+        RotateKeysReport {
+            scanned: 1,
+            rotated: 0,
+            skipped: 1,
+            failed: 0,
+        }
+    );
+    assert_eq!(h.key_on_disk("did:plc:alice").await, rotated);
+    assert_eq!(h.plc.posted().len(), 1);
+}
+
+#[tokio::test]
+async fn a_run_interrupted_after_the_key_write_republishes_that_key() {
+    let h = harness(&["did:plc:alice"]).await;
+    // stand in for a crash between the key write and the PLC operation
+    let written = keypair(0x44);
+    h.actor_store
+        .set_keypair("did:plc:alice", &written)
+        .await
+        .unwrap();
+
+    let outcome = rotate_one(&h.ctx(), "did:plc:alice", false).await.unwrap();
+    assert_eq!(outcome, RotationOutcome::Rotated);
+    // the interrupted run's key is published rather than a third key
+    let expected = encode_did_key(&written.public_key());
+    assert_eq!(h.key_on_disk("did:plc:alice").await, expected);
+    assert_eq!(h.plc.published_key("did:plc:alice"), Some(expected));
+}
+
+#[tokio::test]
+async fn a_dry_run_touches_nothing() {
+    let h = harness(&["did:plc:alice"]).await;
+    let shared = encode_did_key(&h.shared_signing_key.public_key());
+    let report = rotate_keys(
+        &h.ctx(),
+        RotateKeysOpts {
+            dids: None,
+            dry_run: true,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        report,
+        RotateKeysReport {
+            scanned: 1,
+            rotated: 1,
+            skipped: 0,
+            failed: 0,
+        }
+    );
+    assert_eq!(h.key_on_disk("did:plc:alice").await, shared);
+    assert_eq!(h.plc.published_key("did:plc:alice"), Some(shared));
+    assert!(h.plc.posted().is_empty());
+    assert!(h.sequenced_event_types().await.is_empty());
+}
+
+#[tokio::test]
+async fn non_plc_dids_are_skipped() {
+    let h = harness(&["did:web:alice.test"]).await;
+    let report = rotate_keys(
+        &h.ctx(),
+        RotateKeysOpts {
+            dids: None,
+            dry_run: false,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        report,
+        RotateKeysReport {
+            scanned: 1,
+            rotated: 0,
+            skipped: 1,
+            failed: 0,
+        }
+    );
+    assert_eq!(
+        rotate_one(&h.ctx(), "did:web:alice.test", false)
+            .await
+            .unwrap(),
+        RotationOutcome::Skipped(SkipReason::NotPlcDid)
+    );
+}
+
+#[tokio::test]
+async fn an_explicit_did_list_bounds_the_run() {
+    let h = harness(&["did:plc:alice", "did:plc:bob"]).await;
+    let report = rotate_keys(
+        &h.ctx(),
+        RotateKeysOpts {
+            dids: Some(vec!["did:plc:alice".to_owned()]),
+            dry_run: false,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        report,
+        RotateKeysReport {
+            scanned: 1,
+            rotated: 1,
+            skipped: 0,
+            failed: 0,
+        }
+    );
+    let shared = encode_did_key(&h.shared_signing_key.public_key());
+    assert_eq!(h.key_on_disk("did:plc:bob").await, shared);
+}
+
+#[tokio::test]
+async fn a_failing_did_is_counted_and_the_run_continues() {
+    let h = harness(&["did:plc:alice"]).await;
+    let report = rotate_keys(
+        &h.ctx(),
+        RotateKeysOpts {
+            // no key file and no account for this one
+            dids: Some(vec!["did:plc:ghost".to_owned(), "did:plc:alice".to_owned()]),
+            dry_run: false,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        report,
+        RotateKeysReport {
+            scanned: 2,
+            rotated: 1,
+            skipped: 0,
+            failed: 1,
+        }
+    );
+    assert_ne!(
+        h.key_on_disk("did:plc:alice").await,
+        encode_did_key(&h.shared_signing_key.public_key())
+    );
+}

--- a/rsky-pds/src/xrpc_server/auth.rs
+++ b/rsky-pds/src/xrpc_server/auth.rs
@@ -5,6 +5,7 @@ use base64ct::{Base64, Base64UrlUnpadded, Encoding};
 use reqwest::header::{HeaderValue, AUTHORIZATION};
 use rsky_crypto::types::VerifyOptions;
 use rsky_crypto::verify::verify_signature_digest;
+use secp256k1::Keypair;
 use sha2::{Digest, Sha256};
 use std::time::{Duration, SystemTime};
 
@@ -28,8 +29,11 @@ pub struct JwtPayload {
     pub lxm: Option<String>,
 }
 
-pub async fn create_service_auth_headers(params: ServiceJwtParams) -> Result<HeaderMap> {
-    let jwt = create_service_jwt(params).await?;
+pub async fn create_service_auth_headers(
+    params: ServiceJwtParams,
+    keypair: &Keypair,
+) -> Result<HeaderMap> {
+    let jwt = create_service_jwt(params, keypair).await?;
     let jwt_str = format!("Bearer {jwt}");
     let mut headers = HeaderMap::new();
     headers.insert(AUTHORIZATION, HeaderValue::from_str(&jwt_str)?);
@@ -157,30 +161,33 @@ where
 mod tests {
     use super::*;
 
+    fn issuer_keypair() -> Keypair {
+        // fixed secret so the test carries no unseeded randomness
+        let secret = secp256k1::SecretKey::from_slice(&[0x17u8; 32]).unwrap();
+        Keypair::from_secret_key(&secp256k1::Secp256k1::new(), &secret)
+    }
+
     /// A token minted by `create_service_jwt` must verify against the mint
     /// keypair's did:key — the full round trip other PDSes exercise. This is
     /// the test that catches an encode/verify mismatch a claims-only test
     /// cannot.
     #[tokio::test]
     async fn a_minted_token_verifies_end_to_end() {
-        use crate::context::PDS_REPO_SIGNING_KEYPAIR;
         use rsky_crypto::utils::encode_did_key;
-        if std::env::var("PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX").is_err() {
-            std::env::set_var(
-                "PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX",
-                "1717171717171717171717171717171717171717171717171717171717171717",
-            );
-        }
-        let jwt = create_service_jwt(ServiceJwtParams {
-            iss: "did:plc:issuer".to_string(),
-            aud: "did:web:service".to_string(),
-            exp: None,
-            lxm: Some("com.atproto.server.createAccount".to_string()),
-            jti: None,
-        })
+        let keypair = issuer_keypair();
+        let jwt = create_service_jwt(
+            ServiceJwtParams {
+                iss: "did:plc:issuer".to_string(),
+                aud: "did:web:service".to_string(),
+                exp: None,
+                lxm: Some("com.atproto.server.createAccount".to_string()),
+                jti: None,
+            },
+            &keypair,
+        )
         .await
         .unwrap();
-        let did_key = encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key());
+        let did_key = encode_did_key(&keypair.public_key());
         let payload = verify_jwt(
             jwt,
             Some("did:web:service".to_string()),

--- a/rsky-pds/tests/common/mod.rs
+++ b/rsky-pds/tests/common/mod.rs
@@ -8,10 +8,19 @@ use rsky_pds::config::{ServerConfig, ServiceDbConfig};
 use rsky_pds::{build_rocket, RocketConfig};
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::sync::Once;
+use std::sync::{Mutex, Once};
 use tempfile::TempDir;
 
 static INIT_ENV: Once = Once::new();
+
+/// The `atproto` verification method the mock directory serves from
+/// `/{did}/data`. Tests that exercise DID-document validation set it.
+static PUBLISHED_SIGNING_KEY: Mutex<Option<String>> = Mutex::new(None);
+
+#[allow(dead_code)] // only the signing-key test binary drives this
+pub fn set_published_signing_key(signing_key: Option<String>) {
+    *PUBLISHED_SIGNING_KEY.lock().unwrap() = signing_key;
+}
 
 /// Serves DID documents for any did requested, claiming the handle of the
 /// account created by `create_account`. Keeps DID resolution hermetic.
@@ -38,11 +47,33 @@ fn start_mock_plc_directory() -> u16 {
             // Every doc claims a PDS service endpoint pointing back at this
             // mock, which answers 200 to any request. This lets best-effort
             // notification fan-out resolve and deliver hermetically.
-            let body = format!(
-                "{{\"id\":\"{did}\",\"alsoKnownAs\":[\"at://foo{domain}\"],\
-                 \"service\":[{{\"id\":\"#atproto_pds\",\"type\":\"AtprotoPersonalDataServer\",\
-                 \"serviceEndpoint\":\"http://127.0.0.1:{port}\"}}]}}"
-            );
+            // `/{did}/data` is the PLC document-data shape an account's own
+            // DID document is validated against.
+            let body = if let Some(did) = did.strip_suffix("/data") {
+                let hostname =
+                    std::env::var("PDS_HOSTNAME").unwrap_or_else(|_| "localhost".to_string());
+                let rotation_key = rsky_crypto::utils::encode_did_key(
+                    &rsky_pds::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR.public_key(),
+                );
+                let signing_key = PUBLISHED_SIGNING_KEY
+                    .lock()
+                    .unwrap()
+                    .clone()
+                    .unwrap_or_default();
+                format!(
+                    "{{\"did\":\"{did}\",\"rotationKeys\":[\"{rotation_key}\"],\
+                     \"verificationMethods\":{{\"atproto\":\"{signing_key}\"}},\
+                     \"alsoKnownAs\":[\"at://foo{domain}\"],\
+                     \"services\":{{\"atproto_pds\":{{\"type\":\"AtprotoPersonalDataServer\",\
+                     \"endpoint\":\"https://{hostname}\"}}}}}}"
+                )
+            } else {
+                format!(
+                    "{{\"id\":\"{did}\",\"alsoKnownAs\":[\"at://foo{domain}\"],\
+                     \"service\":[{{\"id\":\"#atproto_pds\",\"type\":\"AtprotoPersonalDataServer\",\
+                     \"serviceEndpoint\":\"http://127.0.0.1:{port}\"}}]}}"
+                )
+            };
             let response = format!(
                 "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                 body.len(),

--- a/rsky-pds/tests/signing_key_tests.rs
+++ b/rsky-pds/tests/signing_key_tests.rs
@@ -1,0 +1,173 @@
+use rocket::http::{ContentType, Header, Status};
+use rocket::local::asynchronous::Client;
+use rsky_crypto::utils::encode_did_key;
+use rsky_lexicon::com::atproto::server::CreateInviteCodeOutput;
+use rsky_pds::config::ServerConfig;
+use rsky_pds::context::PDS_REPO_SIGNING_KEYPAIR;
+use rsky_pds::xrpc_server::auth::verify_jwt;
+use serde_json::json;
+
+mod common;
+
+use crate::common::{get_admin_token, set_published_signing_key};
+
+async fn invite_code(client: &Client) -> String {
+    client
+        .post("/xrpc/com.atproto.server.createInviteCode")
+        .header(ContentType::JSON)
+        .header(Header::new("Authorization", get_admin_token()))
+        .body(json!({ "useCount": 1 }).to_string())
+        .dispatch()
+        .await
+        .into_json::<CreateInviteCodeOutput>()
+        .await
+        .unwrap()
+        .code
+}
+
+/// Creates an account with a caller-supplied did and returns its access token.
+async fn account(client: &Client, did: &str, name: &str) -> String {
+    let domain = client
+        .rocket()
+        .state::<ServerConfig>()
+        .unwrap()
+        .identity
+        .service_handle_domains
+        .first()
+        .unwrap()
+        .clone();
+    let invite = invite_code(client).await;
+    let response = client
+        .post("/xrpc/com.atproto.server.createAccount")
+        .header(ContentType::JSON)
+        .header(Header::new("Authorization", get_admin_token()))
+        .body(
+            json!({
+                "did": did,
+                "email": format!("{name}@example.com"),
+                "handle": format!("{name}{domain}"),
+                "password": "password",
+                "inviteCode": invite,
+            })
+            .to_string(),
+        )
+        .dispatch()
+        .await;
+    assert_eq!(response.status(), Status::Ok);
+    let body: serde_json::Value = response.into_json().await.unwrap();
+    body["accessJwt"].as_str().unwrap().to_string()
+}
+
+async fn recommended_signing_key(client: &Client, token: &str) -> String {
+    let response = client
+        .get("/xrpc/com.atproto.identity.getRecommendedDidCredentials")
+        .header(Header::new("Authorization", format!("Bearer {token}")))
+        .dispatch()
+        .await;
+    assert_eq!(response.status(), Status::Ok);
+    let body: serde_json::Value = response.into_json().await.unwrap();
+    body["verificationMethods"]["atproto"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Two accounts must not share a signing key, and neither may be the
+/// process-wide `PDS_REPO_SIGNING_KEYPAIR` every account used to get.
+#[tokio::test]
+async fn each_account_gets_its_own_signing_key() {
+    let (_dir, client) = common::get_client().await;
+    let alice = account(&client, "did:plc:aaaaaaaaaaaaaaaaaaaaaaaa", "alice").await;
+    let bob = account(&client, "did:plc:bbbbbbbbbbbbbbbbbbbbbbbb", "bob").await;
+
+    let alice_key = recommended_signing_key(&client, &alice).await;
+    let bob_key = recommended_signing_key(&client, &bob).await;
+    let shared_key = encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key());
+
+    assert_ne!(alice_key, bob_key);
+    assert_ne!(alice_key, shared_key);
+    assert_ne!(bob_key, shared_key);
+}
+
+/// A `getServiceAuth` token must verify against the issuing account's own
+/// key — the property a remote service checks after resolving `iss`.
+#[tokio::test]
+async fn a_service_auth_token_verifies_against_the_issuing_accounts_key() {
+    let (_dir, client) = common::get_client().await;
+    let did = "did:plc:cccccccccccccccccccccccc";
+    let token = account(&client, did, "carol").await;
+    let signing_key = recommended_signing_key(&client, &token).await;
+
+    let response = client
+        .get(
+            "/xrpc/com.atproto.server.getServiceAuth\
+             ?aud=did:web:appview.invalid&lxm=app.bsky.feed.getTimeline",
+        )
+        .header(Header::new("Authorization", format!("Bearer {token}")))
+        .dispatch()
+        .await;
+    assert_eq!(response.status(), Status::Ok);
+    let body: serde_json::Value = response.into_json().await.unwrap();
+    let service_jwt = body["token"].as_str().unwrap().to_string();
+
+    let payload = verify_jwt(
+        service_jwt.clone(),
+        Some("did:web:appview.invalid".to_string()),
+        Some("app.bsky.feed.getTimeline"),
+        |_iss, _refresh| {
+            let signing_key = signing_key.clone();
+            async move { Ok(signing_key) }
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(payload.iss, did);
+
+    // the old shared key must no longer verify it
+    let shared_key = encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key());
+    let error = verify_jwt(
+        service_jwt,
+        Some("did:web:appview.invalid".to_string()),
+        Some("app.bsky.feed.getTimeline"),
+        move |_iss, _refresh| {
+            let shared_key = shared_key.clone();
+            async move { Ok(shared_key) }
+        },
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(error.starts_with("BadJwtSignature"), "{error}");
+}
+
+/// `checkAccountStatus` reports `validDid` by comparing the published
+/// document against the account's own key, not a server-wide one.
+#[tokio::test]
+async fn the_did_document_is_validated_against_the_accounts_own_key() {
+    let (_dir, client) = common::get_client().await;
+    let did = "did:plc:dddddddddddddddddddddddd";
+    let token = account(&client, did, "dave").await;
+    let signing_key = recommended_signing_key(&client, &token).await;
+
+    let valid_did = |token: String| {
+        let client = &client;
+        async move {
+            let response = client
+                .get("/xrpc/com.atproto.server.checkAccountStatus")
+                .header(Header::new("Authorization", format!("Bearer {token}")))
+                .dispatch()
+                .await;
+            assert_eq!(response.status(), Status::Ok);
+            let body: serde_json::Value = response.into_json().await.unwrap();
+            body["validDid"].as_bool().unwrap()
+        }
+    };
+
+    set_published_signing_key(Some(signing_key));
+    assert!(valid_did(token.clone()).await);
+
+    // the process-wide key is no longer what the document must name
+    set_published_signing_key(Some(encode_did_key(&PDS_REPO_SIGNING_KEYPAIR.public_key())));
+    assert!(!valid_did(token).await);
+    set_published_signing_key(None);
+}


### PR DESCRIPTION
Every actor store was built with the process-wide repo signing key, so one leaked secret could forge commits — and mint service-auth tokens — for any account on the server. There was no per-account blast radius.

`createAccount` now generates a secp256k1 keypair per account and stamps it into that account's PLC operation. `getRecommendedDidCredentials`, `submitPlcOperation` and `activateAccount` validate against the account's own key, and service-auth JWTs are signed with the issuing account's key. Those change together by necessity: once a DID document names an account's own key, a token signed with the global key no longer verifies.

Accounts created before this release keep the shared key until an operator runs the new `rotate-keys` binary, which publishes a PLC operation and emits firehose events per account and so is never run automatically. It is resumable and idempotent — an account whose document already names its own key is skipped, and one whose key was written but whose operation did not land is republished rather than re-keyed. Operator steps and the warnings that go with them are in `rsky-pds/MIGRATING-1.0.md`.

Breaking, hence the major version. `PDS_REPO_SIGNING_KEY_K256_PRIVATE_KEY_HEX` remains required: `rotate-keys` uses it to tell a rotated account from an unrotated one.

Test plan:
- [ ] `cargo test -p rsky-pds` passes
- [ ] `cargo build --release -p rsky-pds` succeeds and produces `rotate-keys`
- [ ] two newly created accounts have different signing keys, and neither matches the configured shared key
- [ ] an inbound account migration completes end to end against a real relay and appview
- [ ] `rotate-keys --dry-run` reports the unrotated accounts and changes nothing
- [ ] `rotate-keys` on a test account: repo still verifies downstream, `getRecommendedDidCredentials` returns that account's key
- [ ] a service-auth token verifies against the issuing account's DID document key
- [ ] re-running `rotate-keys` after a completed run is a no-op