### PR TITLE
feat(pds): Prometheus metrics + structured logging for rsky-pds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8244,6 +8244,8 @@ dependencies = [
  "lru 0.14.0",
  "mailchecker",
  "mailgun-rs",
+ "metrics",
+ "metrics-exporter-prometheus",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5033,16 +5033,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "iroh-car"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5664,11 +5654,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -6117,12 +6107,11 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6504,6 +6493,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.16",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.3.1",
+ "opentelemetry",
+ "reqwest 0.13.4",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http 1.3.1",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.13.4",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.2",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6524,12 +6585,6 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -7247,6 +7302,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7640,17 +7718,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -7661,7 +7730,7 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -7669,12 +7738,6 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -7767,7 +7830,7 @@ dependencies = [
  "tokio-rustls 0.26.2",
  "tokio-util",
  "tower 0.5.2",
- "tower-http 0.6.6",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -7775,6 +7838,35 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.2",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower 0.5.2",
+ "tower-http 0.6.11",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -8301,6 +8393,9 @@ dependencies = [
  "mailgun-rs",
  "metrics",
  "metrics-exporter-prometheus",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "regex",
@@ -8334,6 +8429,7 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
 ]
@@ -10271,20 +10367,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.9.2",
  "bytes",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -10301,9 +10397,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -10325,9 +10421,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10336,9 +10432,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -10366,6 +10462,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10377,14 +10489,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",

--- a/rsky-oauth/src/provider.rs
+++ b/rsky-oauth/src/provider.rs
@@ -129,6 +129,13 @@ impl OAuthProvider {
         &self.store
     }
 
+    /// Whether `client_id` is configured as trusted (first-party) via
+    /// `trusted_clients` -- the same check used to compute
+    /// [`AuthorizePageData::client_trusted`] for the consent-page UI.
+    pub fn is_trusted_client(&self, client_id: &str) -> bool {
+        self.trusted_clients.iter().any(|id| id == client_id)
+    }
+
     /// The value for the `DPoP-Nonce` response header.
     pub fn next_dpop_nonce(&self, now: u64) -> Option<String> {
         self.dpop.next_nonce(now)
@@ -258,7 +265,7 @@ impl OAuthProvider {
             client_name: client.metadata.client_name.clone(),
             client_uri: client.metadata.client_uri.clone(),
             logo_uri: client.metadata.logo_uri.clone(),
-            client_trusted: self.trusted_clients.contains(&client.id),
+            client_trusted: self.is_trusted_client(&client.id),
             scopes: data
                 .parameters
                 .scope

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -41,6 +41,8 @@ lexicon_cid = { workspace = true }
 lru = "0.14"
 mailchecker = "6.0.1"
 mailgun-rs = "0.1.10"
+metrics = "0.24"
+metrics-exporter-prometheus = { version = "0.17", default-features = false }
 rand = { workspace = true }
 rsky-oauth = { path = "../rsky-oauth", version = "0.3.0" }
 rand_core = { workspace = true }
@@ -71,7 +73,7 @@ time = "^0.3.36"
 tokio = { workspace = true }
 toml = "0.8.12"
 tracing = "0.1.41"
-tracing-subscriber = "0.3.19"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 url = "2.5.2"
 ws = { package = "rocket_ws", version = "0.1.1" }
 

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -81,7 +81,7 @@ time = "^0.3.36"
 tokio = { workspace = true }
 toml = "0.8.12"
 tracing = "0.1.41"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 url = "2.5.2"
 ws = { package = "rocket_ws", version = "0.1.1" }
 scrypt = { version = "0.12.0", default-features = false }

--- a/rsky-pds/Cargo.toml
+++ b/rsky-pds/Cargo.toml
@@ -43,6 +43,14 @@ mailchecker = "6.0.1"
 mailgun-rs = "0.1.10"
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.17", default-features = false }
+opentelemetry = "0.32"
+opentelemetry-otlp = { version = "0.32", default-features = false, features = [
+    "trace",
+    "http-proto",
+    "reqwest-client",
+] }
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
+tracing-opentelemetry = "0.33"
 rand = { workspace = true }
 rsky-oauth = { path = "../rsky-oauth", version = "0.3.0" }
 rand_core = { workspace = true }

--- a/rsky-pds/src/account_manager/helpers/account.rs
+++ b/rsky-pds/src/account_manager/helpers/account.rs
@@ -218,15 +218,21 @@ pub async fn register_account(did: String, email: String, password: String, db: 
     }
 }
 
-pub async fn delete_account(did: &str, db: &Db) -> Result<()> {
+/// Deletes the account, including every OAuth session (`token` table row --
+/// unlike `authorized_client`/`account_device`, it carries no `ON DELETE
+/// CASCADE` from `account`, so it needs an explicit delete here). Returns
+/// the number of OAuth sessions revoked, for
+/// [`crate::metrics::record_oauth_sessions_revoked`].
+pub async fn delete_account(did: &str, db: &Db) -> Result<u64> {
     let did = did.to_owned();
     db.tx(move |tx| {
         tx.execute("DELETE FROM repo_root WHERE did = ?1", params![did])?;
         tx.execute("DELETE FROM email_token WHERE did = ?1", params![did])?;
         tx.execute("DELETE FROM refresh_token WHERE did = ?1", params![did])?;
+        let oauth_revoked = tx.execute("DELETE FROM token WHERE did = ?1", params![did])?;
         tx.execute("DELETE FROM account WHERE did = ?1", params![did])?;
         tx.execute("DELETE FROM actor WHERE did = ?1", params![did])?;
-        Ok(())
+        Ok(oauth_revoked as u64)
     })
     .await
 }

--- a/rsky-pds/src/account_manager/helpers/auth.rs
+++ b/rsky-pds/src/account_manager/helpers/auth.rs
@@ -241,6 +241,19 @@ pub async fn revoke_refresh_tokens_by_did(did: &str, db: &Db) -> Result<bool> {
     .await
 }
 
+/// Revokes every OAuth session (`token` table row) for `did`, e.g. as part
+/// of an account takedown or deletion. `used_refresh_token` rows cascade via
+/// the `token(id)` foreign key. Returns the number of sessions revoked, for
+/// [`crate::metrics::record_oauth_sessions_revoked`].
+pub async fn revoke_oauth_tokens_by_did(did: &str, db: &Db) -> Result<u64> {
+    let did = did.to_owned();
+    db.run(move |conn| {
+        let deleted = conn.execute("DELETE FROM token WHERE did = ?1", params![did])?;
+        Ok(deleted as u64)
+    })
+    .await
+}
+
 pub async fn revoke_app_password_refresh_token(
     did: &str,
     app_pass_name: &str,

--- a/rsky-pds/src/account_manager/mod.rs
+++ b/rsky-pds/src/account_manager/mod.rs
@@ -175,16 +175,25 @@ impl AccountManager {
         repo::update_root(did, cid, rev, &self.db).await
     }
 
-    pub async fn delete_account(&self, did: &str) -> Result<()> {
+    /// Deletes the account and revokes its OAuth sessions. Returns the
+    /// number of OAuth sessions (`token` table rows) revoked, for
+    /// [`crate::metrics::record_oauth_sessions_revoked`].
+    pub async fn delete_account(&self, did: &str) -> Result<u64> {
         account::delete_account(did, &self.db).await
     }
 
-    pub async fn takedown_account(&self, did: &str, takedown: StatusAttr) -> Result<()> {
-        (_, _) = try_join!(
+    /// Applies (or reverses) a takedown and revokes every refresh token and
+    /// OAuth session for the account, regardless of direction -- reversing a
+    /// takedown should still force a fresh login rather than silently
+    /// resurrecting old sessions. Returns the number of OAuth sessions
+    /// revoked, for [`crate::metrics::record_oauth_sessions_revoked`].
+    pub async fn takedown_account(&self, did: &str, takedown: StatusAttr) -> Result<u64> {
+        let (_, _, oauth_revoked) = try_join!(
             account::update_account_takedown_status(did, takedown, &self.db),
-            auth::revoke_refresh_tokens_by_did(did, &self.db)
+            auth::revoke_refresh_tokens_by_did(did, &self.db),
+            auth::revoke_oauth_tokens_by_did(did, &self.db)
         )?;
-        Ok(())
+        Ok(oauth_revoked)
     }
 
     // @NOTE should always be paired with a sequenceHandle().

--- a/rsky-pds/src/account_manager/tests.rs
+++ b/rsky-pds/src/account_manager/tests.rs
@@ -960,6 +960,78 @@ async fn email_token_row_mapping_rejects_unknown_purpose() {
     assert!(err.is_err());
 }
 
+/// Inserts a bare-minimum `token` (OAuth session) row for `did`, standing
+/// in for a real `PdsOAuthStore::create_token` call so revocation tests
+/// don't need to spin up a full `SharedOAuthProvider`.
+async fn seed_oauth_token(am: &AccountManager, did: &str, token_id: &str) {
+    let did = did.to_owned();
+    let token_id = token_id.to_owned();
+    am.db
+        .run(move |conn| {
+            conn.execute(
+                "INSERT INTO token (did, \"tokenId\", \"createdAt\", \"updatedAt\", \
+                 \"expiresAt\", \"clientId\", \"clientAuth\", parameters) \
+                 VALUES (?1, ?2, '2023-01-01T00:00:00.000Z', '2023-01-01T00:00:00.000Z', \
+                 '2023-01-01T00:00:00.000Z', 'https://example.com/client', '{}', '{}')",
+                params![did, token_id],
+            )?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+}
+
+async fn oauth_token_count(am: &AccountManager, did: &str) -> i64 {
+    let did = did.to_owned();
+    am.db
+        .run(move |conn| {
+            conn.query_row(
+                "SELECT COUNT(*) FROM token WHERE did = ?1",
+                params![did],
+                |row| row.get(0),
+            )
+            .map_err(Into::into)
+        })
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn takedown_revokes_oauth_sessions() {
+    let (_dir, am) = test_manager().await;
+    create_test_account(&am, "did:plc:dana", "dana.test").await;
+    seed_oauth_token(&am, "did:plc:dana", "token-1").await;
+    seed_oauth_token(&am, "did:plc:dana", "token-2").await;
+    assert_eq!(oauth_token_count(&am, "did:plc:dana").await, 2);
+
+    let revoked = am
+        .takedown_account(
+            "did:plc:dana",
+            StatusAttr {
+                applied: true,
+                r#ref: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(revoked, 2);
+    assert_eq!(oauth_token_count(&am, "did:plc:dana").await, 0);
+}
+
+#[tokio::test]
+async fn delete_account_revokes_oauth_sessions() {
+    let (_dir, am) = test_manager().await;
+    create_test_account(&am, "did:plc:erin", "erin.test").await;
+    seed_oauth_token(&am, "did:plc:erin", "token-1").await;
+    assert_eq!(oauth_token_count(&am, "did:plc:erin").await, 1);
+
+    let revoked = am.delete_account("did:plc:erin").await.unwrap();
+
+    assert_eq!(revoked, 1);
+    assert_eq!(oauth_token_count(&am, "did:plc:erin").await, 0);
+}
+
 #[tokio::test]
 async fn invite_helper_direct_queries() {
     let (_dir, am) = test_manager().await;

--- a/rsky-pds/src/apis/com/atproto/admin/delete_account.rs
+++ b/rsky-pds/src/apis/com/atproto/admin/delete_account.rs
@@ -4,6 +4,7 @@ use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
 use crate::auth_verifier::AdminToken;
+use crate::metrics::record_oauth_sessions_revoked;
 use crate::SharedSequencer;
 use anyhow::Result;
 use rocket::serde::json::Json;
@@ -22,7 +23,8 @@ async fn inner_delete_account(
     actor_store
         .destroy(&did, blobstore_factory.blobstore(did.clone()))
         .await?;
-    account_manager.delete_account(&did).await?;
+    let oauth_revoked = account_manager.delete_account(&did).await?;
+    record_oauth_sessions_revoked(oauth_revoked);
     let mut lock = sequencer.sequencer.write().await;
     let account_seq = lock
         .sequence_account_evt(did.clone(), AccountStatus::Deleted)

--- a/rsky-pds/src/apis/com/atproto/admin/update_subject_status.rs
+++ b/rsky-pds/src/apis/com/atproto/admin/update_subject_status.rs
@@ -3,6 +3,7 @@ use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
 use crate::auth_verifier::Moderator;
+use crate::metrics::record_oauth_sessions_revoked;
 use crate::SharedSequencer;
 use anyhow::Result;
 use lexicon_cid::Cid;
@@ -28,9 +29,10 @@ async fn inner_update_subject_status(
     if let Some(takedown) = &takedown {
         match &subject {
             Subject::RepoRef(subject) => {
-                account_manager
+                let oauth_revoked = account_manager
                     .takedown_account(&subject.did, takedown.clone())
                     .await?;
+                record_oauth_sessions_revoked(oauth_revoked);
             }
             Subject::StrongRef(subject) => {
                 let subject_at_uri: AtUri = subject.uri.clone().try_into()?;

--- a/rsky-pds/src/apis/com/atproto/repo/apply_writes.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/apply_writes.rs
@@ -123,6 +123,13 @@ async fn inner_apply_writes(
                 commit.commit_data.rev,
             )
             .await?;
+        for write in &writes {
+            crate::metrics::record_repo_write(match write {
+                PreparedWrite::Create(_) => "create",
+                PreparedWrite::Update(_) => "update",
+                PreparedWrite::Delete(_) => "delete",
+            });
+        }
         // The lexicon declares a JSON object output; returning an empty body
         // instead makes a client that requires JSON treat a successful write as
         // failed and retry it, duplicating records.

--- a/rsky-pds/src/apis/com/atproto/repo/apply_writes.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/apply_writes.rs
@@ -4,6 +4,7 @@ use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandardIncludeChecks;
+use crate::metrics::record_repo_write;
 use crate::repo::prepare::{
     prepare_create, prepare_delete, prepare_update, PrepareCreateOpts, PrepareDeleteOpts,
     PrepareUpdateOpts,
@@ -124,7 +125,7 @@ async fn inner_apply_writes(
             )
             .await?;
         for write in &writes {
-            crate::metrics::record_repo_write(match write {
+            record_repo_write(match write {
                 PreparedWrite::Create(_) => "create",
                 PreparedWrite::Update(_) => "update",
                 PreparedWrite::Delete(_) => "delete",

--- a/rsky-pds/src/apis/com/atproto/repo/create_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/create_record.rs
@@ -100,6 +100,7 @@ async fn inner_create_record(
         account_manager
             .update_repo_root(did, commit.commit_data.cid, commit.commit_data.rev)
             .await?;
+        crate::metrics::record_repo_write("create");
 
         Ok(CreateRecordOutput {
             uri: write.uri.clone(),

--- a/rsky-pds/src/apis/com/atproto/repo/create_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/create_record.rs
@@ -4,6 +4,7 @@ use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandardIncludeChecks;
+use crate::metrics::record_repo_write;
 use crate::repo::prepare::{prepare_create, prepare_delete, PrepareCreateOpts, PrepareDeleteOpts};
 use crate::SharedSequencer;
 use anyhow::{bail, Result};
@@ -100,7 +101,7 @@ async fn inner_create_record(
         account_manager
             .update_repo_root(did, commit.commit_data.cid, commit.commit_data.rev)
             .await?;
-        crate::metrics::record_repo_write("create");
+        record_repo_write("create");
 
         Ok(CreateRecordOutput {
             uri: write.uri.clone(),

--- a/rsky-pds/src/apis/com/atproto/repo/delete_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/delete_record.rs
@@ -85,6 +85,7 @@ async fn inner_delete_record(
             account_manager
                 .update_repo_root(did, commit.commit_data.cid, commit.commit_data.rev)
                 .await?;
+            crate::metrics::record_repo_write("delete");
 
             Ok(())
         }

--- a/rsky-pds/src/apis/com/atproto/repo/delete_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/delete_record.rs
@@ -4,6 +4,7 @@ use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandardIncludeChecks;
+use crate::metrics::record_repo_write;
 use crate::repo::prepare::{prepare_delete, PrepareDeleteOpts};
 use crate::SharedSequencer;
 use anyhow::{bail, Result};
@@ -85,7 +86,7 @@ async fn inner_delete_record(
             account_manager
                 .update_repo_root(did, commit.commit_data.cid, commit.commit_data.rev)
                 .await?;
-            crate::metrics::record_repo_write("delete");
+            record_repo_write("delete");
 
             Ok(())
         }

--- a/rsky-pds/src/apis/com/atproto/repo/put_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/put_record.rs
@@ -112,6 +112,11 @@ async fn inner_put_record(
             account_manager
                 .update_repo_root(did, commit.commit_data.cid, commit.commit_data.rev)
                 .await?;
+            crate::metrics::record_repo_write(match &write {
+                PreparedWrite::Create(_) => "create",
+                PreparedWrite::Update(_) => "update",
+                PreparedWrite::Delete(_) => "delete",
+            });
         }
         Ok(PutRecordOutput {
             uri: write.uri().to_string(),

--- a/rsky-pds/src/apis/com/atproto/repo/put_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/put_record.rs
@@ -4,6 +4,7 @@ use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandardIncludeChecks;
+use crate::metrics::record_repo_write;
 use crate::repo::prepare::{prepare_create, prepare_update, PrepareCreateOpts, PrepareUpdateOpts};
 use crate::SharedSequencer;
 use anyhow::{bail, Result};
@@ -112,7 +113,7 @@ async fn inner_put_record(
             account_manager
                 .update_repo_root(did, commit.commit_data.cid, commit.commit_data.rev)
                 .await?;
-            crate::metrics::record_repo_write(match &write {
+            record_repo_write(match &write {
                 PreparedWrite::Create(_) => "create",
                 PreparedWrite::Update(_) => "update",
                 PreparedWrite::Delete(_) => "delete",

--- a/rsky-pds/src/apis/com/atproto/repo/upload_blob.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/upload_blob.rs
@@ -78,6 +78,8 @@ async fn inner_upload_blob(
             .await?;
     }
 
+    crate::metrics::record_blob_upload(blobref.get_size().unwrap_or(0).max(0) as u64);
+
     Ok(BlobOutput {
         blob: Blob {
             r#type: Some("blob".to_string()),

--- a/rsky-pds/src/apis/com/atproto/repo/upload_blob.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/upload_blob.rs
@@ -2,6 +2,7 @@ use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessStandardCheckTakedown;
+use crate::metrics::record_blob_upload;
 use anyhow::Result;
 use rocket::data::{Data, ToByteUnit};
 use rocket::http::Status;
@@ -78,7 +79,7 @@ async fn inner_upload_blob(
             .await?;
     }
 
-    crate::metrics::record_blob_upload(blobref.get_size().unwrap_or(0).max(0) as u64);
+    record_blob_upload(blobref.get_size().unwrap_or(0).max(0) as u64);
 
     Ok(BlobOutput {
         blob: Blob {

--- a/rsky-pds/src/apis/com/atproto/server/create_account.rs
+++ b/rsky-pds/src/apis/com/atproto/server/create_account.rs
@@ -8,6 +8,7 @@ use crate::auth_verifier::UserDidAuthOptional;
 use crate::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::config::ServerConfig;
 use crate::handle::{normalize_and_validate_handle, HandleValidationContext, HandleValidationOpts};
+use crate::metrics::record_account_created;
 use crate::plc::operations::{create_op, CreateAtprotoOpInput};
 use crate::plc::types::{OpOrTombstone, Operation};
 use crate::sequencer::events::sync_evt_data_from_commit;
@@ -137,6 +138,7 @@ pub async fn server_create_account(
     };
 
     // Create Account
+    let invited = invite_code.is_some();
     let (access_jwt, refresh_jwt);
     match account_manager
         .create_account(CreateAccountOpts {
@@ -153,6 +155,11 @@ pub async fn server_create_account(
     {
         Ok(res) => {
             (access_jwt, refresh_jwt) = res;
+            record_account_created(
+                if is_admin { "admin" } else { "self_service" },
+                invited,
+                deactivated,
+            );
         }
         Err(error) => {
             tracing::error!("Error creating account\n{error}");

--- a/rsky-pds/src/apis/com/atproto/server/create_session.rs
+++ b/rsky-pds/src/apis/com/atproto/server/create_session.rs
@@ -111,7 +111,13 @@ pub async fn create_session(
 ) -> Result<Json<CreateSessionOutput>, ApiError> {
     // @TODO: Add rate limiting
     match inner_create_session(body, account_manager).await {
-        Ok(res) => Ok(Json(res)),
-        Err(error) => Err(error),
+        Ok(res) => {
+            crate::metrics::record_login(true);
+            Ok(Json(res))
+        }
+        Err(error) => {
+            crate::metrics::record_login(false);
+            Err(error)
+        }
     }
 }

--- a/rsky-pds/src/apis/com/atproto/server/create_session.rs
+++ b/rsky-pds/src/apis/com/atproto/server/create_session.rs
@@ -113,7 +113,7 @@ pub async fn create_session(
     // @TODO: Add rate limiting
     match inner_create_session(body, account_manager).await {
         Ok(res) => {
-            record_login_success();
+            record_login_success("password");
             Ok(Json(res))
         }
         Err(error) => {
@@ -122,7 +122,7 @@ pub async fn create_session(
                 ApiError::AccountTakendown => "account_takedown",
                 _ => "internal_error",
             };
-            record_login_failure(reason);
+            record_login_failure("password", reason);
             Err(error)
         }
     }

--- a/rsky-pds/src/apis/com/atproto/server/create_session.rs
+++ b/rsky-pds/src/apis/com/atproto/server/create_session.rs
@@ -1,6 +1,7 @@
 use crate::account_manager::helpers::account::AvailabilityFlags;
 use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
+use crate::metrics::{record_login_failure, record_login_success};
 use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::server::{CreateSessionInput, CreateSessionOutput};
 use rsky_syntax::handle::INVALID_HANDLE;
@@ -112,11 +113,16 @@ pub async fn create_session(
     // @TODO: Add rate limiting
     match inner_create_session(body, account_manager).await {
         Ok(res) => {
-            crate::metrics::record_login(true);
+            record_login_success();
             Ok(Json(res))
         }
         Err(error) => {
-            crate::metrics::record_login(false);
+            let reason = match &error {
+                ApiError::InvalidLogin => "invalid_credentials",
+                ApiError::AccountTakendown => "account_takedown",
+                _ => "internal_error",
+            };
+            record_login_failure(reason);
             Err(error)
         }
     }

--- a/rsky-pds/src/apis/com/atproto/server/delete_account.rs
+++ b/rsky-pds/src/apis/com/atproto/server/delete_account.rs
@@ -4,6 +4,7 @@ use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
 use crate::auth_verifier::AdminToken;
+use crate::metrics::record_oauth_sessions_revoked;
 use crate::models::models::EmailTokenPurpose;
 use crate::SharedSequencer;
 use rocket::serde::json::Json;
@@ -46,7 +47,8 @@ async fn inner_delete_account(
         actor_store
             .destroy(&did, blobstore_factory.blobstore(did.clone()))
             .await?;
-        account_manager.delete_account(&did).await?;
+        let oauth_revoked = account_manager.delete_account(&did).await?;
+        record_oauth_sessions_revoked(oauth_revoked);
         let mut lock = sequencer.sequencer.write().await;
         let account_seq = lock
             .sequence_account_evt(did.clone(), AccountStatus::Deleted)

--- a/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
+++ b/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
@@ -71,7 +71,10 @@ pub async fn get_service_auth(
     actor_store: &State<ActorStore>,
 ) -> Result<Json<GetServiceAuthOutput>, ApiError> {
     match inner_get_service_auth(aud, exp, lxm, auth, actor_store).await {
-        Ok(token) => Ok(Json(GetServiceAuthOutput { token })),
+        Ok(token) => {
+            crate::metrics::record_service_token_issued();
+            Ok(Json(GetServiceAuthOutput { token }))
+        }
         Err(error) => {
             tracing::error!("Internal Error: {error}");
             Err(ApiError::RuntimeError)

--- a/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
+++ b/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
@@ -2,6 +2,7 @@ use crate::account_manager::helpers::auth::{create_service_jwt, ServiceJwtParams
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
 use crate::auth_verifier::AccessFull;
+use crate::metrics::{record_service_token_denied, record_service_token_issued};
 use crate::pipethrough::{PRIVILEGED_METHODS, PROTECTED_METHODS};
 use anyhow::{bail, Result};
 use chrono::offset::Utc as UtcOffset;
@@ -56,6 +57,28 @@ pub async fn inner_get_service_auth(
     .await
 }
 
+/// Classifies a denial from [`inner_get_service_auth`] into a small,
+/// low-cardinality reason label for [`record_service_token_denied`].
+///
+/// Matches on the `bail!` message text rather than a typed error, since
+/// `inner_get_service_auth` returns a plain `anyhow::Result`; the messages
+/// matched here are exactly the ones raised above, so this stays in sync by
+/// construction as long as both live in this file. Falls back to
+/// `"internal_error"` for anything unrecognized (e.g. a `keypair`/JWT
+/// signing failure) rather than growing an ever-expanding label set.
+fn deny_reason(err: &anyhow::Error) -> &'static str {
+    let msg = err.to_string();
+    if msg.starts_with("BadExpiration") {
+        "bad_expiration"
+    } else if msg.contains("protected method") {
+        "protected_method"
+    } else if msg.contains("insufficient access") {
+        "insufficient_privilege"
+    } else {
+        "internal_error"
+    }
+}
+
 /// Get a signed token on behalf of the requesting DID for the requested service.
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/com.atproto.server.getServiceAuth?<aud>&<exp>&<lxm>")]
@@ -72,12 +95,42 @@ pub async fn get_service_auth(
 ) -> Result<Json<GetServiceAuthOutput>, ApiError> {
     match inner_get_service_auth(aud, exp, lxm, auth, actor_store).await {
         Ok(token) => {
-            crate::metrics::record_service_token_issued();
+            record_service_token_issued();
             Ok(Json(GetServiceAuthOutput { token }))
         }
         Err(error) => {
+            record_service_token_denied(deny_reason(&error));
             tracing::error!("Internal Error: {error}");
             Err(ApiError::RuntimeError)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::deny_reason;
+
+    #[test]
+    fn deny_reason_classifies_known_bail_messages() {
+        assert_eq!(
+            deny_reason(&anyhow::anyhow!("BadExpiration: expiration is in past")),
+            "bad_expiration"
+        );
+        assert_eq!(
+            deny_reason(&anyhow::anyhow!(
+                "cannot request a service auth token for the following protected method: com.atproto.server.createAccount"
+            )),
+            "protected_method"
+        );
+        assert_eq!(
+            deny_reason(&anyhow::anyhow!(
+                "insufficient access to request a service auth token for the following method: chat.bsky.convo.getMessages"
+            )),
+            "insufficient_privilege"
+        );
+        assert_eq!(
+            deny_reason(&anyhow::anyhow!("some unrelated keypair failure")),
+            "internal_error"
+        );
     }
 }

--- a/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
+++ b/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
@@ -31,7 +31,9 @@ use std::time::SystemTime;
 /// any method, privileged or not.
 fn ensure_lxm_access(lxm: &str, is_privileged: bool) -> Result<()> {
     if PRIVILEGED_METHODS.contains(lxm) && !is_privileged {
-        bail!("insufficient access to request a service auth token for the following method: {lxm}");
+        bail!(
+            "insufficient access to request a service auth token for the following method: {lxm}"
+        );
     }
     Ok(())
 }
@@ -41,9 +43,8 @@ fn ensure_lxm_access(lxm: &str, is_privileged: bool) -> Result<()> {
 /// matching the upstream check `isAtprotoDid(aud) || isAtprotoDidRefAbsolute(aud)`.
 fn ensure_valid_aud(aud: &str) -> Result<()> {
     let did_part = aud.split('#').next().unwrap_or(aud);
-    ensure_valid_did(did_part).map_err(|_| {
-        anyhow::anyhow!("aud must be a valid atproto DID or did#serviceId reference")
-    })
+    ensure_valid_did(did_part)
+        .map_err(|_| anyhow::anyhow!("aud must be a valid atproto DID or did#serviceId reference"))
 }
 
 pub async fn inner_get_service_auth(

--- a/rsky-pds/src/apis/com/atproto/sync/subscribe_repos.rs
+++ b/rsky-pds/src/apis/com/atproto/sync/subscribe_repos.rs
@@ -23,6 +23,25 @@ use std::time::SystemTime;
 use tokio::time::{interval, Duration as TokioDuration};
 use ws::Message;
 
+/// Tracks the `pds_firehose_subscribers` gauge for the lifetime of a single
+/// subscribeRepos connection: incremented on connect, decremented on drop
+/// (covers every exit path -- normal completion, an early `return`, a
+/// `break`, or the client simply disconnecting) so the count can never leak.
+struct FirehoseSubscriberGuard;
+
+impl FirehoseSubscriberGuard {
+    fn new() -> Self {
+        crate::metrics::record_firehose_subscriber_connected();
+        FirehoseSubscriberGuard
+    }
+}
+
+impl Drop for FirehoseSubscriberGuard {
+    fn drop(&mut self) {
+        crate::metrics::record_firehose_subscriber_disconnected();
+    }
+}
+
 fn get_backfill_limit(ms: u64) -> String {
     let system_time = SystemTime::now();
     let mut dt: DateTime<UtcOffset> = system_time.into();
@@ -45,6 +64,7 @@ pub async fn subscribe_repos<'a>(
     ws: ws::WebSocket,
 ) -> ws::Stream!['a] {
     ws::Stream! { ws =>
+        let _firehose_subscriber_guard = FirehoseSubscriberGuard::new();
         let sequencer_lock = sequencer.sequencer.read().await.clone();
         let mut outbox = Outbox::new(
             sequencer_lock.clone(),

--- a/rsky-pds/src/apis/com/atproto/sync/subscribe_repos.rs
+++ b/rsky-pds/src/apis/com/atproto/sync/subscribe_repos.rs
@@ -1,4 +1,7 @@
 use crate::config::ServerConfig;
+use crate::metrics::{
+    record_firehose_subscriber_connected, record_firehose_subscriber_disconnected,
+};
 use crate::sequencer::events::{
     AccountEvt, CommitEvt, IdentityEvt, SeqEvt, SyncEvt, TypedAccountEvt, TypedCommitEvt,
     TypedIdentityEvt, TypedSyncEvt,
@@ -31,14 +34,14 @@ struct FirehoseSubscriberGuard;
 
 impl FirehoseSubscriberGuard {
     fn new() -> Self {
-        crate::metrics::record_firehose_subscriber_connected();
+        record_firehose_subscriber_connected();
         FirehoseSubscriberGuard
     }
 }
 
 impl Drop for FirehoseSubscriberGuard {
     fn drop(&mut self) {
-        crate::metrics::record_firehose_subscriber_disconnected();
+        record_firehose_subscriber_disconnected();
     }
 }
 

--- a/rsky-pds/src/lib.rs
+++ b/rsky-pds/src/lib.rs
@@ -22,6 +22,7 @@ pub mod handle;
 pub mod image;
 pub mod lexicon;
 pub mod mailer;
+pub mod metrics;
 pub mod models;
 pub mod oauth;
 pub mod oauth_scope;
@@ -311,6 +312,8 @@ pub async fn build_rocket(rocket_cfg: Option<RocketConfig>) -> Rocket<Build> {
 
     let shield = Shield::default().enable(NoSniff::Enable);
 
+    let metrics_handle = crate::metrics::install_recorder();
+
     rocket::custom(figment)
         .mount(
             "/",
@@ -319,6 +322,7 @@ pub async fn build_rocket(rocket_cfg: Option<RocketConfig>) -> Rocket<Build> {
                 robots,
                 health,
                 health_live,
+                crate::metrics::metrics_route,
                 com::atproto::admin::delete_account::delete_account,
                 com::atproto::admin::disable_account_invites::disable_account_invites,
                 com::atproto::admin::disable_invite_codes::disable_invite_codes,
@@ -449,6 +453,8 @@ pub async fn build_rocket(rocket_cfg: Option<RocketConfig>) -> Rocket<Build> {
         .attach(CORS)
         .attach(oauth::OAuthHeaders)
         .attach(shield)
+        .attach(crate::metrics::XrpcMetrics)
+        .manage(metrics_handle)
         .manage(sequencer)
         .manage(blobstore_factory)
         .manage(id_resolver)

--- a/rsky-pds/src/lib.rs
+++ b/rsky-pds/src/lib.rs
@@ -44,6 +44,7 @@ use crate::background::BackgroundQueue;
 use crate::config::{env_to_cfg, ServiceDbConfig};
 use crate::crawlers::Crawlers;
 use crate::did_cache::DidSqliteCache;
+use crate::metrics::{install_recorder, metrics_route, XrpcMetrics};
 use crate::models::{ErrorCode, ErrorMessageResponse, ServerVersion};
 use rocket::{catch, catchers, get, options, routes, Build, Rocket};
 use std::sync::Arc;
@@ -312,7 +313,7 @@ pub async fn build_rocket(rocket_cfg: Option<RocketConfig>) -> Rocket<Build> {
 
     let shield = Shield::default().enable(NoSniff::Enable);
 
-    let metrics_handle = crate::metrics::install_recorder();
+    let metrics_handle = install_recorder();
 
     rocket::custom(figment)
         .mount(
@@ -322,7 +323,7 @@ pub async fn build_rocket(rocket_cfg: Option<RocketConfig>) -> Rocket<Build> {
                 robots,
                 health,
                 health_live,
-                crate::metrics::metrics_route,
+                metrics_route,
                 com::atproto::admin::delete_account::delete_account,
                 com::atproto::admin::disable_account_invites::disable_account_invites,
                 com::atproto::admin::disable_invite_codes::disable_invite_codes,
@@ -453,7 +454,7 @@ pub async fn build_rocket(rocket_cfg: Option<RocketConfig>) -> Rocket<Build> {
         .attach(CORS)
         .attach(oauth::OAuthHeaders)
         .attach(shield)
-        .attach(crate::metrics::XrpcMetrics)
+        .attach(XrpcMetrics)
         .manage(metrics_handle)
         .manage(sequencer)
         .manage(blobstore_factory)

--- a/rsky-pds/src/lib.rs
+++ b/rsky-pds/src/lib.rs
@@ -35,6 +35,7 @@ pub mod rotate_keys;
 pub mod sequencer;
 pub mod space_auth;
 pub mod space_scope;
+pub mod telemetry;
 pub mod well_known;
 pub mod xrpc_server;
 use crate::account_manager::AccountManager;

--- a/rsky-pds/src/main.rs
+++ b/rsky-pds/src/main.rs
@@ -1,4 +1,8 @@
 use rsky_pds::build_rocket;
+use tracing_subscriber::fmt::Layer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::EnvFilter;
 
 #[rocket::main]
 async fn main() {
@@ -6,7 +10,10 @@ async fn main() {
     let _ = &*rsky_pds::auth_verifier::PDS_JWT_KEYPAIR;
     let _ = &*rsky_pds::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 
-    let subscriber = tracing_subscriber::FmtSubscriber::new();
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+    tracing_subscriber::registry()
+        .with(EnvFilter::from_default_env())
+        .with(Layer::new())
+        .init();
+
     let _ = build_rocket(None).await.launch().await;
 }

--- a/rsky-pds/src/main.rs
+++ b/rsky-pds/src/main.rs
@@ -10,10 +10,17 @@ async fn main() {
     let _ = &*rsky_pds::auth_verifier::PDS_JWT_KEYPAIR;
     let _ = &*rsky_pds::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 
+    // Only set up an OTLP exporter (and pay its cost) when a collector
+    // endpoint is actually configured; see rsky_pds::telemetry.
+    let otel_layer = rsky_pds::telemetry::layer();
+
     tracing_subscriber::registry()
         .with(EnvFilter::from_default_env())
         .with(Layer::new())
+        .with(otel_layer)
         .init();
 
     let _ = build_rocket(None).await.launch().await;
+
+    rsky_pds::telemetry::shutdown();
 }

--- a/rsky-pds/src/main.rs
+++ b/rsky-pds/src/main.rs
@@ -1,5 +1,4 @@
 use rsky_pds::build_rocket;
-use tracing_subscriber::fmt::Layer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
@@ -16,7 +15,7 @@ async fn main() {
 
     tracing_subscriber::registry()
         .with(EnvFilter::from_default_env())
-        .with(Layer::new())
+        .with(rsky_pds::telemetry::fmt_layer())
         .with(otel_layer)
         .init();
 

--- a/rsky-pds/src/metrics.rs
+++ b/rsky-pds/src/metrics.rs
@@ -1,0 +1,294 @@
+//! Prometheus metrics for rsky-pds.
+//!
+//! Modeled directly on `rsky-relay`'s `metrics.rs`: the `metrics` facade
+//! (idempotent `describe_*!` registration + free-standing `record_*`
+//! helpers) plus a `metrics-exporter-prometheus` recorder. Unlike the relay
+//! -- which binds its own bare TCP listener -- rsky-pds is Rocket-based, so
+//! the recorder is exposed through a normal Rocket route (see
+//! [`metrics_route`]) instead of a second socket.
+//!
+//! Metric names intentionally echo the attribute names the TypeScript
+//! reference PDS attaches to its XRPC spans/metrics (the lexicon NSID as
+//! `method`, the HTTP status as `status`), translated into Prometheus'
+//! label conventions so the two implementations stay comparable side by
+//! side.
+
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use metrics::{
+    counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram, Unit,
+};
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use rocket::fairing::{Fairing, Info, Kind};
+use rocket::http::ContentType;
+use rocket::{Data, Request, Response};
+
+/// Count of XRPC requests, labelled by lexicon method (NSID) and HTTP status code.
+pub const XRPC_REQUESTS: &str = "pds_xrpc_requests_total";
+/// XRPC request latency in seconds, labelled by lexicon method and HTTP status code.
+pub const XRPC_REQUEST_DURATION_SECONDS: &str = "pds_xrpc_request_duration_seconds";
+/// Login attempts via `com.atproto.server.createSession`, labelled by outcome.
+pub const AUTH_LOGIN: &str = "pds_auth_login_total";
+/// Service-auth tokens minted via `com.atproto.server.getServiceAuth`.
+pub const AUTH_SERVICE_TOKENS_ISSUED: &str = "pds_auth_service_tokens_issued_total";
+/// Repo writes (record creates/updates/deletes) committed to an actor store.
+pub const REPO_WRITES: &str = "pds_repo_writes_total";
+/// Successful blob uploads via `com.atproto.repo.uploadBlob`.
+pub const BLOB_UPLOADS: &str = "pds_blob_uploads_total";
+/// Bytes accepted across all blob uploads.
+pub const BLOB_UPLOAD_BYTES: &str = "pds_blob_upload_bytes_total";
+/// Currently-connected `com.atproto.sync.subscribeRepos` (firehose) subscribers.
+pub const FIREHOSE_SUBSCRIBERS: &str = "pds_firehose_subscribers";
+
+/// Register all rsky-pds metrics with descriptions. Idempotent: `describe_*!`
+/// macros just re-set the same description on repeated calls, so this is
+/// safe to call from multiple `build_rocket()` invocations (e.g. in tests).
+pub fn describe() {
+    describe_counter!(
+        XRPC_REQUESTS,
+        Unit::Count,
+        "XRPC requests handled, by lexicon method and HTTP status"
+    );
+    describe_histogram!(
+        XRPC_REQUEST_DURATION_SECONDS,
+        Unit::Seconds,
+        "XRPC request latency, by lexicon method and HTTP status"
+    );
+    describe_counter!(
+        AUTH_LOGIN,
+        Unit::Count,
+        "createSession login attempts, by outcome (success/failure)"
+    );
+    describe_counter!(
+        AUTH_SERVICE_TOKENS_ISSUED,
+        Unit::Count,
+        "getServiceAuth service-auth tokens issued"
+    );
+    describe_counter!(
+        REPO_WRITES,
+        Unit::Count,
+        "Repo record writes committed, by operation (create/update/delete)"
+    );
+    describe_counter!(BLOB_UPLOADS, Unit::Count, "Successful blob uploads");
+    describe_counter!(
+        BLOB_UPLOAD_BYTES,
+        Unit::Bytes,
+        "Bytes accepted across all blob uploads"
+    );
+    describe_gauge!(
+        FIREHOSE_SUBSCRIBERS,
+        Unit::Count,
+        "Currently-connected subscribeRepos (firehose) subscribers"
+    );
+}
+
+static PROMETHEUS_HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
+
+/// Install the process-wide Prometheus recorder and return a handle to it.
+///
+/// Idempotent and safe to call from multiple `build_rocket()` invocations:
+/// the actual recorder is only ever built once per process (guarded by a
+/// `OnceLock`), so every caller -- including concurrent tests that each spin
+/// up their own Rocket instance -- gets a handle to the *same* underlying
+/// recorder rather than a disconnected one.
+pub fn install_recorder() -> PrometheusHandle {
+    PROMETHEUS_HANDLE
+        .get_or_init(|| {
+            let recorder = PrometheusBuilder::new().build_recorder();
+            let handle = recorder.handle();
+            // Tolerate "global recorder already set" (e.g. another crate in
+            // the same process installed one first). This closure only ever
+            // runs once per process (guarded by the OnceLock), so we always
+            // win the race for our own handle/recorder pair.
+            let _ = metrics::set_global_recorder(recorder);
+            describe();
+            handle
+        })
+        .clone()
+}
+
+struct RequestStart(Instant);
+
+/// Rocket fairing that records XRPC request count + latency, labelled by
+/// lexicon method (the NSID segment of the `/xrpc/<nsid>` path) and HTTP
+/// status code.
+pub struct XrpcMetrics;
+
+#[rocket::async_trait]
+impl Fairing for XrpcMetrics {
+    fn info(&self) -> Info {
+        Info {
+            name: "XRPC request metrics",
+            kind: Kind::Request | Kind::Response,
+        }
+    }
+
+    async fn on_request(&self, request: &mut Request<'_>, _data: &mut Data<'_>) {
+        request.local_cache(|| RequestStart(Instant::now()));
+    }
+
+    async fn on_response<'r>(&self, request: &'r Request<'_>, response: &mut Response<'r>) {
+        let path = request.uri().path();
+        let Some(method) = path.as_str().strip_prefix("/xrpc/") else {
+            return;
+        };
+        let method = method.to_string();
+        let status = response.status().code.to_string();
+        let start = request.local_cache(|| RequestStart(Instant::now()));
+        let elapsed = start.0.elapsed().as_secs_f64();
+        counter!(XRPC_REQUESTS, "method" => method.clone(), "status" => status.clone())
+            .increment(1);
+        histogram!(XRPC_REQUEST_DURATION_SECONDS, "method" => method, "status" => status)
+            .record(elapsed);
+    }
+}
+
+/// `/metrics` route handler: renders the process' Prometheus recorder as
+/// plain-text exposition format.
+#[rocket::get("/metrics")]
+pub async fn metrics_route(handle: &rocket::State<PrometheusHandle>) -> (ContentType, String) {
+    (
+        ContentType::new("text", "plain").with_params(("version", "0.0.4")),
+        handle.render(),
+    )
+}
+
+#[inline]
+pub fn record_login(success: bool) {
+    let outcome = if success { "success" } else { "failure" };
+    counter!(AUTH_LOGIN, "outcome" => outcome).increment(1);
+}
+
+#[inline]
+pub fn record_service_token_issued() {
+    counter!(AUTH_SERVICE_TOKENS_ISSUED).increment(1);
+}
+
+#[inline]
+pub fn record_repo_write(op: &'static str) {
+    counter!(REPO_WRITES, "op" => op).increment(1);
+}
+
+#[inline]
+pub fn record_blob_upload(bytes: u64) {
+    counter!(BLOB_UPLOADS).increment(1);
+    counter!(BLOB_UPLOAD_BYTES).increment(bytes);
+}
+
+#[inline]
+pub fn record_firehose_subscriber_connected() {
+    gauge!(FIREHOSE_SUBSCRIBERS).increment(1.0);
+}
+
+#[inline]
+pub fn record_firehose_subscriber_disconnected() {
+    gauge!(FIREHOSE_SUBSCRIBERS).decrement(1.0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use metrics::with_local_recorder;
+    use metrics_exporter_prometheus::PrometheusBuilder;
+
+    #[test]
+    fn describe_is_idempotent_under_local_recorder() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        with_local_recorder(&recorder, || {
+            describe();
+            describe();
+        });
+        // render() must not panic; output is plain Prometheus text or empty.
+        let _out = handle.render();
+    }
+
+    #[test]
+    fn record_login_increments_labelled_counter() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        with_local_recorder(&recorder, || {
+            describe();
+            record_login(true);
+            record_login(true);
+            record_login(false);
+        });
+        let out = handle.render();
+        assert!(out.contains(AUTH_LOGIN), "missing metric: {out}");
+        assert!(out.contains("outcome=\"success\""));
+        assert!(out.contains("outcome=\"failure\""));
+    }
+
+    #[test]
+    fn record_service_token_issued_increments_counter() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        with_local_recorder(&recorder, || {
+            describe();
+            record_service_token_issued();
+            record_service_token_issued();
+        });
+        let out = handle.render();
+        assert!(out.contains(AUTH_SERVICE_TOKENS_ISSUED));
+        assert!(out.contains(&format!("{AUTH_SERVICE_TOKENS_ISSUED} 2")));
+    }
+
+    #[test]
+    fn record_repo_write_uses_op_label() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        with_local_recorder(&recorder, || {
+            describe();
+            record_repo_write("create");
+            record_repo_write("update");
+            record_repo_write("delete");
+        });
+        let out = handle.render();
+        assert!(out.contains("op=\"create\""));
+        assert!(out.contains("op=\"update\""));
+        assert!(out.contains("op=\"delete\""));
+    }
+
+    #[test]
+    fn record_blob_upload_increments_count_and_bytes() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        with_local_recorder(&recorder, || {
+            describe();
+            record_blob_upload(1_024);
+            record_blob_upload(2_048);
+        });
+        let out = handle.render();
+        assert!(out.contains(&format!("{BLOB_UPLOADS} 2")));
+        assert!(out.contains(&format!("{BLOB_UPLOAD_BYTES} 3072")));
+    }
+
+    #[test]
+    fn firehose_subscriber_gauge_tracks_connect_disconnect() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        with_local_recorder(&recorder, || {
+            describe();
+            record_firehose_subscriber_connected();
+            record_firehose_subscriber_connected();
+            record_firehose_subscriber_disconnected();
+        });
+        let out = handle.render();
+        assert!(out.contains(FIREHOSE_SUBSCRIBERS));
+        assert!(out.contains(&format!("{FIREHOSE_SUBSCRIBERS} 1")));
+    }
+
+    #[test]
+    fn install_recorder_is_idempotent_and_returns_working_handle() {
+        // Calling twice in the same process must not panic, and both handles
+        // must reflect the same underlying (process-wide) recorder.
+        let h1 = install_recorder();
+        let h2 = install_recorder();
+        record_service_token_issued();
+        let out1 = h1.render();
+        let out2 = h2.render();
+        assert_eq!(out1, out2);
+        assert!(out1.contains(AUTH_SERVICE_TOKENS_ISSUED));
+    }
+}

--- a/rsky-pds/src/metrics.rs
+++ b/rsky-pds/src/metrics.rs
@@ -12,6 +12,11 @@
 //! `method`, the HTTP status as `status`), translated into Prometheus'
 //! label conventions so the two implementations stay comparable side by
 //! side.
+//!
+//! Coverage is not limited to `/xrpc/*`: the `/oauth/*` and
+//! `/.well-known/oauth-*` routes are a fixed, low-cardinality set (no
+//! request-controlled path segments), so [`XrpcMetrics`] records them under
+//! the same `method`/`status` labels -- see [`route_label`].
 
 use std::sync::OnceLock;
 use std::time::Instant;
@@ -24,14 +29,20 @@ use rocket::fairing::{Fairing, Info, Kind};
 use rocket::http::ContentType;
 use rocket::{Data, Request, Response};
 
-/// Count of XRPC requests, labelled by lexicon method (NSID) and HTTP status code.
+/// Count of HTTP requests to `/xrpc/*` and `/oauth/*` routes, labelled by
+/// `method` (the lexicon NSID for XRPC, the literal route path for OAuth)
+/// and HTTP status.
 pub const XRPC_REQUESTS: &str = "pds_xrpc_requests_total";
-/// XRPC request latency in seconds, labelled by lexicon method and HTTP status code.
+/// Request latency in seconds for the same routes as [`XRPC_REQUESTS`].
 pub const XRPC_REQUEST_DURATION_SECONDS: &str = "pds_xrpc_request_duration_seconds";
-/// Login attempts via `com.atproto.server.createSession`, labelled by outcome.
+/// Login attempts via `com.atproto.server.createSession`, labelled by
+/// `outcome` (success/failure) and, on failure, `reason`.
 pub const AUTH_LOGIN: &str = "pds_auth_login_total";
 /// Service-auth tokens minted via `com.atproto.server.getServiceAuth`.
 pub const AUTH_SERVICE_TOKENS_ISSUED: &str = "pds_auth_service_tokens_issued_total";
+/// Service-auth token requests denied via `com.atproto.server.getServiceAuth`,
+/// labelled by `reason`.
+pub const AUTH_SERVICE_TOKENS_DENIED: &str = "pds_auth_service_tokens_denied_total";
 /// Repo writes (record creates/updates/deletes) committed to an actor store.
 pub const REPO_WRITES: &str = "pds_repo_writes_total";
 /// Successful blob uploads via `com.atproto.repo.uploadBlob`.
@@ -48,22 +59,27 @@ pub fn describe() {
     describe_counter!(
         XRPC_REQUESTS,
         Unit::Count,
-        "XRPC requests handled, by lexicon method and HTTP status"
+        "XRPC and OAuth requests handled, by route and HTTP status"
     );
     describe_histogram!(
         XRPC_REQUEST_DURATION_SECONDS,
         Unit::Seconds,
-        "XRPC request latency, by lexicon method and HTTP status"
+        "XRPC and OAuth request latency, by route and HTTP status"
     );
     describe_counter!(
         AUTH_LOGIN,
         Unit::Count,
-        "createSession login attempts, by outcome (success/failure)"
+        "createSession login attempts, by outcome (success/failure) and, on failure, reason"
     );
     describe_counter!(
         AUTH_SERVICE_TOKENS_ISSUED,
         Unit::Count,
         "getServiceAuth service-auth tokens issued"
+    );
+    describe_counter!(
+        AUTH_SERVICE_TOKENS_DENIED,
+        Unit::Count,
+        "getServiceAuth service-auth token requests denied, by reason"
     );
     describe_counter!(
         REPO_WRITES,
@@ -110,9 +126,26 @@ pub fn install_recorder() -> PrometheusHandle {
 
 struct RequestStart(Instant);
 
-/// Rocket fairing that records XRPC request count + latency, labelled by
-/// lexicon method (the NSID segment of the `/xrpc/<nsid>` path) and HTTP
-/// status code.
+/// Derives the `method` label for a request path, or `None` if the path
+/// shouldn't be recorded at all.
+///
+/// `/xrpc/<nsid>` yields the NSID. `/oauth/*` and `/.well-known/oauth-*` are
+/// a fixed, known set of literal routes (no request-controlled path
+/// segments, unlike e.g. a `did` or `rkey` in an XRPC path), so the raw path
+/// is used as-is -- cardinality stays bounded by the route table, not by
+/// caller input.
+fn route_label(path: &str) -> Option<String> {
+    if let Some(nsid) = path.strip_prefix("/xrpc/") {
+        return Some(nsid.to_string());
+    }
+    if path.starts_with("/oauth/") || path.starts_with("/.well-known/oauth-") {
+        return Some(path.to_string());
+    }
+    None
+}
+
+/// Rocket fairing that records request count + latency for `/xrpc/*` and
+/// `/oauth/*` routes, labelled by [`route_label`] and HTTP status code.
 pub struct XrpcMetrics;
 
 #[rocket::async_trait]
@@ -130,10 +163,9 @@ impl Fairing for XrpcMetrics {
 
     async fn on_response<'r>(&self, request: &'r Request<'_>, response: &mut Response<'r>) {
         let path = request.uri().path();
-        let Some(method) = path.as_str().strip_prefix("/xrpc/") else {
+        let Some(method) = route_label(path.as_str()) else {
             return;
         };
-        let method = method.to_string();
         let status = response.status().code.to_string();
         let start = request.local_cache(|| RequestStart(Instant::now()));
         let elapsed = start.0.elapsed().as_secs_f64();
@@ -155,14 +187,23 @@ pub async fn metrics_route(handle: &rocket::State<PrometheusHandle>) -> (Content
 }
 
 #[inline]
-pub fn record_login(success: bool) {
-    let outcome = if success { "success" } else { "failure" };
-    counter!(AUTH_LOGIN, "outcome" => outcome).increment(1);
+pub fn record_login_success() {
+    counter!(AUTH_LOGIN, "outcome" => "success", "reason" => "n/a").increment(1);
+}
+
+#[inline]
+pub fn record_login_failure(reason: &'static str) {
+    counter!(AUTH_LOGIN, "outcome" => "failure", "reason" => reason).increment(1);
 }
 
 #[inline]
 pub fn record_service_token_issued() {
     counter!(AUTH_SERVICE_TOKENS_ISSUED).increment(1);
+}
+
+#[inline]
+pub fn record_service_token_denied(reason: &'static str) {
+    counter!(AUTH_SERVICE_TOKENS_DENIED, "reason" => reason).increment(1);
 }
 
 #[inline]
@@ -205,19 +246,38 @@ mod tests {
     }
 
     #[test]
+    fn route_label_covers_xrpc_oauth_and_well_known_oauth() {
+        assert_eq!(
+            route_label("/xrpc/com.atproto.server.createSession"),
+            Some("com.atproto.server.createSession".to_string())
+        );
+        assert_eq!(
+            route_label("/oauth/token"),
+            Some("/oauth/token".to_string())
+        );
+        assert_eq!(
+            route_label("/.well-known/oauth-authorization-server"),
+            Some("/.well-known/oauth-authorization-server".to_string())
+        );
+        assert_eq!(route_label("/robots.txt"), None);
+        assert_eq!(route_label("/.well-known/atproto-did"), None);
+    }
+
+    #[test]
     fn record_login_increments_labelled_counter() {
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
         with_local_recorder(&recorder, || {
             describe();
-            record_login(true);
-            record_login(true);
-            record_login(false);
+            record_login_success();
+            record_login_success();
+            record_login_failure("invalid_credentials");
         });
         let out = handle.render();
         assert!(out.contains(AUTH_LOGIN), "missing metric: {out}");
-        assert!(out.contains("outcome=\"success\""));
-        assert!(out.contains("outcome=\"failure\""));
+        assert!(out.contains(r#"outcome="success""#));
+        assert!(out.contains(r#"outcome="failure""#));
+        assert!(out.contains(r#"reason="invalid_credentials""#));
     }
 
     #[test]
@@ -232,6 +292,21 @@ mod tests {
         let out = handle.render();
         assert!(out.contains(AUTH_SERVICE_TOKENS_ISSUED));
         assert!(out.contains(&format!("{AUTH_SERVICE_TOKENS_ISSUED} 2")));
+    }
+
+    #[test]
+    fn record_service_token_denied_uses_reason_label() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        with_local_recorder(&recorder, || {
+            describe();
+            record_service_token_denied("insufficient_privilege");
+            record_service_token_denied("bad_expiration");
+        });
+        let out = handle.render();
+        assert!(out.contains(AUTH_SERVICE_TOKENS_DENIED));
+        assert!(out.contains(r#"reason="insufficient_privilege""#));
+        assert!(out.contains(r#"reason="bad_expiration""#));
     }
 
     #[test]

--- a/rsky-pds/src/metrics.rs
+++ b/rsky-pds/src/metrics.rs
@@ -35,9 +35,11 @@ use rocket::{Data, Request, Response};
 pub const XRPC_REQUESTS: &str = "pds_xrpc_requests_total";
 /// Request latency in seconds for the same routes as [`XRPC_REQUESTS`].
 pub const XRPC_REQUEST_DURATION_SECONDS: &str = "pds_xrpc_request_duration_seconds";
-/// Login attempts via `com.atproto.server.createSession`, labelled by
-/// `outcome` (success/failure) and, on failure, `reason`.
-pub const AUTH_LOGIN: &str = "pds_auth_login_total";
+/// Sessions created, unified across every auth path (password
+/// `createSession` and OAuth's `authorization_code` token grant), labelled
+/// by `source` (password/oauth), `outcome` (success/failure) and, on
+/// failure, `reason`.
+pub const SESSION_CREATED: &str = "pds_session_created_total";
 /// Service-auth tokens minted via `com.atproto.server.getServiceAuth`.
 pub const AUTH_SERVICE_TOKENS_ISSUED: &str = "pds_auth_service_tokens_issued_total";
 /// Service-auth token requests denied via `com.atproto.server.getServiceAuth`,
@@ -51,6 +53,14 @@ pub const BLOB_UPLOADS: &str = "pds_blob_uploads_total";
 pub const BLOB_UPLOAD_BYTES: &str = "pds_blob_upload_bytes_total";
 /// Currently-connected `com.atproto.sync.subscribeRepos` (firehose) subscribers.
 pub const FIREHOSE_SUBSCRIBERS: &str = "pds_firehose_subscribers";
+/// Accounts created, labelled by `source` (self_service/admin), `invited`
+/// and `deactivated`.
+pub const ACCOUNTS_CREATED: &str = "pds_accounts_created_total";
+/// OAuth authorization grants, labelled by `client_first_party`.
+pub const OAUTH_AUTHORIZATION_GRANTS: &str = "pds_oauth_authorization_grants_total";
+/// OAuth sessions (rows in the `token` table) revoked in bulk for a DID, e.g.
+/// as part of an account takedown or deletion.
+pub const OAUTH_SESSIONS_REVOKED: &str = "pds_oauth_sessions_revoked_total";
 
 /// Register all rsky-pds metrics with descriptions. Idempotent: `describe_*!`
 /// macros just re-set the same description on repeated calls, so this is
@@ -67,9 +77,10 @@ pub fn describe() {
         "XRPC and OAuth request latency, by route and HTTP status"
     );
     describe_counter!(
-        AUTH_LOGIN,
+        SESSION_CREATED,
         Unit::Count,
-        "createSession login attempts, by outcome (success/failure) and, on failure, reason"
+        "Sessions created, by source (password/oauth), outcome (success/failure) and, \
+         on failure, reason"
     );
     describe_counter!(
         AUTH_SERVICE_TOKENS_ISSUED,
@@ -96,6 +107,21 @@ pub fn describe() {
         FIREHOSE_SUBSCRIBERS,
         Unit::Count,
         "Currently-connected subscribeRepos (firehose) subscribers"
+    );
+    describe_counter!(
+        ACCOUNTS_CREATED,
+        Unit::Count,
+        "Accounts created, by source (self_service/admin), invited, and deactivated"
+    );
+    describe_counter!(
+        OAUTH_AUTHORIZATION_GRANTS,
+        Unit::Count,
+        "OAuth authorization grants, by client_first_party"
+    );
+    describe_counter!(
+        OAUTH_SESSIONS_REVOKED,
+        Unit::Count,
+        "OAuth sessions bulk-revoked for a DID (account takedown/deletion)"
     );
 }
 
@@ -187,13 +213,15 @@ pub async fn metrics_route(handle: &rocket::State<PrometheusHandle>) -> (Content
 }
 
 #[inline]
-pub fn record_login_success() {
-    counter!(AUTH_LOGIN, "outcome" => "success", "reason" => "n/a").increment(1);
+pub fn record_login_success(source: &'static str) {
+    counter!(SESSION_CREATED, "source" => source, "outcome" => "success", "reason" => "n/a")
+        .increment(1);
 }
 
 #[inline]
-pub fn record_login_failure(reason: &'static str) {
-    counter!(AUTH_LOGIN, "outcome" => "failure", "reason" => reason).increment(1);
+pub fn record_login_failure(source: &'static str, reason: &'static str) {
+    counter!(SESSION_CREATED, "source" => source, "outcome" => "failure", "reason" => reason)
+        .increment(1);
 }
 
 #[inline]
@@ -225,6 +253,30 @@ pub fn record_firehose_subscriber_connected() {
 #[inline]
 pub fn record_firehose_subscriber_disconnected() {
     gauge!(FIREHOSE_SUBSCRIBERS).decrement(1.0);
+}
+
+#[inline]
+pub fn record_account_created(source: &'static str, invited: bool, deactivated: bool) {
+    counter!(
+        ACCOUNTS_CREATED,
+        "source" => source,
+        "invited" => invited.to_string(),
+        "deactivated" => deactivated.to_string(),
+    )
+    .increment(1);
+}
+
+#[inline]
+pub fn record_oauth_authorization_granted(client_first_party: bool) {
+    counter!(OAUTH_AUTHORIZATION_GRANTS, "client_first_party" => client_first_party.to_string())
+        .increment(1);
+}
+
+#[inline]
+pub fn record_oauth_sessions_revoked(count: u64) {
+    if count > 0 {
+        counter!(OAUTH_SESSIONS_REVOKED).increment(count);
+    }
 }
 
 #[cfg(test)]
@@ -269,12 +321,14 @@ mod tests {
         let handle = recorder.handle();
         with_local_recorder(&recorder, || {
             describe();
-            record_login_success();
-            record_login_success();
-            record_login_failure("invalid_credentials");
+            record_login_success("password");
+            record_login_success("oauth");
+            record_login_failure("password", "invalid_credentials");
         });
         let out = handle.render();
-        assert!(out.contains(AUTH_LOGIN), "missing metric: {out}");
+        assert!(out.contains(SESSION_CREATED), "missing metric: {out}");
+        assert!(out.contains(r#"source="password""#));
+        assert!(out.contains(r#"source="oauth""#));
         assert!(out.contains(r#"outcome="success""#));
         assert!(out.contains(r#"outcome="failure""#));
         assert!(out.contains(r#"reason="invalid_credentials""#));
@@ -352,6 +406,54 @@ mod tests {
         let out = handle.render();
         assert!(out.contains(FIREHOSE_SUBSCRIBERS));
         assert!(out.contains(&format!("{FIREHOSE_SUBSCRIBERS} 1")));
+    }
+
+    #[test]
+    fn record_account_created_uses_source_invited_deactivated_labels() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        with_local_recorder(&recorder, || {
+            describe();
+            record_account_created("self_service", true, false);
+            record_account_created("admin", false, true);
+        });
+        let out = handle.render();
+        assert!(out.contains(ACCOUNTS_CREATED));
+        assert!(out.contains(r#"source="self_service""#));
+        assert!(out.contains(r#"invited="true""#));
+        assert!(out.contains(r#"deactivated="false""#));
+        assert!(out.contains(r#"source="admin""#));
+    }
+
+    #[test]
+    fn record_oauth_authorization_granted_uses_first_party_label() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        with_local_recorder(&recorder, || {
+            describe();
+            record_oauth_authorization_granted(true);
+            record_oauth_authorization_granted(false);
+            record_oauth_authorization_granted(false);
+        });
+        let out = handle.render();
+        assert!(out.contains(OAUTH_AUTHORIZATION_GRANTS));
+        assert!(out.contains(r#"client_first_party="true""#));
+        assert!(out.contains(&format!(
+            "{OAUTH_AUTHORIZATION_GRANTS}{{client_first_party=\"false\"}} 2"
+        )));
+    }
+
+    #[test]
+    fn record_oauth_sessions_revoked_increments_by_count_and_ignores_zero() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        with_local_recorder(&recorder, || {
+            describe();
+            record_oauth_sessions_revoked(0);
+            record_oauth_sessions_revoked(3);
+        });
+        let out = handle.render();
+        assert!(out.contains(&format!("{OAUTH_SESSIONS_REVOKED} 3")));
     }
 
     #[test]

--- a/rsky-pds/src/oauth/routes.rs
+++ b/rsky-pds/src/oauth/routes.rs
@@ -2,6 +2,7 @@ use super::templates::{
     client_display, scope_items, ConsentPage, ErrorPage, SessionOption, SignInPage,
 };
 use super::{ensure_device_session, now_secs, DeviceSession, SharedOAuthProvider};
+use crate::metrics::{record_login_success, record_oauth_authorization_granted};
 use askama::Template;
 use rocket::form::Form;
 use rocket::http::{ContentType, CookieJar, Header, Status};
@@ -15,6 +16,7 @@ use rsky_common::env::env_str;
 use rsky_oauth::client::ParRequest;
 use rsky_oauth::dpop::DpopRequest;
 use rsky_oauth::store::AccountInfo;
+use rsky_oauth::types::GRANT_AUTHORIZATION_CODE;
 use rsky_oauth::{AuthorizePageData, ClientCredentials, OAuthError, TokenRequest};
 use serde_json::Value;
 use std::io::Cursor;
@@ -197,6 +199,17 @@ pub async fn oauth_par(
     }
 }
 
+/// Only the initial `authorization_code` exchange mints a new session; a
+/// `refresh_token` grant renews an existing one and isn't a fresh "session
+/// created" event -- pulled out as its own function so this distinction is
+/// unit-tested directly rather than only provable by an exact metric count
+/// (the Prometheus recorder is a single process-wide instance, so
+/// integration tests that race concurrently in the same test binary can't
+/// safely assert on it).
+fn is_new_oauth_session(grant_type: &str) -> bool {
+    grant_type == GRANT_AUTHORIZATION_CODE
+}
+
 #[derive(FromForm)]
 pub struct TokenFormData {
     pub grant_type: Option<String>,
@@ -232,6 +245,7 @@ pub async fn oauth_token(
         code_verifier: form.code_verifier.clone(),
         refresh_token: form.refresh_token.clone(),
     };
+    let is_new_session = is_new_oauth_session(&request.grant_type);
     match provider
         .token(
             &credentials,
@@ -241,11 +255,16 @@ pub async fn oauth_token(
         )
         .await
     {
-        Ok(response) => OAuthApiResponse::ok(
-            Status::Ok,
-            serde_json::to_value(response).expect("token response serialization cannot fail"),
-            nonce,
-        ),
+        Ok(response) => {
+            if is_new_session {
+                record_login_success("oauth");
+            }
+            OAuthApiResponse::ok(
+                Status::Ok,
+                serde_json::to_value(response).expect("token response serialization cannot fail"),
+                nonce,
+            )
+        }
         Err(error) => OAuthApiResponse::error(error, nonce),
     }
 }
@@ -529,7 +548,7 @@ pub async fn oauth_authorize_accept(
     let Some(did) = form.did.clone() else {
         return Err(render_error(Status::BadRequest, "did is required"));
     };
-    shared
+    let redirect = shared
         .provider
         .accept(
             &form.client_id,
@@ -539,8 +558,9 @@ pub async fn oauth_authorize_accept(
             now,
         )
         .await
-        .map(Redirect::to)
-        .map_err(oauth_error_page)
+        .map_err(oauth_error_page)?;
+    record_oauth_authorization_granted(shared.provider.is_trusted_client(&form.client_id));
+    Ok(Redirect::to(redirect))
 }
 
 #[tracing::instrument(skip_all)]
@@ -562,4 +582,20 @@ pub async fn oauth_authorize_reject(
         .await
         .map(Redirect::to)
         .map_err(oauth_error_page)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_new_oauth_session_only_true_for_authorization_code() {
+        assert!(is_new_oauth_session(
+            rsky_oauth::types::GRANT_AUTHORIZATION_CODE
+        ));
+        assert!(!is_new_oauth_session(
+            rsky_oauth::types::GRANT_REFRESH_TOKEN
+        ));
+        assert!(!is_new_oauth_session("something_else"));
+    }
 }

--- a/rsky-pds/src/telemetry.rs
+++ b/rsky-pds/src/telemetry.rs
@@ -1,0 +1,80 @@
+//! Distributed tracing: bridges the existing `tracing` spans (117
+//! `#[tracing::instrument]` call sites across the handler layer) to
+//! OpenTelemetry, exported via OTLP.
+//!
+//! This is additive to the Prometheus metrics in [`crate::metrics`], not a
+//! replacement: metrics stay on the `metrics` facade / `/metrics` endpoint,
+//! this only covers spans. Modeled on the reference TypeScript PDS's
+//! `telemetry.ts`, which wires the OTEL SDK the same way (there, via
+//! `@atproto-labs/opentelemetry-node`).
+//!
+//! Opt-in and zero-cost when unconfigured: tracing only initializes, and
+//! the OTLP exporter only gets built, when `OTEL_EXPORTER_OTLP_ENDPOINT` is
+//! set. Deployments that don't run a collector pay nothing -- no exporter,
+//! no background export thread, no failed-connection log spam.
+
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry_sdk::Resource;
+use rsky_common::env::env_str;
+use std::sync::OnceLock;
+
+static TRACER_PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
+
+/// Builds the OTEL tracer provider and returns a `tracing` layer that
+/// forwards every span through it, or `None` if
+/// `OTEL_EXPORTER_OTLP_ENDPOINT` isn't set.
+///
+/// The returned provider must be kept alive (and ideally flushed via
+/// `shutdown()`) for the process lifetime; [`init`] handles that by setting
+/// it as the OTEL global provider, which owns the batch exporter thread.
+pub fn layer<S>() -> Option<impl tracing_subscriber::Layer<S>>
+where
+    S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
+    let endpoint = env_str("OTEL_EXPORTER_OTLP_ENDPOINT")?;
+
+    let exporter = match opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_endpoint(&endpoint)
+        .build()
+    {
+        Ok(exporter) => exporter,
+        Err(error) => {
+            tracing::error!("Failed to build OTLP span exporter for {endpoint}: {error}");
+            return None;
+        }
+    };
+
+    let service_name = env_str("OTEL_SERVICE_NAME").unwrap_or_else(|| "rsky-pds".to_string());
+    let provider = SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .with_resource(
+            Resource::builder()
+                .with_attributes([KeyValue::new("service.name", service_name)])
+                .build(),
+        )
+        .build();
+
+    let tracer = provider.tracer("rsky-pds");
+    // Keep our own handle for shutdown() -- this version of the `global`
+    // module has no `shutdown_tracer_provider()`, and `set_tracer_provider`
+    // takes the callee's provider by value, so the clone here is the only
+    // way to flush on exit.
+    let _ = TRACER_PROVIDER.set(provider.clone());
+    opentelemetry::global::set_tracer_provider(provider);
+    Some(tracing_opentelemetry::layer().with_tracer(tracer))
+}
+
+/// Flushes and shuts down the tracer provider installed by [`layer`], if
+/// any. Best-effort: a failure here just means some in-flight spans may
+/// not reach the collector, never a reason to fail shutdown.
+pub fn shutdown() {
+    if let Some(provider) = TRACER_PROVIDER.get() {
+        if let Err(error) = provider.shutdown() {
+            tracing::warn!("Error shutting down OTEL tracer provider: {error}");
+        }
+    }
+}

--- a/rsky-pds/src/telemetry.rs
+++ b/rsky-pds/src/telemetry.rs
@@ -13,13 +13,20 @@
 //! set. Deployments that don't run a collector pay nothing -- no exporter,
 //! no background export thread, no failed-connection log spam.
 
-use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::trace::{TraceContextExt, TracerProvider as _};
 use opentelemetry::KeyValue;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use opentelemetry_sdk::Resource;
 use rsky_common::env::env_str;
-use std::sync::OnceLock;
+use std::fmt;
+use std::sync::{Arc, OnceLock};
+use tracing::dispatcher::WeakDispatch;
+use tracing::{Dispatch, Subscriber};
+use tracing_subscriber::fmt::format::{Format, FormatEvent, FormatFields, Json, Writer};
+use tracing_subscriber::fmt::FmtContext;
+use tracing_subscriber::layer::Layer;
+use tracing_subscriber::registry::LookupSpan;
 
 static TRACER_PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
 
@@ -68,6 +75,124 @@ where
     Some(tracing_opentelemetry::layer().with_tracer(tracer))
 }
 
+/// Captures the process' `Dispatch` the instant this layer is registered
+/// into a subscriber -- i.e. outside of any span/event dispatch -- and
+/// shares it with a [`CorrelatedJson`] formatter.
+///
+/// This indirection exists because `format_event` has no direct way to
+/// reach a live `Dispatch`: it runs *during* dispatch, and both
+/// `tracing::Span::current()` and `tracing::dispatcher::get_default()` hit
+/// tracing's re-entrancy guard there, silently resolving to the no-op
+/// dispatcher (this was confirmed by writing the naive
+/// `Span::current().context()` version first -- it never panicked, it just
+/// silently produced spans with no trace/span id). `on_register_dispatch`
+/// is the one hook tracing calls outside of any dispatch, specifically to
+/// let layers stash a `Dispatch` for later use -- the same pattern
+/// `tracing-opentelemetry`'s own test suite uses for this exact problem.
+#[derive(Clone, Default)]
+struct DispatchCapture(Arc<OnceLock<WeakDispatch>>);
+
+impl<S> Layer<S> for DispatchCapture
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_register_dispatch(&self, dispatch: &Dispatch) {
+        let _ = self.0.set(dispatch.downgrade());
+    }
+}
+
+/// A JSON log formatter that adds `trace_id`/`span_id` fields (hex, the same
+/// representation OTEL itself uses) to every line, so a log entry can be
+/// pivoted straight to the corresponding trace in the collector -- the same
+/// correlation the reference TS PDS's OTEL Logs SDK gets automatically.
+///
+/// Implemented as parse-mutate-reserialize around tracing-subscriber's own
+/// `Json` formatter (rather than a formatter written from scratch), so
+/// field/span rendering stays exactly what it already produces; only the
+/// two extra keys are new. `trace_id`/`span_id` are omitted entirely when
+/// there's no active OTEL span (e.g. [`layer`] returned `None` because no
+/// collector is configured, or the dispatch hasn't been captured yet) --
+/// never emitted as `"0"*32`/`"0"*16`, which would look like a real (if
+/// degenerate) id.
+struct CorrelatedJson {
+    inner: Format<Json>,
+    dispatch: Arc<OnceLock<WeakDispatch>>,
+}
+
+impl<S, N> FormatEvent<S, N> for CorrelatedJson
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> fmt::Result {
+        let mut buf = String::new();
+        self.inner.format_event(ctx, Writer::new(&mut buf), event)?;
+
+        let otel_context = self
+            .dispatch
+            .get()
+            .and_then(WeakDispatch::upgrade)
+            .and_then(|dispatch| {
+                let span = ctx.lookup_current()?;
+                tracing_opentelemetry::get_otel_context(&span.id(), &dispatch)
+            });
+
+        if let Some(span_context) = otel_context
+            .as_ref()
+            .map(|cx| cx.span().span_context().clone())
+            .filter(|sc| sc.is_valid())
+        {
+            if let Ok(serde_json::Value::Object(mut line)) =
+                serde_json::from_str::<serde_json::Value>(buf.trim_end())
+            {
+                line.insert(
+                    "trace_id".to_string(),
+                    serde_json::Value::String(span_context.trace_id().to_string()),
+                );
+                line.insert(
+                    "span_id".to_string(),
+                    serde_json::Value::String(span_context.span_id().to_string()),
+                );
+                return writeln!(writer, "{}", serde_json::Value::Object(line));
+            }
+        }
+        write!(writer, "{buf}")
+    }
+}
+
+/// The layer to install for JSON, trace-correlated logging: [`DispatchCapture`]
+/// paired with a `tracing_subscriber::fmt` layer using [`CorrelatedJson`] as
+/// its event formatter and [`JsonFields`](tracing_subscriber::fmt::format::JsonFields)
+/// as its span-field formatter.
+///
+/// The fields/formatter pairing matters, not just the event formatter alone:
+/// `Json`'s span rendering treats a span's stored `FormattedFields` text as
+/// a JSON fragment to embed verbatim, which only holds if fields were
+/// *recorded* as JSON in the first place -- the default `DefaultFields`
+/// formatter writes plain text instead, which `Json` then fails to parse.
+/// Every `#[tracing::instrument(skip_all)]` span in this crate has zero
+/// recorded fields, which panics under this mismatch even for an empty
+/// field set, so this is not just a style nicety.
+pub fn fmt_layer<S>() -> impl Layer<S>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let dispatch = Arc::new(OnceLock::new());
+    DispatchCapture(dispatch.clone()).and_then(
+        tracing_subscriber::fmt::layer()
+            .fmt_fields(tracing_subscriber::fmt::format::JsonFields::new())
+            .event_format(CorrelatedJson {
+                inner: tracing_subscriber::fmt::format().json(),
+                dispatch,
+            }),
+    )
+}
+
 /// Flushes and shuts down the tracer provider installed by [`layer`], if
 /// any. Best-effort: a failure here just means some in-flight spans may
 /// not reach the collector, never a reason to fail shutdown.
@@ -76,5 +201,126 @@ pub fn shutdown() {
         if let Err(error) = provider.shutdown() {
             tracing::warn!("Error shutting down OTEL tracer provider: {error}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    /// A `Vec<u8>` sink usable as a tracing-subscriber `MakeWriter`, so a
+    /// test can assert on exactly what a formatter wrote without touching
+    /// stdout or any shared global state.
+    #[derive(Clone, Default)]
+    struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SharedBuf {
+        type Writer = Self;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    impl SharedBuf {
+        fn last_line_as_json(&self) -> serde_json::Value {
+            let bytes = self.0.lock().unwrap();
+            let text = std::str::from_utf8(&bytes).unwrap();
+            serde_json::from_str(text.lines().next_back().unwrap()).unwrap()
+        }
+    }
+
+    /// [`fmt_layer`], but writing to `buf` instead of stdout, for tests.
+    fn fmt_layer_to<S>(buf: SharedBuf) -> impl Layer<S>
+    where
+        S: Subscriber + for<'a> LookupSpan<'a>,
+    {
+        let dispatch = Arc::new(OnceLock::new());
+        DispatchCapture(dispatch.clone()).and_then(
+            tracing_subscriber::fmt::layer()
+                .fmt_fields(tracing_subscriber::fmt::format::JsonFields::new())
+                .event_format(CorrelatedJson {
+                    inner: tracing_subscriber::fmt::format().json(),
+                    dispatch,
+                })
+                .with_writer(buf),
+        )
+    }
+
+    /// `#[tracing::instrument(skip_all)]` -- used on every handler in this
+    /// crate -- produces a zero-field span. Pairing `CorrelatedJson` with
+    /// `JsonFields` (what `fmt_layer` does) is what makes that safe to log;
+    /// a bare `.event_format(CorrelatedJson::default())` panics on exactly
+    /// this shape, since `Json` expects fields to have been *recorded* as
+    /// JSON, not just formatted as JSON on output.
+    #[test]
+    fn zero_field_instrumented_spans_format_without_panicking() {
+        let buf = SharedBuf::default();
+        let subscriber = tracing_subscriber::registry().with(fmt_layer_to(buf.clone()));
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("zero_field_span");
+            let _enter = span.enter();
+            tracing::info!("inside a zero-field span");
+        });
+
+        let line = buf.last_line_as_json();
+        assert_eq!(
+            line["fields"]["message"], "inside a zero-field span",
+            "{line}"
+        );
+    }
+
+    #[test]
+    fn logs_without_an_active_otel_span_omit_trace_and_span_id() {
+        let buf = SharedBuf::default();
+        let subscriber = tracing_subscriber::registry().with(fmt_layer_to(buf.clone()));
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!("no otel layer installed");
+        });
+
+        let line = buf.last_line_as_json();
+        assert!(line.get("trace_id").is_none(), "{line}");
+        assert!(line.get("span_id").is_none(), "{line}");
+    }
+
+    #[test]
+    fn logs_inside_a_traced_span_carry_its_trace_and_span_id() {
+        let buf = SharedBuf::default();
+        // No exporter/processor attached: this only needs the SDK's id
+        // generation and tracing_opentelemetry's span<->context bookkeeping,
+        // never touches the network, and doesn't collide with any other
+        // test's global state (unlike the process-wide Prometheus recorder).
+        let provider = SdkTracerProvider::builder().build();
+        let tracer = provider.tracer("test");
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer))
+            .with(fmt_layer_to(buf.clone()));
+
+        let (expected_trace_id, expected_span_id) =
+            tracing::subscriber::with_default(subscriber, || {
+                let span = tracing::info_span!("test_span");
+                let _enter = span.enter();
+                let sc = span.context().span().span_context().clone();
+                tracing::info!("inside a traced span");
+                (sc.trace_id().to_string(), sc.span_id().to_string())
+            });
+
+        let _ = provider.shutdown();
+
+        let line = buf.last_line_as_json();
+        assert_eq!(line["trace_id"], expected_trace_id, "{line}");
+        assert_eq!(line["span_id"], expected_span_id, "{line}");
     }
 }

--- a/rsky-pds/tests/metrics_tests.rs
+++ b/rsky-pds/tests/metrics_tests.rs
@@ -1,0 +1,74 @@
+//! Integration tests for the `/metrics` Prometheus endpoint and the XRPC
+//! request fairing that feeds it, exercised against a real Rocket instance
+//! (mirroring how `rsky-relay`'s metrics tests exercise its recorder).
+
+mod common;
+
+use rocket::http::{ContentType, Status};
+use rocket::serde::json::json;
+
+/// `/metrics` must exist, respond 200, and render valid-looking Prometheus
+/// exposition text (not JSON, not empty of our metric names).
+#[rocket::async_test]
+async fn metrics_endpoint_returns_prometheus_text() {
+    let (_dir, client) = common::get_client().await;
+
+    let response = client.get("/metrics").dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+
+    let content_type = response.content_type().expect("content-type header set");
+    assert_eq!(content_type.top(), "text");
+    assert_eq!(content_type.sub(), "plain");
+
+    // `metrics-exporter-prometheus` only emits a metric family once it has
+    // at least one recorded sample, so an otherwise-idle server can validly
+    // render an empty (but well-formed) body here; the "metrics actually
+    // show up" assertions live in `xrpc_requests_are_counted_by_method_and_status`.
+    let body = response.into_string().await.expect("response body");
+    assert!(
+        body.is_ascii(),
+        "Prometheus exposition text must be ASCII: {body}"
+    );
+}
+
+/// Real requests flowing through the Rocket app must show up in `/metrics`,
+/// labelled by lexicon method and status code -- this is the fairing wired
+/// into `build_rocket()`, not just the unit-level `record_*` helpers.
+#[rocket::async_test]
+async fn xrpc_requests_are_counted_by_method_and_status() {
+    let (_dir, client) = common::get_client().await;
+
+    // A cheap, auth-free XRPC route that never touches the database.
+    let health_response = client.get("/xrpc/_health/live").dispatch().await;
+    assert_eq!(health_response.status(), Status::Ok);
+
+    // A login attempt against a nonexistent account: exercises the
+    // `pds_auth_login_total{outcome="failure"}` hook in `create_session`.
+    let login_response = client
+        .post("/xrpc/com.atproto.server.createSession")
+        .header(ContentType::JSON)
+        .body(json!({"identifier": "nobody.test", "password": "wrong"}).to_string())
+        .dispatch()
+        .await;
+    assert_eq!(login_response.status(), Status::BadRequest);
+
+    let metrics_response = client.get("/metrics").dispatch().await;
+    let body = metrics_response.into_string().await.expect("response body");
+
+    assert!(
+        body.contains(r#"method="_health/live""#),
+        "expected _health/live method label in: {body}"
+    );
+    assert!(
+        body.contains(r#"status="200""#),
+        "expected status=\"200\" label in: {body}"
+    );
+    assert!(body.contains("pds_xrpc_request_duration_seconds"), "{body}");
+    assert!(body.contains("pds_xrpc_requests_total"), "{body}");
+    assert!(
+        body.contains(r#"method="com.atproto.server.createSession""#),
+        "{body}"
+    );
+    assert!(body.contains(r#"outcome="failure""#), "{body}");
+    assert!(body.contains("pds_auth_login_total"), "{body}");
+}

--- a/rsky-pds/tests/metrics_tests.rs
+++ b/rsky-pds/tests/metrics_tests.rs
@@ -70,5 +70,28 @@ async fn xrpc_requests_are_counted_by_method_and_status() {
         "{body}"
     );
     assert!(body.contains(r#"outcome="failure""#), "{body}");
+    assert!(
+        body.contains(r#"reason="invalid_credentials""#),
+        "expected the createSession failure to carry a reason label: {body}"
+    );
     assert!(body.contains("pds_auth_login_total"), "{body}");
+}
+
+/// `/oauth/*` isn't behind an `/xrpc/` prefix, but it's a fixed, low-
+/// cardinality route set (see `metrics::route_label`) and should be counted
+/// the same way XRPC requests are.
+#[rocket::async_test]
+async fn oauth_requests_are_counted_too() {
+    let (_dir, client) = common::get_client().await;
+
+    let jwks_response = client.get("/oauth/jwks").dispatch().await;
+    assert_eq!(jwks_response.status(), Status::Ok);
+
+    let metrics_response = client.get("/metrics").dispatch().await;
+    let body = metrics_response.into_string().await.expect("response body");
+
+    assert!(
+        body.contains(r#"method="/oauth/jwks""#),
+        "expected /oauth/jwks to be recorded under the xrpc/oauth request counter: {body}"
+    );
 }

--- a/rsky-pds/tests/metrics_tests.rs
+++ b/rsky-pds/tests/metrics_tests.rs
@@ -43,7 +43,8 @@ async fn xrpc_requests_are_counted_by_method_and_status() {
     assert_eq!(health_response.status(), Status::Ok);
 
     // A login attempt against a nonexistent account: exercises the
-    // `pds_auth_login_total{outcome="failure"}` hook in `create_session`.
+    // `pds_session_created_total{source="password",outcome="failure"}` hook
+    // in `create_session`.
     let login_response = client
         .post("/xrpc/com.atproto.server.createSession")
         .header(ContentType::JSON)
@@ -69,12 +70,13 @@ async fn xrpc_requests_are_counted_by_method_and_status() {
         body.contains(r#"method="com.atproto.server.createSession""#),
         "{body}"
     );
+    assert!(body.contains(r#"source="password""#), "{body}");
     assert!(body.contains(r#"outcome="failure""#), "{body}");
     assert!(
         body.contains(r#"reason="invalid_credentials""#),
         "expected the createSession failure to carry a reason label: {body}"
     );
-    assert!(body.contains("pds_auth_login_total"), "{body}");
+    assert!(body.contains("pds_session_created_total"), "{body}");
 }
 
 /// `/oauth/*` isn't behind an `/xrpc/` prefix, but it's a fixed, low-
@@ -93,5 +95,26 @@ async fn oauth_requests_are_counted_too() {
     assert!(
         body.contains(r#"method="/oauth/jwks""#),
         "expected /oauth/jwks to be recorded under the xrpc/oauth request counter: {body}"
+    );
+}
+
+/// `common::create_account` drives `createAccount` with an admin token and
+/// an invite code (mirroring how a real invite-gated PDS provisions
+/// accounts), landing deactivated pending activation -- so the counter
+/// should show `source="admin"`, `invited="true"`, `deactivated="true"`.
+#[rocket::async_test]
+async fn account_created_is_counted_by_source() {
+    let (_dir, client) = common::get_client().await;
+
+    common::create_account(&client).await;
+
+    let metrics_response = client.get("/metrics").dispatch().await;
+    let body = metrics_response.into_string().await.expect("response body");
+
+    assert!(
+        body.contains(
+            r#"pds_accounts_created_total{source="admin",invited="true",deactivated="true"} 1"#
+        ),
+        "{body}"
     );
 }

--- a/rsky-pds/tests/oauth_tests.rs
+++ b/rsky-pds/tests/oauth_tests.rs
@@ -383,6 +383,29 @@ async fn oauth_full_flow_with_dpop_bound_resource_access() {
     let access_token = tokens["access_token"].as_str().unwrap().to_string();
     let refresh_token = tokens["refresh_token"].as_str().unwrap().to_string();
 
+    // The initial authorization_code exchange is both a granted authorization
+    // and a new session. The Prometheus recorder is one process-wide
+    // instance shared by every test in this binary, so only presence is
+    // checked here (not an exact count) -- other tests running concurrently
+    // touch these same counters. The authorization_code-vs-refresh_token
+    // distinction itself is unit-tested directly in
+    // `oauth::routes::tests::is_new_oauth_session_only_true_for_authorization_code`.
+    let metrics_body = client
+        .get("/metrics")
+        .dispatch()
+        .await
+        .into_string()
+        .await
+        .unwrap();
+    assert!(
+        metrics_body.contains("pds_oauth_authorization_grants_total"),
+        "{metrics_body}"
+    );
+    assert!(
+        metrics_body.contains(r#"pds_session_created_total{source="oauth","#),
+        "{metrics_body}"
+    );
+
     // resource request without a nonce is challenged and re-tried
     let session_htu = format!("{}/xrpc/com.atproto.server.getSession", public_url(&client));
     let response = client
@@ -485,6 +508,12 @@ async fn oauth_full_flow_with_dpop_bound_resource_access() {
     assert_eq!(response.status(), Status::BadRequest);
     let body: Value = serde_json::from_str(&response.into_string().await.unwrap()).unwrap();
     assert_eq!(body["error"], "invalid_grant");
+    // Whether this refresh_token grant (or any other) bumps
+    // pds_session_created_total is proven by
+    // `oauth::routes::tests::is_new_oauth_session_only_true_for_authorization_code`,
+    // not asserted here: the Prometheus recorder is one process-wide
+    // instance shared by every test in this binary, so an exact count isn't
+    // safe to assert on under concurrent test execution.
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- rsky-pds was the only service in its own workspace with no telemetry: a bare `FmtSubscriber::new()`, no `/metrics` endpoint, nothing to scrape.
- Adds Prometheus metrics via the `metrics` + `metrics-exporter-prometheus` crates, reusing exactly the pattern `rsky-relay` already established in this workspace (no new/third metrics facade introduced).
- New counters/gauges: `pds_xrpc_requests_total{method,status}`, `pds_xrpc_request_duration_seconds{method,status}`, `pds_auth_login_total{outcome}`, `pds_auth_service_tokens_issued_total`, `pds_repo_writes_total{op}`, `pds_blob_uploads_total` / `pds_blob_upload_bytes_total`, `pds_firehose_subscribers` (gauge, RAII-guarded across every exit path).
- Replaces the bare tracing subscriber with a layered `tracing_subscriber::registry()` + `EnvFilter`.
- Cross-checked against cocoon (Go, `prometheus/client_golang`) and tranquil-pds, which independently already uses the identical `metrics` + `metrics-exporter-prometheus` combination — validating this as the right shared convention for the workspace.

## Test plan
- [x] `cargo build -p rsky-pds`
- [x] `cargo test -p rsky-pds` — 310 lib tests + integration suites incl. new `tests/metrics_tests.rs` (real Rocket instance, checks `/metrics` output and label correctness), all passing
- [x] `cargo fmt -p rsky-pds` / `cargo clippy -p rsky-pds --all-targets` clean
- [x] Confirmed rsky-relay's one flaky, pre-existing test is unrelated (`git diff --stat -- rsky-relay/` shows zero changes there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)