### PR TITLE
feat(pds): enforce blob/rpc/identity/account OAuth scopes (proposal 0011)

### DIFF
--- a/rsky-pds/src/apis/com/atproto/identity/sign_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/sign_plc_operation.rs
@@ -22,6 +22,11 @@ pub async fn sign_plc_operation(
     auth: AccessFull,
     account_manager: AccountManager,
 ) -> Result<Json<Operation>, ApiError> {
+    crate::apis::assert_account_scope(
+        &auth.access.credentials,
+        "repo",
+        crate::oauth_scope::AccountAction::Manage,
+    )?;
     let did = auth.access.credentials.unwrap().did.unwrap();
     let request = body.into_inner();
     let token = request.token.clone();

--- a/rsky-pds/src/apis/com/atproto/identity/sign_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/sign_plc_operation.rs
@@ -1,7 +1,7 @@
 use crate::account_manager::AccountManager;
 use crate::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessFull;
+use crate::auth_verifier::AccountRepoScopedAccess;
 use crate::models::models::EmailTokenPurpose;
 use crate::plc;
 use crate::plc::operations::create_update_op;
@@ -19,14 +19,10 @@ use std::collections::BTreeMap;
 #[tracing::instrument(skip_all)]
 pub async fn sign_plc_operation(
     body: Json<SignPlcOperationRequest>,
-    auth: AccessFull,
+    // `AccessFull` (its pre-existing tier) via the guard's default `Base`.
+    auth: AccountRepoScopedAccess,
     account_manager: AccountManager,
 ) -> Result<Json<Operation>, ApiError> {
-    crate::apis::assert_account_scope(
-        &auth.access.credentials,
-        "repo",
-        crate::oauth_scope::AccountAction::Manage,
-    )?;
     let did = auth.access.credentials.unwrap().did.unwrap();
     let request = body.into_inner();
     let token = request.token.clone();

--- a/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
@@ -3,7 +3,7 @@ use crate::account_manager::AccountManager;
 use crate::actor_store::ActorStore;
 use crate::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessStandard;
+use crate::auth_verifier::{AccessStandard, AccountRepoScopedAccess};
 use crate::config::ServerConfig;
 use crate::plc::types::{OpOrTombstone, Operation};
 use crate::{plc, SharedIdResolver, SharedSequencer};
@@ -13,7 +13,7 @@ use rsky_crypto::utils::encode_did_key;
 use rsky_lexicon::com::atproto::identity::SubmitPlcOperationRequest;
 
 #[tracing::instrument(skip_all)]
-fn get_requester_did(auth: &AccessStandard) -> Result<String, ApiError> {
+fn get_requester_did(auth: &AccountRepoScopedAccess<AccessStandard>) -> Result<String, ApiError> {
     match &auth.access.credentials {
         None => {
             tracing::error!("Failed to find access credentials");
@@ -165,18 +165,15 @@ fn validate_operation_body(request: SubmitPlcOperationRequest) -> Result<Operati
 #[tracing::instrument(skip_all)]
 pub async fn submit_plc_operation(
     body: Json<SubmitPlcOperationRequest>,
-    auth: AccessStandard,
+    // `AccessStandard` (its pre-existing tier, app passwords included) named
+    // explicitly since it differs from the guard's default `Base`.
+    auth: AccountRepoScopedAccess<AccessStandard>,
     sequencer: &State<SharedSequencer>,
     id_resolver: &State<SharedIdResolver>,
     server_config: &State<ServerConfig>,
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
-    crate::apis::assert_account_scope(
-        &auth.access.credentials,
-        "repo",
-        crate::oauth_scope::AccountAction::Manage,
-    )?;
     let did = get_requester_did(&auth)?;
 
     //Validate and transform request

--- a/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
@@ -172,6 +172,11 @@ pub async fn submit_plc_operation(
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
+    crate::apis::assert_account_scope(
+        &auth.access.credentials,
+        "repo",
+        crate::oauth_scope::AccountAction::Manage,
+    )?;
     let did = get_requester_did(&auth)?;
 
     //Validate and transform request

--- a/rsky-pds/src/apis/com/atproto/identity/update_handle.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/update_handle.rs
@@ -2,7 +2,7 @@ use crate::account_manager::helpers::account::AvailabilityFlags;
 use crate::account_manager::AccountManager;
 use crate::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessStandardCheckTakedown;
+use crate::auth_verifier::HandleScopedAccess;
 use crate::config::ServerConfig;
 use crate::handle::{normalize_and_validate_handle, HandleValidationContext, HandleValidationOpts};
 use crate::{plc, SharedIdResolver, SharedSequencer};
@@ -18,7 +18,7 @@ async fn inner_update_handle(
     sequencer: &State<SharedSequencer>,
     server_config: &State<ServerConfig>,
     id_resolver: &State<SharedIdResolver>,
-    auth: AccessStandardCheckTakedown,
+    auth: HandleScopedAccess,
     account_manager: AccountManager,
 ) -> Result<()> {
     let UpdateHandleInput { handle } = body.into_inner();
@@ -92,10 +92,9 @@ pub async fn update_handle(
     sequencer: &State<SharedSequencer>,
     server_config: &State<ServerConfig>,
     id_resolver: &State<SharedIdResolver>,
-    auth: AccessStandardCheckTakedown,
+    auth: HandleScopedAccess,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
-    crate::apis::assert_identity_scope(&auth.access.credentials, "handle")?;
     match inner_update_handle(
         body,
         sequencer,

--- a/rsky-pds/src/apis/com/atproto/identity/update_handle.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/update_handle.rs
@@ -95,6 +95,7 @@ pub async fn update_handle(
     auth: AccessStandardCheckTakedown,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
+    crate::apis::assert_identity_scope(&auth.access.credentials, "handle")?;
     match inner_update_handle(
         body,
         sequencer,

--- a/rsky-pds/src/apis/com/atproto/repo/upload_blob.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/upload_blob.rs
@@ -1,7 +1,7 @@
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessStandardCheckTakedown;
+use crate::auth_verifier::BlobScopedAccess;
 use anyhow::Result;
 use rocket::data::{Data, ToByteUnit};
 use rocket::http::Status;
@@ -36,7 +36,7 @@ impl<'r> FromRequest<'r> for ContentType {
 }
 
 async fn inner_upload_blob(
-    auth: AccessStandardCheckTakedown,
+    auth: BlobScopedAccess,
     blob: Data<'_>,
     content_type: ContentType,
     blobstore_factory: &State<BlobstoreFactory>,
@@ -93,13 +93,15 @@ async fn inner_upload_blob(
 #[tracing::instrument(skip_all)]
 #[rocket::post("/xrpc/com.atproto.repo.uploadBlob", data = "<blob>")]
 pub async fn upload_blob(
-    auth: AccessStandardCheckTakedown,
-    blob: Data<'_>,
+    // `content_type` first so a request with no content type gets its own
+    // guard's rejection before `BlobScopedAccess` re-reads the same header
+    // to run the `blob:` scope check.
     content_type: ContentType,
+    auth: BlobScopedAccess,
+    blob: Data<'_>,
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,
 ) -> Result<Json<BlobOutput>, ApiError> {
-    crate::apis::assert_blob_scope(&auth.access.credentials, &content_type.name)?;
     match inner_upload_blob(auth, blob, content_type, blobstore_factory, actor_store).await {
         Ok(res) => Ok(Json(res)),
         Err(error) => {

--- a/rsky-pds/src/apis/com/atproto/repo/upload_blob.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/upload_blob.rs
@@ -99,6 +99,7 @@ pub async fn upload_blob(
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,
 ) -> Result<Json<BlobOutput>, ApiError> {
+    crate::apis::assert_blob_scope(&auth.access.credentials, &content_type.name)?;
     match inner_upload_blob(auth, blob, content_type, blobstore_factory, actor_store).await {
         Ok(res) => Ok(Json(res)),
         Err(error) => {

--- a/rsky-pds/src/apis/com/atproto/server/deactivate_account.rs
+++ b/rsky-pds/src/apis/com/atproto/server/deactivate_account.rs
@@ -1,6 +1,6 @@
 use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessFull;
+use crate::auth_verifier::AccountStatusScopedAccess;
 use anyhow::Result;
 use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::server::DeactivateAccountInput;
@@ -13,14 +13,9 @@ use rsky_lexicon::com::atproto::server::DeactivateAccountInput;
 )]
 pub async fn deactivate_account(
     body: Json<DeactivateAccountInput>,
-    auth: AccessFull,
+    auth: AccountStatusScopedAccess,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
-    crate::apis::assert_account_scope(
-        &auth.access.credentials,
-        "status",
-        crate::oauth_scope::AccountAction::Manage,
-    )?;
     let did = auth.access.credentials.unwrap().did.unwrap();
     let DeactivateAccountInput { delete_after } = body.into_inner();
     match account_manager.deactivate_account(&did, delete_after).await {

--- a/rsky-pds/src/apis/com/atproto/server/deactivate_account.rs
+++ b/rsky-pds/src/apis/com/atproto/server/deactivate_account.rs
@@ -16,6 +16,11 @@ pub async fn deactivate_account(
     auth: AccessFull,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
+    crate::apis::assert_account_scope(
+        &auth.access.credentials,
+        "status",
+        crate::oauth_scope::AccountAction::Manage,
+    )?;
     let did = auth.access.credentials.unwrap().did.unwrap();
     let DeactivateAccountInput { delete_after } = body.into_inner();
     match account_manager.deactivate_account(&did, delete_after).await {

--- a/rsky-pds/src/apis/com/atproto/server/update_email.rs
+++ b/rsky-pds/src/apis/com/atproto/server/update_email.rs
@@ -1,7 +1,7 @@
 use crate::account_manager::helpers::account::{AccountHelperError, AvailabilityFlags};
 use crate::account_manager::{AccountManager, UpdateEmailOpts};
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessFull;
+use crate::auth_verifier::EmailScopedAccess;
 use crate::models::models::EmailTokenPurpose;
 use anyhow::{bail, Result};
 use rocket::serde::json::Json;
@@ -9,7 +9,7 @@ use rsky_lexicon::com::atproto::server::UpdateEmailInput;
 
 async fn inner_update_email(
     body: Json<UpdateEmailInput>,
-    auth: AccessFull,
+    auth: EmailScopedAccess,
     account_manager: AccountManager,
 ) -> Result<()> {
     let did = auth.access.credentials.unwrap().did.unwrap();
@@ -63,14 +63,9 @@ async fn inner_update_email(
 )]
 pub async fn update_email(
     body: Json<UpdateEmailInput>,
-    auth: AccessFull,
+    auth: EmailScopedAccess,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
-    crate::apis::assert_account_scope(
-        &auth.access.credentials,
-        "email",
-        crate::oauth_scope::AccountAction::Manage,
-    )?;
     match inner_update_email(body, auth, account_manager).await {
         Ok(_) => Ok(()),
         Err(error) => {

--- a/rsky-pds/src/apis/com/atproto/server/update_email.rs
+++ b/rsky-pds/src/apis/com/atproto/server/update_email.rs
@@ -66,6 +66,11 @@ pub async fn update_email(
     auth: AccessFull,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
+    crate::apis::assert_account_scope(
+        &auth.access.credentials,
+        "email",
+        crate::oauth_scope::AccountAction::Manage,
+    )?;
     match inner_update_email(body, auth, account_manager).await {
         Ok(_) => Ok(()),
         Err(error) => {

--- a/rsky-pds/src/apis/mod.rs
+++ b/rsky-pds/src/apis/mod.rs
@@ -2,8 +2,8 @@ use crate::auth_verifier::{AccessStandard, AuthError, AuthScope, Credentials};
 use crate::handle;
 use crate::handle::errors::ErrorKind;
 use crate::pipethrough::{
-    pipethrough_error, pipethrough_procedure, pipethrough_procedure_post, ProxyRequest,
-    PRIVILEGED_METHODS,
+    assert_rpc_scope, pipethrough_error, pipethrough_procedure, pipethrough_procedure_post,
+    ProxyRequest, PRIVILEGED_METHODS,
 };
 use anyhow::{Error, Result};
 use rocket::http::{ContentType, Header, Status};
@@ -83,6 +83,82 @@ pub fn assert_repo_scope(
     }
 }
 
+/// Enforce a granular OAuth session's `blob:` scope on a blob upload.
+///
+/// Same shape as [`assert_repo_scope`]: a session carrying `blob:` grants but
+/// no `transition:generic` is confined to the accepted mime patterns those
+/// grants name. Legacy transition sessions and app passwords carry no
+/// `blob:` grant and are unaffected.
+pub fn assert_blob_scope(credentials: &Option<Credentials>, mime: &str) -> Result<(), ApiError> {
+    let Some(granted) = credentials.as_ref().and_then(|c| c.granted_scopes.as_ref()) else {
+        return Ok(());
+    };
+    let scopes = crate::oauth_scope::GrantedScopes::parse(granted);
+    if !scopes.is_granular_blob_session() {
+        return Ok(());
+    }
+    if scopes.allows_blob(mime) {
+        Ok(())
+    } else {
+        Err(ApiError::InsufficientScope(format!(
+            "Token scope does not permit uploading blobs of type {mime}"
+        )))
+    }
+}
+
+/// Enforce a granular OAuth session's `identity:` scope on an identity write
+/// (e.g. `com.atproto.identity.updateHandle`).
+///
+/// Same shape as [`assert_repo_scope`]: a session carrying `identity:`
+/// grants but no `transition:generic` is confined to the attributes those
+/// grants name.
+pub fn assert_identity_scope(
+    credentials: &Option<Credentials>,
+    attr: &str,
+) -> Result<(), ApiError> {
+    let Some(granted) = credentials.as_ref().and_then(|c| c.granted_scopes.as_ref()) else {
+        return Ok(());
+    };
+    let scopes = crate::oauth_scope::GrantedScopes::parse(granted);
+    if !scopes.is_granular_identity_session() {
+        return Ok(());
+    }
+    if scopes.allows_identity(attr) {
+        Ok(())
+    } else {
+        Err(ApiError::InsufficientScope(format!(
+            "Token scope does not permit changing identity attribute {attr}"
+        )))
+    }
+}
+
+/// Enforce a granular OAuth session's `account:` scope on an account-level
+/// mutation (email, deactivation/activation, PLC rotation).
+///
+/// Same shape as [`assert_repo_scope`]: a session carrying `account:` grants
+/// but no `transition:generic` is confined to the attribute/action pairs
+/// those grants name.
+pub fn assert_account_scope(
+    credentials: &Option<Credentials>,
+    attr: &str,
+    action: crate::oauth_scope::AccountAction,
+) -> Result<(), ApiError> {
+    let Some(granted) = credentials.as_ref().and_then(|c| c.granted_scopes.as_ref()) else {
+        return Ok(());
+    };
+    let scopes = crate::oauth_scope::GrantedScopes::parse(granted);
+    if !scopes.is_granular_account_session() {
+        return Ok(());
+    }
+    if scopes.allows_account(attr, action) {
+        Ok(())
+    } else {
+        Err(ApiError::InsufficientScope(format!(
+            "Token scope does not permit {action:?} on account attribute {attr}"
+        )))
+    }
+}
+
 // Lower ranks have higher presidence
 #[tracing::instrument(skip_all)]
 #[allow(unused_variables)]
@@ -94,6 +170,12 @@ pub async fn bsky_api_get_forwarder(
     req: ProxyRequest<'_>,
 ) -> Result<ProxyResponder, ApiError> {
     assert_valid_token_method(&nsid.0, &auth.access.credentials)?;
+    let granted_scopes = auth
+        .access
+        .credentials
+        .as_ref()
+        .and_then(|c| c.granted_scopes.clone());
+    assert_rpc_scope(&granted_scopes, &req).await?;
     let requester: Option<String> = match auth.access.credentials {
         None => None,
         Some(credentials) => credentials.did,
@@ -126,6 +208,12 @@ pub async fn bsky_api_post_forwarder(
     req: ProxyRequest<'_>,
 ) -> Result<ProxyResponder, ApiError> {
     assert_valid_token_method(&nsid.0, &auth.access.credentials)?;
+    let granted_scopes = auth
+        .access
+        .credentials
+        .as_ref()
+        .and_then(|c| c.granted_scopes.clone());
+    assert_rpc_scope(&granted_scopes, &req).await?;
     let requester: Option<String> = match auth.access.credentials {
         None => None,
         Some(credentials) => credentials.did,
@@ -587,3 +675,92 @@ impl From<handle::errors::Error> for ApiError {
 pub mod app;
 pub mod com;
 pub mod community;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn creds(granted: &[&str]) -> Option<Credentials> {
+        Some(Credentials {
+            r#type: "oauth".to_string(),
+            did: Some("did:plc:test".to_string()),
+            scope: Some(AuthScope::AppPass),
+            granted_scopes: Some(granted.iter().map(|s| s.to_string()).collect()),
+            audience: None,
+            token_id: None,
+            aud: None,
+            iss: None,
+            is_privileged: None,
+        })
+    }
+
+    #[test]
+    fn blob_scope_allows_and_denies_by_mime() {
+        let allowed = creds(&["atproto", "blob:image/*"]);
+        assert!(assert_blob_scope(&allowed, "image/png").is_ok());
+        assert!(matches!(
+            assert_blob_scope(&allowed, "video/mp4"),
+            Err(ApiError::InsufficientScope(_))
+        ));
+
+        // No `blob:` grant at all: enforcement is opt-in per resource, so
+        // this passes through unrestricted (same as `assert_repo_scope`).
+        let no_blob_grant = creds(&["atproto", "repo:app.bsky.feed.post"]);
+        assert!(assert_blob_scope(&no_blob_grant, "video/mp4").is_ok());
+
+        // Legacy app-password sessions carry no `granted_scopes` at all.
+        assert!(assert_blob_scope(&None, "video/mp4").is_ok());
+    }
+
+    #[test]
+    fn identity_scope_allows_and_denies_by_attribute() {
+        let allowed = creds(&["atproto", "identity:handle"]);
+        assert!(assert_identity_scope(&allowed, "handle").is_ok());
+
+        let wrong_attr = creds(&["atproto", "identity:invalid"]);
+        assert!(matches!(
+            assert_identity_scope(&wrong_attr, "handle"),
+            Err(ApiError::InsufficientScope(_))
+        ));
+
+        let no_identity_grant = creds(&["atproto", "repo:app.bsky.feed.post"]);
+        assert!(assert_identity_scope(&no_identity_grant, "handle").is_ok());
+    }
+
+    #[test]
+    fn account_scope_allows_and_denies_by_attribute_and_action() {
+        let manage = creds(&["atproto", "account:email?action=manage"]);
+        assert!(
+            assert_account_scope(&manage, "email", crate::oauth_scope::AccountAction::Manage)
+                .is_ok()
+        );
+
+        let read_only = creds(&["atproto", "account:email"]);
+        assert!(matches!(
+            assert_account_scope(
+                &read_only,
+                "email",
+                crate::oauth_scope::AccountAction::Manage
+            ),
+            Err(ApiError::InsufficientScope(_))
+        ));
+
+        let wrong_attr = creds(&["atproto", "account:status?action=manage"]);
+        assert!(matches!(
+            assert_account_scope(
+                &wrong_attr,
+                "email",
+                crate::oauth_scope::AccountAction::Manage
+            ),
+            Err(ApiError::InsufficientScope(_))
+        ));
+
+        let no_account_grant = creds(&["atproto", "repo:app.bsky.feed.post"]);
+        assert!(assert_account_scope(
+            &no_account_grant,
+            "email",
+            crate::oauth_scope::AccountAction::Manage
+        )
+        .is_ok());
+    }
+}

--- a/rsky-pds/src/apis/mod.rs
+++ b/rsky-pds/src/apis/mod.rs
@@ -144,6 +144,13 @@ pub fn assert_identity_scope(
 
 /// Enforce an OAuth session's `account:` scope on an account-level mutation
 /// (email, deactivation/activation, PLC rotation).
+///
+/// Like `identity:`, this takes no `transition:generic` exemption. The OAuth
+/// spec grants that scope "no account management actions: change handle,
+/// change email, delete or deactivate account, migrate account", which is
+/// exactly the surface these guards cover -- every one of them asks for
+/// `Manage`. `transition:email` is unaffected: it confers a `read` on the
+/// address, which no caller here requests.
 pub fn assert_account_scope(
     credentials: &Option<Credentials>,
     attr: &str,
@@ -151,7 +158,7 @@ pub fn assert_account_scope(
 ) -> Result<(), ApiError> {
     assert_scope(
         credentials,
-        true,
+        false,
         |scopes| scopes.allows_account(attr, action),
         || format!("Token scope does not permit {action:?} on account attribute {attr}"),
     )
@@ -826,12 +833,21 @@ mod tests {
     /// change its handle.
     #[test]
     fn a_transition_generic_session_keeps_its_legacy_reach() {
+        // Repo writes, blob uploads and service proxying, per the OAuth spec's
+        // definition of the scope -- and no account management: not the handle,
+        // not the email, not deactivation, not migration.
         let transition = creds(&["atproto", "transition:generic"]);
-        assert_eq!(denials(&transition), [false, false, false, true, false]);
+        assert_eq!(denials(&transition), [false, false, false, true, true]);
 
-        // An explicit `identity:` grant alongside it still works.
+        // Explicit grants alongside it still work.
         let with_identity = creds(&["atproto", "transition:generic", "identity:handle"]);
         assert!(assert_identity_scope(&with_identity, "handle").is_ok());
+        let with_account = creds(&[
+            "atproto",
+            "transition:generic",
+            "account:email?action=manage",
+        ]);
+        assert!(assert_account_scope(&with_account, "email", AccountAction::Manage).is_ok());
     }
 
     /// App passwords and legacy access tokens carry no `granted_scopes`;

--- a/rsky-pds/src/apis/mod.rs
+++ b/rsky-pds/src/apis/mod.rs
@@ -55,108 +55,106 @@ pub fn assert_valid_token_method(
     Ok(())
 }
 
-/// Enforce a granular OAuth session's `repo:` scope on a record write.
+/// The granted scopes an enforcement check must consult, or `None` when the
+/// session is not subject to granular scope enforcement at all.
 ///
-/// A session that carries `repo:` grants but no `transition:generic` is
-/// confined to the collections and actions those grants name (proposal 0016
-/// §Scopes). Legacy transition sessions and app passwords carry no `repo:`
-/// grant and are unaffected. Without this a token scoped to one collection
-/// can write any collection.
+/// The gate is the *auth source*, not the scope content: a session carrying
+/// `granted_scopes` is an OAuth session and every resource check applies to
+/// it, so a session that names no grant for a resource is denied rather than
+/// left unrestricted. App passwords and legacy access tokens carry no
+/// `granted_scopes` and are unaffected. Gating on "does this session hold a
+/// grant of this kind" instead would make absence of a grant mean unlimited
+/// access, and would let a permission set that expands to nothing disengage
+/// enforcement entirely.
+///
+/// `transition_exempt` names the resources a legacy `transition:generic`
+/// session may reach without a modern grant, mirroring upstream's
+/// `ScopePermissionsTransition` (`repo`, `blob`, `rpc` -- but not `identity`,
+/// which that class deliberately leaves to the base implementation).
+pub(crate) fn scoped_session(
+    granted: Option<&Vec<String>>,
+    transition_exempt: bool,
+) -> Option<crate::oauth_scope::GrantedScopes> {
+    let scopes = crate::oauth_scope::GrantedScopes::parse(granted?);
+    (!(transition_exempt && scopes.has_transition("generic"))).then_some(scopes)
+}
+
+/// Run one resource check behind [`scoped_session`], rendering a refusal as
+/// [`ApiError::InsufficientScope`].
+fn assert_scope(
+    credentials: &Option<Credentials>,
+    transition_exempt: bool,
+    allows: impl FnOnce(&crate::oauth_scope::GrantedScopes) -> bool,
+    denial: impl FnOnce() -> String,
+) -> Result<(), ApiError> {
+    match scoped_session(
+        credentials.as_ref().and_then(|c| c.granted_scopes.as_ref()),
+        transition_exempt,
+    ) {
+        Some(scopes) if !allows(&scopes) => Err(ApiError::InsufficientScope(denial())),
+        _ => Ok(()),
+    }
+}
+
+/// Enforce an OAuth session's `repo:` scope on a record write: the session is
+/// confined to the collections and actions its grants name (proposal 0016
+/// §Scopes).
 pub fn assert_repo_scope(
     credentials: &Option<Credentials>,
     collection: &str,
     action: crate::oauth_scope::RepoAction,
 ) -> Result<(), ApiError> {
-    let Some(granted) = credentials.as_ref().and_then(|c| c.granted_scopes.as_ref()) else {
-        return Ok(());
-    };
-    let scopes = crate::oauth_scope::GrantedScopes::parse(granted);
-    if !scopes.is_granular_repo_session() {
-        return Ok(());
-    }
-    if scopes.allows_repo(collection, action) {
-        Ok(())
-    } else {
-        Err(ApiError::InsufficientScope(format!(
-            "Token scope does not permit {action:?} on {collection}"
-        )))
-    }
+    assert_scope(
+        credentials,
+        true,
+        |scopes| scopes.allows_repo(collection, action),
+        || format!("Token scope does not permit {action:?} on {collection}"),
+    )
 }
 
-/// Enforce a granular OAuth session's `blob:` scope on a blob upload.
-///
-/// Same shape as [`assert_repo_scope`]: a session carrying `blob:` grants but
-/// no `transition:generic` is confined to the accepted mime patterns those
-/// grants name. Legacy transition sessions and app passwords carry no
-/// `blob:` grant and are unaffected.
+/// Enforce an OAuth session's `blob:` scope on a blob upload: the session is
+/// confined to the mime patterns its grants accept.
 pub fn assert_blob_scope(credentials: &Option<Credentials>, mime: &str) -> Result<(), ApiError> {
-    let Some(granted) = credentials.as_ref().and_then(|c| c.granted_scopes.as_ref()) else {
-        return Ok(());
-    };
-    let scopes = crate::oauth_scope::GrantedScopes::parse(granted);
-    if !scopes.is_granular_blob_session() {
-        return Ok(());
-    }
-    if scopes.allows_blob(mime) {
-        Ok(())
-    } else {
-        Err(ApiError::InsufficientScope(format!(
-            "Token scope does not permit uploading blobs of type {mime}"
-        )))
-    }
+    assert_scope(
+        credentials,
+        true,
+        |scopes| scopes.allows_blob(mime),
+        || format!("Token scope does not permit uploading blobs of type {mime}"),
+    )
 }
 
-/// Enforce a granular OAuth session's `identity:` scope on an identity write
-/// (e.g. `com.atproto.identity.updateHandle`).
+/// Enforce an OAuth session's `identity:` scope on an identity write (e.g.
+/// `com.atproto.identity.updateHandle`).
 ///
-/// Same shape as [`assert_repo_scope`]: a session carrying `identity:`
-/// grants but no `transition:generic` is confined to the attributes those
-/// grants name.
+/// Unlike the other resources this takes no `transition:generic` exemption:
+/// upstream's `ScopePermissionsTransition` overrides `allowsRepo`,
+/// `allowsBlob` and `allowsRpc` but leaves `allowsIdentity` alone, so a
+/// legacy transition session must still hold an explicit `identity:` grant.
 pub fn assert_identity_scope(
     credentials: &Option<Credentials>,
     attr: &str,
 ) -> Result<(), ApiError> {
-    let Some(granted) = credentials.as_ref().and_then(|c| c.granted_scopes.as_ref()) else {
-        return Ok(());
-    };
-    let scopes = crate::oauth_scope::GrantedScopes::parse(granted);
-    if !scopes.is_granular_identity_session() {
-        return Ok(());
-    }
-    if scopes.allows_identity(attr) {
-        Ok(())
-    } else {
-        Err(ApiError::InsufficientScope(format!(
-            "Token scope does not permit changing identity attribute {attr}"
-        )))
-    }
+    assert_scope(
+        credentials,
+        false,
+        |scopes| scopes.allows_identity(attr),
+        || format!("Token scope does not permit changing identity attribute {attr}"),
+    )
 }
 
-/// Enforce a granular OAuth session's `account:` scope on an account-level
-/// mutation (email, deactivation/activation, PLC rotation).
-///
-/// Same shape as [`assert_repo_scope`]: a session carrying `account:` grants
-/// but no `transition:generic` is confined to the attribute/action pairs
-/// those grants name.
+/// Enforce an OAuth session's `account:` scope on an account-level mutation
+/// (email, deactivation/activation, PLC rotation).
 pub fn assert_account_scope(
     credentials: &Option<Credentials>,
     attr: &str,
     action: crate::oauth_scope::AccountAction,
 ) -> Result<(), ApiError> {
-    let Some(granted) = credentials.as_ref().and_then(|c| c.granted_scopes.as_ref()) else {
-        return Ok(());
-    };
-    let scopes = crate::oauth_scope::GrantedScopes::parse(granted);
-    if !scopes.is_granular_account_session() {
-        return Ok(());
-    }
-    if scopes.allows_account(attr, action) {
-        Ok(())
-    } else {
-        Err(ApiError::InsufficientScope(format!(
-            "Token scope does not permit {action:?} on account attribute {attr}"
-        )))
-    }
+    assert_scope(
+        credentials,
+        true,
+        |scopes| scopes.allows_account(attr, action),
+        || format!("Token scope does not permit {action:?} on account attribute {attr}"),
+    )
 }
 
 // Lower ranks have higher presidence
@@ -679,6 +677,9 @@ pub mod community;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::oauth_scope::{AccountAction, RepoAction};
+
+    const POST: &str = "app.bsky.feed.post";
 
     fn creds(granted: &[&str]) -> Option<Credentials> {
         Some(Credentials {
@@ -694,6 +695,27 @@ mod tests {
         })
     }
 
+    /// The four synchronous resource checks, plus the gate + `allows_rpc`
+    /// pair that `pipethrough::assert_rpc_scope` performs once it has
+    /// resolved an audience (that helper needs a live `ProxyRequest`, so its
+    /// scope decision is exercised here rather than through the route).
+    fn denials(credentials: &Option<Credentials>) -> [bool; 5] {
+        let rpc_denied = match scoped_session(
+            credentials.as_ref().and_then(|c| c.granted_scopes.as_ref()),
+            true,
+        ) {
+            Some(scopes) => !scopes.allows_rpc("app.bsky.feed.getTimeline", "did:web:api.example"),
+            None => false,
+        };
+        [
+            assert_repo_scope(credentials, POST, RepoAction::Create).is_err(),
+            assert_blob_scope(credentials, "image/png").is_err(),
+            rpc_denied,
+            assert_identity_scope(credentials, "handle").is_err(),
+            assert_account_scope(credentials, "email", AccountAction::Manage).is_err(),
+        ]
+    }
+
     #[test]
     fn blob_scope_allows_and_denies_by_mime() {
         let allowed = creds(&["atproto", "blob:image/*"]);
@@ -703,10 +725,14 @@ mod tests {
             Err(ApiError::InsufficientScope(_))
         ));
 
-        // No `blob:` grant at all: enforcement is opt-in per resource, so
-        // this passes through unrestricted (same as `assert_repo_scope`).
+        // No `blob:` grant at all. Enforcement is gated on the auth source,
+        // not on whether the session happens to hold a grant of this kind, so
+        // absence of the grant is a denial.
         let no_blob_grant = creds(&["atproto", "repo:app.bsky.feed.post"]);
-        assert!(assert_blob_scope(&no_blob_grant, "video/mp4").is_ok());
+        assert!(matches!(
+            assert_blob_scope(&no_blob_grant, "video/mp4"),
+            Err(ApiError::InsufficientScope(_))
+        ));
 
         // Legacy app-password sessions carry no `granted_scopes` at all.
         assert!(assert_blob_scope(&None, "video/mp4").is_ok());
@@ -724,43 +750,94 @@ mod tests {
         ));
 
         let no_identity_grant = creds(&["atproto", "repo:app.bsky.feed.post"]);
-        assert!(assert_identity_scope(&no_identity_grant, "handle").is_ok());
+        assert!(matches!(
+            assert_identity_scope(&no_identity_grant, "handle"),
+            Err(ApiError::InsufficientScope(_))
+        ));
     }
 
     #[test]
     fn account_scope_allows_and_denies_by_attribute_and_action() {
         let manage = creds(&["atproto", "account:email?action=manage"]);
-        assert!(
-            assert_account_scope(&manage, "email", crate::oauth_scope::AccountAction::Manage)
-                .is_ok()
-        );
+        assert!(assert_account_scope(&manage, "email", AccountAction::Manage).is_ok());
 
         let read_only = creds(&["atproto", "account:email"]);
         assert!(matches!(
-            assert_account_scope(
-                &read_only,
-                "email",
-                crate::oauth_scope::AccountAction::Manage
-            ),
+            assert_account_scope(&read_only, "email", AccountAction::Manage),
             Err(ApiError::InsufficientScope(_))
         ));
 
         let wrong_attr = creds(&["atproto", "account:status?action=manage"]);
         assert!(matches!(
-            assert_account_scope(
-                &wrong_attr,
-                "email",
-                crate::oauth_scope::AccountAction::Manage
-            ),
+            assert_account_scope(&wrong_attr, "email", AccountAction::Manage),
             Err(ApiError::InsufficientScope(_))
         ));
 
         let no_account_grant = creds(&["atproto", "repo:app.bsky.feed.post"]);
-        assert!(assert_account_scope(
-            &no_account_grant,
-            "email",
-            crate::oauth_scope::AccountAction::Manage
-        )
-        .is_ok());
+        assert!(matches!(
+            assert_account_scope(&no_account_grant, "email", AccountAction::Manage),
+            Err(ApiError::InsufficientScope(_))
+        ));
+    }
+
+    /// The original defect: a granular session holding one `repo:` grant and
+    /// nothing else got *unrestricted* access to every other resource,
+    /// because each check gated on whether the session held a grant of that
+    /// same kind.
+    #[test]
+    fn a_repo_only_grant_confers_nothing_on_other_resources() {
+        let repo_only = creds(&["atproto", "repo:app.bsky.feed.post"]);
+        assert!(assert_repo_scope(&repo_only, POST, RepoAction::Create).is_ok());
+        assert_eq!(denials(&repo_only), [false, true, true, true, true]);
+    }
+
+    /// A session granted the base scope and nothing else can do nothing.
+    #[test]
+    fn an_empty_scope_set_is_denied_every_resource() {
+        assert_eq!(denials(&creds(&["atproto"])), [true; 5]);
+    }
+
+    /// `include:` scopes reach these helpers already expanded
+    /// (`permission_set::expand_includes`). One that resolved to nothing --
+    /// an unreachable authority, or a set naming no permissions -- must leave
+    /// the session with no grants, not with every grant.
+    #[test]
+    fn an_include_that_resolved_to_nothing_is_denied_every_resource() {
+        assert_eq!(
+            denials(&creds(&["atproto", "include:app.example.nothing"])),
+            [true; 5]
+        );
+    }
+
+    /// An unparseable scope string is inert: it can never be the reason a
+    /// session gets access it was not granted.
+    #[test]
+    fn an_unparseable_scope_widens_nothing() {
+        assert_eq!(
+            denials(&creds(&["atproto", "not-a-scope-this-server-knows"])),
+            [true; 5]
+        );
+    }
+
+    /// Backward compatibility for legacy `transition:generic` sessions,
+    /// following upstream's `ScopePermissionsTransition`: it overrides
+    /// `allowsRepo`, `allowsBlob` and `allowsRpc`, but not `allowsIdentity`,
+    /// so a transition session still needs an explicit `identity:` grant to
+    /// change its handle.
+    #[test]
+    fn a_transition_generic_session_keeps_its_legacy_reach() {
+        let transition = creds(&["atproto", "transition:generic"]);
+        assert_eq!(denials(&transition), [false, false, false, true, false]);
+
+        // An explicit `identity:` grant alongside it still works.
+        let with_identity = creds(&["atproto", "transition:generic", "identity:handle"]);
+        assert!(assert_identity_scope(&with_identity, "handle").is_ok());
+    }
+
+    /// App passwords and legacy access tokens carry no `granted_scopes`;
+    /// nothing here applies to them.
+    #[test]
+    fn a_session_without_granted_scopes_is_unaffected() {
+        assert_eq!(denials(&None), [false; 5]);
     }
 }

--- a/rsky-pds/src/auth_verifier.rs
+++ b/rsky-pds/src/auth_verifier.rs
@@ -512,6 +512,227 @@ impl<'r> FromRequest<'r> for AccessStandardCheckTakedown {
     }
 }
 
+// Scoped-access guards
+// ---------------------
+//
+// Each of these folds a proposal-0011 resource-scope assertion into the
+// request guard itself, wrapping one of the plain `Access*` guards above.
+// Before this, a handler took a plain access guard and made a separate
+// `assert_*_scope` call as the first line of its body -- easy to add when a
+// route is first written, just as easy to forget when a route is copied or
+// refactored later, and invisible at the type level either way. A route that
+// asks for one of these can only get a `did` by way of the assertion having
+// already passed, closing the same "guard succeeded, follow-up check silently
+// skipped" failure mode the service-auth fix in PR #252 closed elsewhere.
+//
+// `assert_*_scope` (in `crate::apis`) is unchanged; this only relocates where
+// it is called from.
+
+/// A guard whose only content is an already-verified [`AccessOutput`],
+/// implemented by every plain `Access*` guard above. Lets a scoped-access
+/// guard be generic over which one it wraps instead of duplicating each
+/// guard's own session/takedown/deactivation handling.
+trait AccessGuard {
+    fn into_access(self) -> AccessOutput;
+}
+
+impl AccessGuard for AccessStandard {
+    fn into_access(self) -> AccessOutput {
+        self.access
+    }
+}
+
+impl AccessGuard for AccessStandardCheckTakedown {
+    fn into_access(self) -> AccessOutput {
+        self.access
+    }
+}
+
+impl AccessGuard for AccessFull {
+    fn into_access(self) -> AccessOutput {
+        self.access
+    }
+}
+
+/// Runs `Base`'s own request-guard logic unchanged, then applies `assert` to
+/// the credentials it produces. `assert` failing is the only way this can
+/// still fail once `Base` has already succeeded.
+async fn assert_scoped<'r, Base>(
+    req: &'r Request<'_>,
+    assert: impl FnOnce(&Option<Credentials>) -> Result<(), ApiError>,
+) -> Outcome<AccessOutput, ApiError>
+where
+    Base: AccessGuard + FromRequest<'r, Error = AuthError>,
+{
+    match Base::from_request(req).await {
+        Outcome::Success(base) => {
+            let access = base.into_access();
+            match assert(&access.credentials) {
+                Ok(()) => Outcome::Success(access),
+                Err(api_error) => {
+                    req.local_cache(|| Some(api_error.clone()));
+                    Outcome::Error((Status::Forbidden, api_error))
+                }
+            }
+        }
+        Outcome::Error((status, auth_error)) => {
+            let api_error = ApiError::from(&auth_error);
+            req.local_cache(|| Some(api_error.clone()));
+            Outcome::Error((status, api_error))
+        }
+        Outcome::Forward(level) => Outcome::Forward(level),
+    }
+}
+
+/// [`AccessStandardCheckTakedown`] narrowed by the session's `blob:` scope
+/// (proposal 0011), for `com.atproto.repo.uploadBlob`. Reads the mime type
+/// straight off the request the same way the route's own `ContentType` guard
+/// does; put `ContentType` ahead of this guard in a route's parameter list so
+/// a request with no content type still gets that guard's own rejection
+/// first.
+pub struct BlobScopedAccess {
+    pub access: AccessOutput,
+}
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for BlobScopedAccess {
+    type Error = ApiError;
+
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let mime = req
+            .content_type()
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        match assert_scoped::<AccessStandardCheckTakedown>(req, |credentials| {
+            crate::apis::assert_blob_scope(credentials, &mime)
+        })
+        .await
+        {
+            Outcome::Success(access) => Outcome::Success(Self { access }),
+            Outcome::Error(error) => Outcome::Error(error),
+            Outcome::Forward(level) => Outcome::Forward(level),
+        }
+    }
+}
+
+/// [`AccessStandardCheckTakedown`] narrowed by the session's `identity:handle`
+/// scope, for `com.atproto.identity.updateHandle`.
+pub struct HandleScopedAccess {
+    pub access: AccessOutput,
+}
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for HandleScopedAccess {
+    type Error = ApiError;
+
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        match assert_scoped::<AccessStandardCheckTakedown>(req, |credentials| {
+            crate::apis::assert_identity_scope(credentials, "handle")
+        })
+        .await
+        {
+            Outcome::Success(access) => Outcome::Success(Self { access }),
+            Outcome::Error(error) => Outcome::Error(error),
+            Outcome::Forward(level) => Outcome::Forward(level),
+        }
+    }
+}
+
+/// [`AccessFull`] narrowed by the session's `account:email?action=manage`
+/// scope, for `com.atproto.server.updateEmail`.
+pub struct EmailScopedAccess {
+    pub access: AccessOutput,
+}
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for EmailScopedAccess {
+    type Error = ApiError;
+
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        match assert_scoped::<AccessFull>(req, |credentials| {
+            crate::apis::assert_account_scope(
+                credentials,
+                "email",
+                crate::oauth_scope::AccountAction::Manage,
+            )
+        })
+        .await
+        {
+            Outcome::Success(access) => Outcome::Success(Self { access }),
+            Outcome::Error(error) => Outcome::Error(error),
+            Outcome::Forward(level) => Outcome::Forward(level),
+        }
+    }
+}
+
+/// [`AccessFull`] narrowed by the session's `account:status?action=manage`
+/// scope, for `com.atproto.server.deactivateAccount`.
+pub struct AccountStatusScopedAccess {
+    pub access: AccessOutput,
+}
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for AccountStatusScopedAccess {
+    type Error = ApiError;
+
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        match assert_scoped::<AccessFull>(req, |credentials| {
+            crate::apis::assert_account_scope(
+                credentials,
+                "status",
+                crate::oauth_scope::AccountAction::Manage,
+            )
+        })
+        .await
+        {
+            Outcome::Success(access) => Outcome::Success(Self { access }),
+            Outcome::Error(error) => Outcome::Error(error),
+            Outcome::Forward(level) => Outcome::Forward(level),
+        }
+    }
+}
+
+/// [`AccessFull`] (the default `Base`) or [`AccessStandard`] narrowed by the
+/// session's `account:repo?action=manage` scope, for the two PLC-rotation
+/// endpoints. `Base` is generic rather than fixed because the two endpoints
+/// keep different, pre-existing access tiers -- `signPlcOperation` requires a
+/// full session (`Base = AccessFull`, the default, so it can be named as
+/// plain `AccountRepoScopedAccess`) while `submitPlcOperation` also accepts
+/// app-password sessions (`Base = AccessStandard`, named explicitly). Both
+/// share this one assertion instead of two copies of it, without silently
+/// widening or narrowing either endpoint's tier to match the other's.
+pub struct AccountRepoScopedAccess<Base = AccessFull> {
+    pub access: AccessOutput,
+    _base: std::marker::PhantomData<Base>,
+}
+
+#[rocket::async_trait]
+impl<'r, Base> FromRequest<'r> for AccountRepoScopedAccess<Base>
+where
+    Base: AccessGuard + FromRequest<'r, Error = AuthError>,
+{
+    type Error = ApiError;
+
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        match assert_scoped::<Base>(req, |credentials| {
+            crate::apis::assert_account_scope(
+                credentials,
+                "repo",
+                crate::oauth_scope::AccountAction::Manage,
+            )
+        })
+        .await
+        {
+            Outcome::Success(access) => Outcome::Success(Self {
+                access,
+                _base: std::marker::PhantomData,
+            }),
+            Outcome::Error(error) => Outcome::Error(error),
+            Outcome::Forward(level) => Outcome::Forward(level),
+        }
+    }
+}
+
 pub struct AccessStandardSignupQueued {
     pub access: AccessOutput,
 }

--- a/rsky-pds/src/oauth_scope.rs
+++ b/rsky-pds/src/oauth_scope.rs
@@ -2,7 +2,8 @@
 //!
 //! ```text
 //! atproto | transition:<name> | repo:<nsid>[?action=...] | blob:<mime-pattern>
-//!         | rpc:<nsid>[?aud=...] | include:<nsid> | space:<...>
+//!         | rpc:<nsid>[?aud=...] | identity:<attr> | account:<attr>[?action=...]
+//!         | include:<nsid> | space:<...>
 //! ```
 //!
 //! This module is pure: parsing and classification only. `space:` forms are
@@ -23,7 +24,18 @@ pub const TRANSITION_PREFIX: &str = "transition:";
 pub const REPO_PREFIX: &str = "repo:";
 pub const BLOB_PREFIX: &str = "blob:";
 pub const RPC_PREFIX: &str = "rpc:";
+pub const IDENTITY_PREFIX: &str = "identity:";
+pub const ACCOUNT_PREFIX: &str = "account:";
 pub const INCLUDE_PREFIX: &str = "include:";
+
+/// The `attr` values an `identity:` scope may name (proposal 0011's
+/// `IdentityPermission` grammar): the account's handle, or a wildcard
+/// covering every identity attribute.
+pub const IDENTITY_ATTRS: [&str; 2] = ["handle", "*"];
+
+/// The `attr` values an `account:` scope may name (proposal 0011's
+/// `AccountPermission` grammar).
+pub const ACCOUNT_ATTRS: [&str; 3] = ["email", "repo", "status"];
 
 /// A single granted scope token.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -38,12 +50,34 @@ pub enum OAuthScope {
     Blob(String),
     /// `rpc:<nsid>` — permission to call a method on another service.
     Rpc(String),
+    /// `identity:<attr>` — permission to read or change an identity
+    /// attribute (currently just the handle), or `identity:*` for all of
+    /// them.
+    Identity(String),
+    /// `account:<attr>[?action=...]` — permission over an account-level
+    /// attribute (`email`, `repo`, or `status`), narrowed to `read` or
+    /// widened to `manage`.
+    Account(String),
     /// `include:<nsid>` — a published permission set, resolved elsewhere.
     Include(String),
     /// `space:<...>` — permissioned-data grants; see [`crate::space_scope`].
     Space(String),
-    /// Anything else. Retained rather than rejected so an unrecognised grant
-    /// narrows access instead of failing the session outright.
+    /// Anything else: a scope string this parser does not recognise.
+    ///
+    /// Retained as a classified variant -- rather than making [`Self::parse`]
+    /// fallible and rejecting the whole scope list -- so a token mixing
+    /// recognised and unrecognised scopes still parses instead of blowing up
+    /// on a form this server doesn't know about yet.
+    ///
+    /// It is inert everywhere a grant is evaluated: [`Self::is_permission_grant`]
+    /// excludes it, and every `is_granular_*_session`/`allows_*` check on
+    /// [`GrantedScopes`] matches a specific typed variant, never this one. So
+    /// an unrecognised scope can never be the reason a session ends up with
+    /// *more* access than its recognised scopes alone would grant -- at most
+    /// it does nothing, and a session carrying only unrecognised scopes (no
+    /// `transition:`, no recognised permission grant) is refused by
+    /// [`crate::auth_verifier::oauth_scopes_to_auth_scope`] rather than
+    /// silently treated as fully authorised.
     Unknown(String),
 }
 
@@ -53,6 +87,15 @@ pub enum RepoAction {
     Create,
     Update,
     Delete,
+}
+
+/// An action named in an `account:` scope. `Manage` implies `Read` (proposal
+/// 0011's `AccountPermission.matches`: a `manage` grant also satisfies a
+/// `read` check).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccountAction {
+    Read,
+    Manage,
 }
 
 /// Parse a `repo:` scope suffix into its collections and actions, applying
@@ -97,6 +140,153 @@ fn parse_repo_scope(suffix: &str) -> (Vec<String>, Vec<RepoAction>) {
     (collections, actions)
 }
 
+/// Split a scope suffix into its positional value and its query string,
+/// matching the same `<positional>` / `?<params>` grammar [`parse_repo_scope`]
+/// uses. Shared by the new resource kinds below; `parse_repo_scope` keeps its
+/// own inline copy so its existing, reference-quality behaviour is untouched.
+fn split_suffix(suffix: &str) -> (Option<&str>, Option<&str>) {
+    match suffix.find('?') {
+        Some(pos) => (
+            Some(&suffix[..pos]).filter(|p| !p.is_empty()),
+            Some(&suffix[pos + 1..]),
+        ),
+        None => (Some(suffix).filter(|p| !p.is_empty()), None),
+    }
+}
+
+/// Parse an `identity:` scope suffix into the attribute it names.
+///
+/// Unlike `repo:`, an empty or unrecognised attribute is not defaulted to a
+/// wildcard: proposal 0011's `IdentityPermission.attr` is required with no
+/// default, so a malformed grant matches nothing rather than matching
+/// everything (see the module docs on why unrecognised input must narrow,
+/// never widen, access).
+fn parse_identity_scope(suffix: &str) -> Option<String> {
+    let (positional, params) = split_suffix(suffix);
+    let attr = match (positional, params) {
+        (Some(attr), None) => attr.to_string(),
+        (None, Some(params)) if !params.is_empty() => {
+            let mut attr = None;
+            for pair in params.split('&') {
+                let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+                if key == "attr" && !value.is_empty() {
+                    attr = Some(value.to_string());
+                } else {
+                    // An `identity:` grant takes no parameter but `attr`
+                    // (proposal 0011 has no `action` for this resource); any
+                    // other key makes the grant unrecognisable, so it must
+                    // deny rather than silently ignore the stray key.
+                    return None;
+                }
+            }
+            attr?
+        }
+        _ => return None,
+    };
+    IDENTITY_ATTRS.contains(&attr.as_str()).then_some(attr)
+}
+
+/// Parse an `account:` scope suffix into the attribute and actions it names,
+/// applying proposal 0011's default (`action=read` when unspecified). An
+/// unrecognised attribute or action denies rather than defaulting wide, for
+/// the same reason as [`parse_identity_scope`].
+fn parse_account_scope(suffix: &str) -> Option<(String, Vec<AccountAction>)> {
+    let (positional, params) = split_suffix(suffix);
+    let mut attr: Option<String> = positional.map(str::to_string);
+    let mut actions: Vec<AccountAction> = Vec::new();
+    if let Some(params) = params {
+        for pair in params.split('&') {
+            let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+            match key {
+                "attr" if attr.is_none() && !value.is_empty() => attr = Some(value.to_string()),
+                "action" => match value {
+                    "read" => actions.push(AccountAction::Read),
+                    "manage" => actions.push(AccountAction::Manage),
+                    _ => return None,
+                },
+                _ => return None,
+            }
+        }
+    }
+    let attr = attr?;
+    if !ACCOUNT_ATTRS.contains(&attr.as_str()) {
+        return None;
+    }
+    if actions.is_empty() {
+        actions.push(AccountAction::Read);
+    }
+    Some((attr, actions))
+}
+
+/// Parse a `blob:` scope suffix into the mime-type patterns it accepts.
+/// `blob:<pattern>` is shorthand for a single pattern; `blob?accept=...`
+/// (repeated) names several. An empty suffix accepts nothing -- unlike
+/// `repo:`'s bare form, there is no wildcard default here.
+fn parse_blob_scope(suffix: &str) -> Vec<String> {
+    let (positional, params) = split_suffix(suffix);
+    let mut accepts: Vec<String> = Vec::new();
+    if let Some(pattern) = positional {
+        accepts.push(pattern.to_string());
+    }
+    if let Some(params) = params {
+        for pair in params.split('&') {
+            let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+            if key == "accept" && !value.is_empty() {
+                accepts.push(value.to_string());
+            }
+        }
+    }
+    accepts
+}
+
+/// Whether `mime` matches an accepted pattern from a `blob:` scope, mirroring
+/// [`crate::actor_store::blob::accepted_mime`]'s glob semantics (`*/*`,
+/// `type/*`, or an exact match).
+fn mime_matches(accepted: &[String], mime: &str) -> bool {
+    accepted.iter().any(|pattern| {
+        pattern == "*/*"
+            || pattern == mime
+            || pattern
+                .strip_suffix("/*")
+                .is_some_and(|base| mime.starts_with(&format!("{base}/")))
+    })
+}
+
+/// Parse an `rpc:` scope suffix into the methods it names and the audience
+/// it is bound to. `rpc:<nsid>` is shorthand for a single method with no
+/// `aud`; the query form allows several `lxm` values plus one `aud`.
+///
+/// `aud` is required by proposal 0011's `RpcPermission` (no default), so a
+/// grant naming no audience matches nothing. `rpc:*?aud=*` -- every method on
+/// every service -- is rejected outright, matching the reference
+/// implementation's constructor check.
+fn parse_rpc_scope(suffix: &str) -> Option<(Vec<String>, String)> {
+    let (positional, params) = split_suffix(suffix);
+    let mut lxms: Vec<String> = Vec::new();
+    if let Some(lxm) = positional {
+        lxms.push(lxm.to_string());
+    }
+    let mut aud: Option<String> = None;
+    if let Some(params) = params {
+        for pair in params.split('&') {
+            let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+            match key {
+                "lxm" if !value.is_empty() => lxms.push(value.to_string()),
+                "aud" if !value.is_empty() => aud = Some(value.to_string()),
+                _ => {}
+            }
+        }
+    }
+    if lxms.is_empty() {
+        return None;
+    }
+    let aud = aud?;
+    if aud == "*" && lxms.iter().any(|l| l == "*") {
+        return None;
+    }
+    Some((lxms, aud))
+}
+
 impl OAuthScope {
     #[must_use]
     pub fn parse(token: &str) -> Self {
@@ -111,6 +301,15 @@ impl OAuthScope {
         if let Some(rest) = token.strip_prefix("repo?") {
             return OAuthScope::Repo(format!("?{rest}"));
         }
+        // `identity` and `account` accept the same named-parameter query
+        // form as `repo?...`, alongside their `identity:`/`account:` colon
+        // shorthand handled by the prefix table below.
+        if let Some(rest) = token.strip_prefix("identity?") {
+            return OAuthScope::Identity(format!("?{rest}"));
+        }
+        if let Some(rest) = token.strip_prefix("account?") {
+            return OAuthScope::Account(format!("?{rest}"));
+        }
         for (prefix, ctor) in [
             (
                 TRANSITION_PREFIX,
@@ -119,6 +318,14 @@ impl OAuthScope {
             (REPO_PREFIX, OAuthScope::Repo as fn(String) -> OAuthScope),
             (BLOB_PREFIX, OAuthScope::Blob as fn(String) -> OAuthScope),
             (RPC_PREFIX, OAuthScope::Rpc as fn(String) -> OAuthScope),
+            (
+                IDENTITY_PREFIX,
+                OAuthScope::Identity as fn(String) -> OAuthScope,
+            ),
+            (
+                ACCOUNT_PREFIX,
+                OAuthScope::Account as fn(String) -> OAuthScope,
+            ),
             (
                 INCLUDE_PREFIX,
                 OAuthScope::Include as fn(String) -> OAuthScope,
@@ -143,6 +350,8 @@ impl OAuthScope {
             OAuthScope::Repo(_)
                 | OAuthScope::Blob(_)
                 | OAuthScope::Rpc(_)
+                | OAuthScope::Identity(_)
+                | OAuthScope::Account(_)
                 | OAuthScope::Include(_)
                 | OAuthScope::Space(_)
         )
@@ -157,6 +366,8 @@ impl fmt::Display for OAuthScope {
             OAuthScope::Repo(v) => write!(f, "{REPO_PREFIX}{v}"),
             OAuthScope::Blob(v) => write!(f, "{BLOB_PREFIX}{v}"),
             OAuthScope::Rpc(v) => write!(f, "{RPC_PREFIX}{v}"),
+            OAuthScope::Identity(v) => write!(f, "{IDENTITY_PREFIX}{v}"),
+            OAuthScope::Account(v) => write!(f, "{ACCOUNT_PREFIX}{v}"),
             OAuthScope::Include(v) => write!(f, "{INCLUDE_PREFIX}{v}"),
             OAuthScope::Space(v) => {
                 write!(f, "{}{v}", crate::space_scope::SPACE_SCOPE_PREFIX)
@@ -227,6 +438,102 @@ impl GrantedScopes {
         })
     }
 
+    /// Whether a granular OAuth session governs blob uploads, mirroring
+    /// [`Self::is_granular_repo_session`] for the `blob:` resource.
+    #[must_use]
+    pub fn is_granular_blob_session(&self) -> bool {
+        !self.has_transition("generic")
+            && self.scopes.iter().any(|s| matches!(s, OAuthScope::Blob(_)))
+    }
+
+    /// Whether some granted `blob:` scope accepts `mime`.
+    #[must_use]
+    pub fn allows_blob(&self, mime: &str) -> bool {
+        self.scopes.iter().any(|s| match s {
+            OAuthScope::Blob(suffix) => mime_matches(&parse_blob_scope(suffix), mime),
+            _ => false,
+        })
+    }
+
+    /// Whether a granular OAuth session governs calls proxied to another
+    /// service, mirroring [`Self::is_granular_repo_session`] for the `rpc:`
+    /// resource.
+    #[must_use]
+    pub fn is_granular_rpc_session(&self) -> bool {
+        !self.has_transition("generic")
+            && self.scopes.iter().any(|s| matches!(s, OAuthScope::Rpc(_)))
+    }
+
+    /// Whether some granted `rpc:` scope permits calling `lxm` on `aud`.
+    #[must_use]
+    pub fn allows_rpc(&self, lxm: &str, aud: &str) -> bool {
+        self.scopes.iter().any(|s| match s {
+            OAuthScope::Rpc(suffix) => match parse_rpc_scope(suffix) {
+                Some((lxms, granted_aud)) => {
+                    let lxm_ok = lxms.iter().any(|l| l == "*" || l == lxm);
+                    let aud_ok = granted_aud == "*" || granted_aud == aud;
+                    lxm_ok && aud_ok
+                }
+                None => false,
+            },
+            _ => false,
+        })
+    }
+
+    /// Whether a granular OAuth session governs identity attribute changes,
+    /// mirroring [`Self::is_granular_repo_session`] for the `identity:`
+    /// resource.
+    #[must_use]
+    pub fn is_granular_identity_session(&self) -> bool {
+        !self.has_transition("generic")
+            && self
+                .scopes
+                .iter()
+                .any(|s| matches!(s, OAuthScope::Identity(_)))
+    }
+
+    /// Whether some granted `identity:` scope permits acting on `attr`
+    /// (`"handle"`, currently the only recognised attribute).
+    #[must_use]
+    pub fn allows_identity(&self, attr: &str) -> bool {
+        self.scopes.iter().any(|s| match s {
+            OAuthScope::Identity(suffix) => match parse_identity_scope(suffix) {
+                Some(granted) => granted == "*" || granted == attr,
+                None => false,
+            },
+            _ => false,
+        })
+    }
+
+    /// Whether a granular OAuth session governs account-level mutations,
+    /// mirroring [`Self::is_granular_repo_session`] for the `account:`
+    /// resource.
+    #[must_use]
+    pub fn is_granular_account_session(&self) -> bool {
+        !self.has_transition("generic")
+            && self
+                .scopes
+                .iter()
+                .any(|s| matches!(s, OAuthScope::Account(_)))
+    }
+
+    /// Whether some granted `account:` scope permits `action` on `attr`
+    /// (`email`, `repo`, or `status`). A `manage` grant also satisfies a
+    /// `read` check (proposal 0011 §AccountPermission).
+    #[must_use]
+    pub fn allows_account(&self, attr: &str, action: AccountAction) -> bool {
+        self.scopes.iter().any(|s| match s {
+            OAuthScope::Account(suffix) => match parse_account_scope(suffix) {
+                Some((granted_attr, actions)) => {
+                    granted_attr == attr
+                        && (actions.contains(&AccountAction::Manage) || actions.contains(&action))
+                }
+                None => false,
+            },
+            _ => false,
+        })
+    }
+
     /// The `space:` grant strings, for [`crate::space_scope`] to evaluate.
     #[must_use]
     pub fn space_grants(&self) -> Vec<String> {
@@ -270,6 +577,14 @@ mod tests {
             OAuthScope::Rpc("com.example.method".into())
         );
         assert_eq!(
+            OAuthScope::parse("identity:handle"),
+            OAuthScope::Identity("handle".into())
+        );
+        assert_eq!(
+            OAuthScope::parse("account:email?action=manage"),
+            OAuthScope::Account("email?action=manage".into())
+        );
+        assert_eq!(
             OAuthScope::parse("include:app.bulleted.authFull"),
             OAuthScope::Include("app.bulleted.authFull".into())
         );
@@ -291,6 +606,10 @@ mod tests {
             "repo:app.bsky.feed.post",
             "blob:image/*",
             "rpc:com.example.method",
+            "identity:handle",
+            "identity:*",
+            "account:email",
+            "account:email?action=manage",
             "include:app.bulleted.authFull",
             "space:app.bulleted.space?action=read",
             "something-else",
@@ -305,6 +624,9 @@ mod tests {
         assert!(!OAuthScope::parse("transition:generic").is_permission_grant());
         assert!(OAuthScope::parse("repo:app.bsky.feed.post").is_permission_grant());
         assert!(OAuthScope::parse("blob:image/*").is_permission_grant());
+        assert!(OAuthScope::parse("rpc:com.example.method").is_permission_grant());
+        assert!(OAuthScope::parse("identity:handle").is_permission_grant());
+        assert!(OAuthScope::parse("account:email").is_permission_grant());
         assert!(OAuthScope::parse("include:app.bulleted.authFull").is_permission_grant());
         assert!(OAuthScope::parse("space:app.bulleted.space").is_permission_grant());
         assert!(!OAuthScope::parse("nonsense").is_permission_grant());
@@ -380,5 +702,171 @@ mod tests {
         assert!(scopes.has_atproto());
         assert!(scopes.has_transition("generic"));
         assert!(!scopes.has_permission_grant());
+    }
+
+    #[test]
+    fn identity_scope_parses_valid_and_rejects_invalid_forms() {
+        // Positional shorthand, the primary form.
+        assert_eq!(parse_identity_scope("handle"), Some("handle".to_string()));
+        assert_eq!(parse_identity_scope("*"), Some("*".to_string()));
+        // Named query form is equivalent.
+        assert_eq!(
+            parse_identity_scope("?attr=handle"),
+            Some("handle".to_string())
+        );
+        // Unrecognised attribute, empty suffix, and a stray parameter
+        // (this resource takes no `action`) all deny rather than default.
+        assert_eq!(parse_identity_scope("invalid"), None);
+        assert_eq!(parse_identity_scope(""), None);
+        assert_eq!(parse_identity_scope("handle?action=manage"), None);
+    }
+
+    #[test]
+    fn account_scope_parses_valid_and_rejects_invalid_forms() {
+        assert_eq!(
+            parse_account_scope("email"),
+            Some(("email".to_string(), vec![AccountAction::Read]))
+        );
+        assert_eq!(
+            parse_account_scope("email?action=manage"),
+            Some(("email".to_string(), vec![AccountAction::Manage]))
+        );
+        assert_eq!(
+            parse_account_scope("repo?action=manage"),
+            Some(("repo".to_string(), vec![AccountAction::Manage]))
+        );
+        assert_eq!(
+            parse_account_scope("?attr=status&action=manage"),
+            Some(("status".to_string(), vec![AccountAction::Manage]))
+        );
+        // Unrecognised attribute or action, and a bare/empty suffix, deny.
+        assert_eq!(parse_account_scope("invalid"), None);
+        assert_eq!(parse_account_scope("email?action=invalid"), None);
+        assert_eq!(parse_account_scope(""), None);
+        assert_eq!(parse_account_scope("?action=manage"), None);
+    }
+
+    #[test]
+    fn identity_scope_enforces_the_granted_attribute() {
+        let g = GrantedScopes::parse(&["atproto".into(), "identity:handle".into()]);
+        assert!(g.is_granular_identity_session());
+        assert!(g.allows_identity("handle"));
+
+        // Wildcard covers every attribute.
+        let g = GrantedScopes::parse(&["atproto".into(), "identity:*".into()]);
+        assert!(g.allows_identity("handle"));
+
+        // A session without an `identity:` grant is not a granular identity
+        // session (enforcement is opt-in per resource, matching the `repo:`
+        // pattern).
+        let g = GrantedScopes::parse(&["atproto".into(), "repo:app.bsky.feed.post".into()]);
+        assert!(!g.is_granular_identity_session());
+
+        // An invalid `identity:` grant is still classified (so it engages
+        // restriction) but permits nothing.
+        let g = GrantedScopes::parse(&["atproto".into(), "identity:invalid".into()]);
+        assert!(g.is_granular_identity_session());
+        assert!(!g.allows_identity("handle"));
+    }
+
+    #[test]
+    fn account_scope_enforces_attribute_and_action() {
+        let g = GrantedScopes::parse(&["atproto".into(), "account:email?action=manage".into()]);
+        assert!(g.is_granular_account_session());
+        assert!(g.allows_account("email", AccountAction::Manage));
+        assert!(g.allows_account("email", AccountAction::Read)); // manage implies read
+        assert!(!g.allows_account("status", AccountAction::Manage));
+
+        // Default action is `read`; it does not satisfy a `manage` check.
+        let g = GrantedScopes::parse(&["atproto".into(), "account:email".into()]);
+        assert!(g.allows_account("email", AccountAction::Read));
+        assert!(!g.allows_account("email", AccountAction::Manage));
+    }
+
+    #[test]
+    fn blob_scope_enforces_the_granted_mime_pattern() {
+        let g = GrantedScopes::parse(&["atproto".into(), "blob:image/*".into()]);
+        assert!(g.is_granular_blob_session());
+        assert!(g.allows_blob("image/png"));
+        assert!(!g.allows_blob("video/mp4"));
+
+        let g = GrantedScopes::parse(&["atproto".into(), "blob:*/*".into()]);
+        assert!(g.allows_blob("video/mp4"));
+
+        // Multiple accepted patterns via the query form.
+        let g = GrantedScopes::parse(&[
+            "atproto".into(),
+            "blob:?accept=image/png&accept=video/mp4".into(),
+        ]);
+        assert!(g.allows_blob("image/png"));
+        assert!(g.allows_blob("video/mp4"));
+        assert!(!g.allows_blob("text/plain"));
+    }
+
+    #[test]
+    fn rpc_scope_enforces_method_and_audience() {
+        let g = GrantedScopes::parse(&[
+            "atproto".into(),
+            "rpc:com.example.method?aud=did:web:example.com".into(),
+        ]);
+        assert!(g.is_granular_rpc_session());
+        assert!(g.allows_rpc("com.example.method", "did:web:example.com"));
+        assert!(!g.allows_rpc("com.example.method", "did:web:other.com"));
+        assert!(!g.allows_rpc("com.example.other", "did:web:example.com"));
+
+        // No `aud` named: proposal 0011 requires one, so the grant matches
+        // nothing rather than defaulting to "any service".
+        let g = GrantedScopes::parse(&["atproto".into(), "rpc:com.example.method".into()]);
+        assert!(!g.allows_rpc("com.example.method", "did:web:example.com"));
+
+        // `rpc:*?aud=*` is forbidden outright.
+        let g = GrantedScopes::parse(&["atproto".into(), "rpc:*?aud=*".into()]);
+        assert!(!g.allows_rpc("com.example.method", "did:web:example.com"));
+    }
+
+    /// Regression coverage for the fail-open shape described on
+    /// [`OAuthScope::Unknown`]: a scope string this parser doesn't recognise
+    /// must never be the reason a session ends up with more access than its
+    /// recognised scopes alone would grant.
+    #[test]
+    fn unrecognised_scope_never_widens_access() {
+        let post = "app.bsky.feed.post";
+        let with_junk = GrantedScopes::parse(&[
+            "atproto".into(),
+            format!("repo:{post}"),
+            "totally-unrecognised-scope-string".into(),
+        ]);
+        let without_junk = GrantedScopes::parse(&["atproto".into(), format!("repo:{post}")]);
+        // Identical restriction with or without the unrecognised scope.
+        assert_eq!(
+            with_junk.is_granular_repo_session(),
+            without_junk.is_granular_repo_session()
+        );
+        assert_eq!(
+            with_junk.allows_repo(post, RepoAction::Create),
+            without_junk.allows_repo(post, RepoAction::Create)
+        );
+        assert_eq!(
+            with_junk.allows_repo("app.bsky.feed.like", RepoAction::Create),
+            without_junk.allows_repo("app.bsky.feed.like", RepoAction::Create)
+        );
+        // It doesn't unlock any *other* resource's restriction either.
+        assert!(!with_junk.is_granular_blob_session());
+        assert!(!with_junk.is_granular_rpc_session());
+        assert!(!with_junk.is_granular_identity_session());
+        assert!(!with_junk.is_granular_account_session());
+
+        // A session carrying only unrecognised scopes (plus the mandatory
+        // base scope) is not a valid modern grant and is not a granular
+        // session for any resource either -- it is refused entirely by
+        // `oauth_scopes_to_auth_scope` before it ever reaches these checks.
+        let junk_only =
+            GrantedScopes::parse(&["atproto".into(), "totally-unrecognised-scope-string".into()]);
+        assert!(!junk_only.has_permission_grant());
+        assert!(!junk_only.is_granular_repo_session());
+        assert!(!junk_only.is_granular_blob_session());
+        assert!(!junk_only.is_granular_rpc_session());
+        assert!(!junk_only.is_granular_identity_session());
+        assert!(!junk_only.is_granular_account_session());
     }
 }

--- a/rsky-pds/src/oauth_scope.rs
+++ b/rsky-pds/src/oauth_scope.rs
@@ -70,12 +70,12 @@ pub enum OAuthScope {
     /// on a form this server doesn't know about yet.
     ///
     /// It is inert everywhere a grant is evaluated: [`Self::is_permission_grant`]
-    /// excludes it, and every `is_granular_*_session`/`allows_*` check on
-    /// [`GrantedScopes`] matches a specific typed variant, never this one. So
-    /// an unrecognised scope can never be the reason a session ends up with
-    /// *more* access than its recognised scopes alone would grant -- at most
-    /// it does nothing, and a session carrying only unrecognised scopes (no
-    /// `transition:`, no recognised permission grant) is refused by
+    /// excludes it, and every `allows_*` check on [`GrantedScopes`] matches a
+    /// specific typed variant, never this one. So an unrecognised scope can
+    /// never be the reason a session ends up with *more* access than its
+    /// recognised scopes alone would grant -- at most it does nothing, and a
+    /// session carrying only unrecognised scopes (no `transition:`, no
+    /// recognised permission grant) is refused by
     /// [`crate::auth_verifier::oauth_scopes_to_auth_scope`] rather than
     /// silently treated as fully authorised.
     Unknown(String),
@@ -409,16 +409,6 @@ impl GrantedScopes {
         self.scopes.iter().any(OAuthScope::is_permission_grant)
     }
 
-    /// Whether a granular OAuth session (one carrying `repo:`/permission
-    /// grants but no `transition:generic`) governs this write. Legacy
-    /// transition sessions and app passwords are `None` here and enforced by
-    /// the existing scope model instead.
-    #[must_use]
-    pub fn is_granular_repo_session(&self) -> bool {
-        !self.has_transition("generic")
-            && self.scopes.iter().any(|s| matches!(s, OAuthScope::Repo(_)))
-    }
-
     /// Whether some granted `repo:` scope permits `action` on `collection`.
     ///
     /// `repo:<nsid>` is shorthand for `repo?collection=<nsid>`; a missing
@@ -438,14 +428,6 @@ impl GrantedScopes {
         })
     }
 
-    /// Whether a granular OAuth session governs blob uploads, mirroring
-    /// [`Self::is_granular_repo_session`] for the `blob:` resource.
-    #[must_use]
-    pub fn is_granular_blob_session(&self) -> bool {
-        !self.has_transition("generic")
-            && self.scopes.iter().any(|s| matches!(s, OAuthScope::Blob(_)))
-    }
-
     /// Whether some granted `blob:` scope accepts `mime`.
     #[must_use]
     pub fn allows_blob(&self, mime: &str) -> bool {
@@ -453,15 +435,6 @@ impl GrantedScopes {
             OAuthScope::Blob(suffix) => mime_matches(&parse_blob_scope(suffix), mime),
             _ => false,
         })
-    }
-
-    /// Whether a granular OAuth session governs calls proxied to another
-    /// service, mirroring [`Self::is_granular_repo_session`] for the `rpc:`
-    /// resource.
-    #[must_use]
-    pub fn is_granular_rpc_session(&self) -> bool {
-        !self.has_transition("generic")
-            && self.scopes.iter().any(|s| matches!(s, OAuthScope::Rpc(_)))
     }
 
     /// Whether some granted `rpc:` scope permits calling `lxm` on `aud`.
@@ -480,18 +453,6 @@ impl GrantedScopes {
         })
     }
 
-    /// Whether a granular OAuth session governs identity attribute changes,
-    /// mirroring [`Self::is_granular_repo_session`] for the `identity:`
-    /// resource.
-    #[must_use]
-    pub fn is_granular_identity_session(&self) -> bool {
-        !self.has_transition("generic")
-            && self
-                .scopes
-                .iter()
-                .any(|s| matches!(s, OAuthScope::Identity(_)))
-    }
-
     /// Whether some granted `identity:` scope permits acting on `attr`
     /// (`"handle"`, currently the only recognised attribute).
     #[must_use]
@@ -503,18 +464,6 @@ impl GrantedScopes {
             },
             _ => false,
         })
-    }
-
-    /// Whether a granular OAuth session governs account-level mutations,
-    /// mirroring [`Self::is_granular_repo_session`] for the `account:`
-    /// resource.
-    #[must_use]
-    pub fn is_granular_account_session(&self) -> bool {
-        !self.has_transition("generic")
-            && self
-                .scopes
-                .iter()
-                .any(|s| matches!(s, OAuthScope::Account(_)))
     }
 
     /// Whether some granted `account:` scope permits `action` on `attr`
@@ -666,7 +615,6 @@ mod tests {
 
         // A collection-limited grant permits only that collection.
         let g = GrantedScopes::parse(&["atproto".into(), format!("repo:{post}")]);
-        assert!(g.is_granular_repo_session());
         assert!(g.allows_repo(post, RepoAction::Create));
         assert!(g.allows_repo(post, RepoAction::Delete));
         assert!(!g.allows_repo(like, RepoAction::Create));
@@ -680,10 +628,10 @@ mod tests {
         let g = GrantedScopes::parse(&["atproto".into(), "repo:*".into()]);
         assert!(g.allows_repo(like, RepoAction::Update));
 
-        // A legacy transition session is not a granular repo session and is
-        // enforced by the app-password model instead.
+        // A legacy transition session names no `repo:` grant of its own; the
+        // enforcement helper exempts it rather than this parser.
         let g = GrantedScopes::parse(&["atproto".into(), "transition:generic".into()]);
-        assert!(!g.is_granular_repo_session());
+        assert!(!g.allows_repo(post, RepoAction::Create));
 
         // Multi-valued collections in query form.
         let g = GrantedScopes::parse(&[
@@ -749,30 +697,25 @@ mod tests {
     #[test]
     fn identity_scope_enforces_the_granted_attribute() {
         let g = GrantedScopes::parse(&["atproto".into(), "identity:handle".into()]);
-        assert!(g.is_granular_identity_session());
         assert!(g.allows_identity("handle"));
 
         // Wildcard covers every attribute.
         let g = GrantedScopes::parse(&["atproto".into(), "identity:*".into()]);
         assert!(g.allows_identity("handle"));
 
-        // A session without an `identity:` grant is not a granular identity
-        // session (enforcement is opt-in per resource, matching the `repo:`
-        // pattern).
+        // A session holding some other resource's grant permits no identity
+        // attribute.
         let g = GrantedScopes::parse(&["atproto".into(), "repo:app.bsky.feed.post".into()]);
-        assert!(!g.is_granular_identity_session());
+        assert!(!g.allows_identity("handle"));
 
-        // An invalid `identity:` grant is still classified (so it engages
-        // restriction) but permits nothing.
+        // An invalid `identity:` grant permits nothing.
         let g = GrantedScopes::parse(&["atproto".into(), "identity:invalid".into()]);
-        assert!(g.is_granular_identity_session());
         assert!(!g.allows_identity("handle"));
     }
 
     #[test]
     fn account_scope_enforces_attribute_and_action() {
         let g = GrantedScopes::parse(&["atproto".into(), "account:email?action=manage".into()]);
-        assert!(g.is_granular_account_session());
         assert!(g.allows_account("email", AccountAction::Manage));
         assert!(g.allows_account("email", AccountAction::Read)); // manage implies read
         assert!(!g.allows_account("status", AccountAction::Manage));
@@ -786,7 +729,6 @@ mod tests {
     #[test]
     fn blob_scope_enforces_the_granted_mime_pattern() {
         let g = GrantedScopes::parse(&["atproto".into(), "blob:image/*".into()]);
-        assert!(g.is_granular_blob_session());
         assert!(g.allows_blob("image/png"));
         assert!(!g.allows_blob("video/mp4"));
 
@@ -809,7 +751,6 @@ mod tests {
             "atproto".into(),
             "rpc:com.example.method?aud=did:web:example.com".into(),
         ]);
-        assert!(g.is_granular_rpc_session());
         assert!(g.allows_rpc("com.example.method", "did:web:example.com"));
         assert!(!g.allows_rpc("com.example.method", "did:web:other.com"));
         assert!(!g.allows_rpc("com.example.other", "did:web:example.com"));
@@ -837,11 +778,7 @@ mod tests {
             "totally-unrecognised-scope-string".into(),
         ]);
         let without_junk = GrantedScopes::parse(&["atproto".into(), format!("repo:{post}")]);
-        // Identical restriction with or without the unrecognised scope.
-        assert_eq!(
-            with_junk.is_granular_repo_session(),
-            without_junk.is_granular_repo_session()
-        );
+        // Identical grants with or without the unrecognised scope.
         assert_eq!(
             with_junk.allows_repo(post, RepoAction::Create),
             without_junk.allows_repo(post, RepoAction::Create)
@@ -850,23 +787,37 @@ mod tests {
             with_junk.allows_repo("app.bsky.feed.like", RepoAction::Create),
             without_junk.allows_repo("app.bsky.feed.like", RepoAction::Create)
         );
-        // It doesn't unlock any *other* resource's restriction either.
-        assert!(!with_junk.is_granular_blob_session());
-        assert!(!with_junk.is_granular_rpc_session());
-        assert!(!with_junk.is_granular_identity_session());
-        assert!(!with_junk.is_granular_account_session());
+        // It confers nothing on any *other* resource either. Under the
+        // auth-source gate these are outright denials, not the unrestricted
+        // pass-through the old `is_granular_*_session` shape gave them.
+        assert!(!with_junk.allows_blob("image/png"));
+        assert!(!with_junk.allows_rpc("com.example.method", "did:web:example.com"));
+        assert!(!with_junk.allows_identity("handle"));
+        assert!(!with_junk.allows_account("email", AccountAction::Manage));
 
         // A session carrying only unrecognised scopes (plus the mandatory
-        // base scope) is not a valid modern grant and is not a granular
-        // session for any resource either -- it is refused entirely by
-        // `oauth_scopes_to_auth_scope` before it ever reaches these checks.
+        // base scope) is not a valid modern grant -- it is refused entirely by
+        // `oauth_scopes_to_auth_scope` before it ever reaches these checks --
+        // and confers nothing if it somehow did.
         let junk_only =
             GrantedScopes::parse(&["atproto".into(), "totally-unrecognised-scope-string".into()]);
         assert!(!junk_only.has_permission_grant());
-        assert!(!junk_only.is_granular_repo_session());
-        assert!(!junk_only.is_granular_blob_session());
-        assert!(!junk_only.is_granular_rpc_session());
-        assert!(!junk_only.is_granular_identity_session());
-        assert!(!junk_only.is_granular_account_session());
+        assert!(!junk_only.allows_repo(post, RepoAction::Create));
+        assert!(!junk_only.allows_blob("image/png"));
+        assert!(!junk_only.allows_rpc("com.example.method", "did:web:example.com"));
+        assert!(!junk_only.allows_identity("handle"));
+        assert!(!junk_only.allows_account("email", AccountAction::Manage));
+    }
+
+    /// The empty grant: a session holding only the mandatory base scope
+    /// permits nothing at all on any resource.
+    #[test]
+    fn base_scope_alone_confers_no_grant() {
+        let g = GrantedScopes::parse(&["atproto".into()]);
+        assert!(!g.allows_repo("app.bsky.feed.post", RepoAction::Create));
+        assert!(!g.allows_blob("image/png"));
+        assert!(!g.allows_rpc("com.example.method", "did:web:example.com"));
+        assert!(!g.allows_identity("handle"));
+        assert!(!g.allows_account("email", AccountAction::Manage));
     }
 }

--- a/rsky-pds/src/permission_set.rs
+++ b/rsky-pds/src/permission_set.rs
@@ -495,7 +495,8 @@ mod tests {
         assert!(scope.starts_with("repo:?"), "{scope}");
         assert!(scope.contains("collection=app.bulleted.node"), "{scope}");
         assert!(scope.contains("action=create"), "{scope}");
-        assert!(crate::oauth_scope::GrantedScopes::parse(&[scope]).is_granular_repo_session());
+        assert!(crate::oauth_scope::GrantedScopes::parse(&[scope])
+            .allows_repo("app.bulleted.node", crate::oauth_scope::RepoAction::Create));
 
         let blob = Permission {
             resource: "blob".to_string(),
@@ -553,9 +554,8 @@ mod tests {
     /// The bug this whole file exists to fix: a permission set naming only a
     /// `repo:` grant (no `space:`) used to expand into nothing, so a session
     /// that granted only `include:<nsid>` ended up with no `repo:` scope at
-    /// all and therefore an *unrestricted* repo session
-    /// (`is_granular_repo_session` requires a `Repo(_)` variant to engage
-    /// restriction). Expanding non-space entries closes that hole.
+    /// all. Expanding non-space entries is what gives such a session the
+    /// grants it was actually issued.
     #[tokio::test]
     async fn a_permission_set_only_grant_restricts_rather_than_failing_open() {
         const REPO_ONLY_SET: &str = r#"{
@@ -586,7 +586,6 @@ mod tests {
         let mut granted = vec!["atproto".to_string()];
         granted.extend(scopes);
         let granted_scopes = crate::oauth_scope::GrantedScopes::parse(&granted);
-        assert!(granted_scopes.is_granular_repo_session());
         assert!(granted_scopes
             .allows_repo("app.bsky.feed.post", crate::oauth_scope::RepoAction::Create));
         assert!(!granted_scopes

--- a/rsky-pds/src/permission_set.rs
+++ b/rsky-pds/src/permission_set.rs
@@ -42,9 +42,9 @@ const SUCCESS_TTL: Duration = Duration::from_secs(3600);
 const FAILURE_TTL: Duration = Duration::from_secs(60);
 
 /// One entry of a published permission set.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct Permission {
-    /// `space`, `repo`, `blob`, `rpc`. Only `space` is meaningful here.
+    /// `space`, `repo`, `blob`, `rpc`, `identity`, or `account`.
     #[serde(default)]
     pub resource: String,
     #[serde(rename = "spaceType", default)]
@@ -53,12 +53,32 @@ pub struct Permission {
     pub authority: Option<String>,
     #[serde(default)]
     pub skey: Option<String>,
+    /// `repo` collections (0011 `RepoPermission.collection`).
     #[serde(default)]
     pub collection: Vec<String>,
+    /// Actions for whichever resource names this: `repo`'s create/update/delete,
+    /// or `account`'s read/manage.
     #[serde(default)]
     pub action: Vec<String>,
     #[serde(default, rename = "manage")]
     pub manage: Vec<String>,
+    /// `rpc` methods (0011 `RpcPermission.lxm`).
+    #[serde(default)]
+    pub lxm: Vec<String>,
+    /// `rpc`'s audience. `inherit_aud` is a coarser stand-in for "any
+    /// audience" until this server can resolve the reference implementation's
+    /// "the requesting PDS itself" semantics for `inheritAud`.
+    #[serde(default)]
+    pub aud: Option<String>,
+    #[serde(default, rename = "inheritAud")]
+    pub inherit_aud: bool,
+    /// `blob` mime-type patterns (0011 `BlobPermission.accept`).
+    #[serde(default)]
+    pub accept: Vec<String>,
+    /// `identity`'s attribute (`handle` or `*`) or `account`'s (`email`,
+    /// `repo`, or `status`).
+    #[serde(default)]
+    pub attr: Option<String>,
 }
 
 impl Permission {
@@ -98,6 +118,98 @@ impl Permission {
         }
         Some(scope)
     }
+
+    /// The equivalent scope string for any of the five proposal-0011
+    /// resource kinds this entry names, or `None` when it names none of them
+    /// (an unrecognised `resource`, or one missing the field its kind
+    /// requires).
+    ///
+    /// This is the general form of [`Self::to_space_scope`]: before it
+    /// existed, a permission set's `repo`/`rpc`/`blob`/`identity`/`account`
+    /// entries silently expanded into nothing (only `space` was handled),
+    /// so a client that granted only a permission set -- the mechanism the
+    /// proposal actually expects real clients to use -- ended up with an
+    /// *unrestricted* session instead of the restricted one it asked for.
+    /// Resolving every kind here, and feeding the result through the same
+    /// parser an inline scope goes through, closes that gap.
+    #[must_use]
+    pub fn to_scope_string(&self) -> Option<String> {
+        match self.resource.as_str() {
+            "space" => self.to_space_scope(),
+            "repo" => self.to_repo_scope(),
+            "blob" => self.to_blob_scope(),
+            "rpc" => self.to_rpc_scope(),
+            "identity" => self.to_identity_scope(),
+            "account" => self.to_account_scope(),
+            _ => None,
+        }
+    }
+
+    fn to_repo_scope(&self) -> Option<String> {
+        if self.collection.is_empty() {
+            return None;
+        }
+        let mut params: Vec<String> = self
+            .collection
+            .iter()
+            .map(|c| format!("collection={c}"))
+            .collect();
+        params.extend(self.action.iter().map(|a| format!("action={a}")));
+        Some(format!(
+            "{}?{}",
+            crate::oauth_scope::REPO_PREFIX,
+            params.join("&")
+        ))
+    }
+
+    fn to_blob_scope(&self) -> Option<String> {
+        if self.accept.is_empty() {
+            return None;
+        }
+        let params: Vec<String> = self.accept.iter().map(|a| format!("accept={a}")).collect();
+        Some(format!(
+            "{}?{}",
+            crate::oauth_scope::BLOB_PREFIX,
+            params.join("&")
+        ))
+    }
+
+    fn to_rpc_scope(&self) -> Option<String> {
+        if self.lxm.is_empty() {
+            return None;
+        }
+        let aud = if self.inherit_aud {
+            Some("*".to_string())
+        } else {
+            self.aud.clone()
+        };
+        let aud = aud?;
+        let mut params: Vec<String> = self.lxm.iter().map(|l| format!("lxm={l}")).collect();
+        params.push(format!("aud={aud}"));
+        Some(format!(
+            "{}?{}",
+            crate::oauth_scope::RPC_PREFIX,
+            params.join("&")
+        ))
+    }
+
+    fn to_identity_scope(&self) -> Option<String> {
+        let attr = self.attr.as_deref()?;
+        Some(format!("{}{attr}", crate::oauth_scope::IDENTITY_PREFIX))
+    }
+
+    fn to_account_scope(&self) -> Option<String> {
+        let attr = self.attr.as_deref()?;
+        if self.action.is_empty() {
+            return Some(format!("{}{attr}", crate::oauth_scope::ACCOUNT_PREFIX));
+        }
+        let params: Vec<String> = self.action.iter().map(|a| format!("action={a}")).collect();
+        Some(format!(
+            "{}{attr}?{}",
+            crate::oauth_scope::ACCOUNT_PREFIX,
+            params.join("&")
+        ))
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -119,15 +231,16 @@ struct GetRecordOutput {
     value: SchemaRecord,
 }
 
-/// The `space:` scope strings a permission set confers, extracted from a
-/// fetched `com.atproto.lexicon.schema` record.
-fn space_scopes_from_record(record: &SchemaRecord) -> Vec<String> {
+/// The scope strings a permission set confers -- across all five proposal
+/// 0011 resource kinds, not just `space:` -- extracted from a fetched
+/// `com.atproto.lexicon.schema` record.
+fn resource_scopes_from_record(record: &SchemaRecord) -> Vec<String> {
     record
         .defs
         .values()
         .filter(|def| def.def_type == "permission-set")
         .flat_map(|def| def.permissions.iter())
-        .filter_map(Permission::to_space_scope)
+        .filter_map(Permission::to_scope_string)
         .collect()
 }
 
@@ -148,10 +261,11 @@ impl PermissionSetResolver {
         Self::default()
     }
 
-    /// The `space:` scope strings an `include:<nsid>` confers. Empty when the
-    /// set names no space grants, and also when it could not be resolved --
-    /// the two are the same denial from a caller's point of view.
-    pub async fn space_scopes(&self, nsid: &str) -> Vec<String> {
+    /// The scope strings an `include:<nsid>` confers, across every
+    /// proposal-0011 resource kind the set names. Empty when the set names no
+    /// grants, and also when it could not be resolved -- the two are the same
+    /// denial from a caller's point of view.
+    pub async fn resolved_scopes(&self, nsid: &str) -> Vec<String> {
         if let Some(entry) = self.cache.read().await.get(nsid) {
             if entry.expires > Instant::now() {
                 return entry.scopes.clone();
@@ -197,7 +311,7 @@ impl PermissionSetResolver {
             anyhow::bail!("{url} returned {}", response.status());
         }
         let output: GetRecordOutput = response.json().await?;
-        Ok(space_scopes_from_record(&output.value))
+        Ok(resource_scopes_from_record(&output.value))
     }
 }
 
@@ -248,16 +362,20 @@ pub struct SharedPermissionSets {
     pub resolver: PermissionSetResolver,
 }
 
-/// Expand every `include:` in a session's granted scopes into the `space:`
-/// scope strings it confers, appended to the scopes as granted.
+/// Expand every `include:` in a session's granted scopes into the scope
+/// strings it confers (`repo:`, `blob:`, `rpc:`, `identity:`, `account:`, or
+/// `space:`), appended to the scopes as granted.
 ///
-/// The result is fed to the same parser an inline `space:` goes through, so a
-/// resolved permission behaves identically to one the client wrote out.
+/// The result is fed to the same parser an inline scope of that kind goes
+/// through, so a resolved permission behaves identically to one the client
+/// wrote out. This is what makes a permission-set-only grant (no bare
+/// `repo:`/`blob:`/etc. alongside the `include:`) actually restrict the
+/// session instead of leaving `GrantedScopes` with nothing to enforce.
 pub async fn expand_includes(resolver: &PermissionSetResolver, granted: &[String]) -> Vec<String> {
     let mut expanded = granted.to_vec();
     for scope in granted {
         if let Some(nsid) = scope.strip_prefix(crate::oauth_scope::INCLUDE_PREFIX) {
-            expanded.extend(resolver.space_scopes(nsid).await);
+            expanded.extend(resolver.resolved_scopes(nsid).await);
         }
     }
     expanded
@@ -303,7 +421,7 @@ mod tests {
 
     fn bulleted_scopes() -> Vec<String> {
         let record: SchemaRecord = serde_json::from_str(BULLETED_SPACE_ACCESS).unwrap();
-        space_scopes_from_record(&record)
+        resource_scopes_from_record(&record)
     }
 
     #[test]
@@ -323,12 +441,9 @@ mod tests {
     fn entries_that_are_not_space_grants_are_skipped() {
         let repo_grant = Permission {
             resource: "repo".to_string(),
-            space_type: None,
-            authority: None,
-            skey: None,
             collection: vec!["app.bulleted.node".to_string()],
             action: vec!["create".to_string()],
-            manage: Vec::new(),
+            ..Default::default()
         };
         assert!(repo_grant.to_space_scope().is_none());
         // A space entry with no space type names no spaces, so it grants none.
@@ -345,11 +460,7 @@ mod tests {
         let bare = Permission {
             resource: "space".to_string(),
             space_type: Some("app.bulleted.space".to_string()),
-            authority: None,
-            skey: None,
-            collection: Vec::new(),
-            action: Vec::new(),
-            manage: Vec::new(),
+            ..Default::default()
         };
         assert_eq!(bare.to_space_scope().unwrap(), "space:app.bulleted.space");
     }
@@ -361,9 +472,8 @@ mod tests {
             space_type: Some("app.bulleted.space".to_string()),
             authority: Some("self".to_string()),
             skey: Some("main".to_string()),
-            collection: Vec::new(),
-            action: Vec::new(),
             manage: vec!["create".to_string(), "delete".to_string()],
+            ..Default::default()
         };
         let scope = managing.to_space_scope().unwrap();
         assert_eq!(
@@ -373,11 +483,121 @@ mod tests {
         crate::space_scope::SpaceScope::parse(&scope).unwrap();
     }
 
+    #[test]
+    fn to_scope_string_expands_repo_blob_rpc_identity_and_account() {
+        let repo = Permission {
+            resource: "repo".to_string(),
+            collection: vec!["app.bulleted.node".to_string()],
+            action: vec!["create".to_string()],
+            ..Default::default()
+        };
+        let scope = repo.to_scope_string().unwrap();
+        assert!(scope.starts_with("repo:?"), "{scope}");
+        assert!(scope.contains("collection=app.bulleted.node"), "{scope}");
+        assert!(scope.contains("action=create"), "{scope}");
+        assert!(crate::oauth_scope::GrantedScopes::parse(&[scope]).is_granular_repo_session());
+
+        let blob = Permission {
+            resource: "blob".to_string(),
+            accept: vec!["image/*".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(blob.to_scope_string().unwrap(), "blob:?accept=image/*");
+
+        let rpc = Permission {
+            resource: "rpc".to_string(),
+            lxm: vec!["com.example.method".to_string()],
+            aud: Some("did:web:example.com".to_string()),
+            ..Default::default()
+        };
+        let scope = rpc.to_scope_string().unwrap();
+        assert!(scope.starts_with("rpc:?"), "{scope}");
+        assert!(scope.contains("lxm=com.example.method"), "{scope}");
+        assert!(scope.contains("aud=did:web:example.com"), "{scope}");
+
+        let identity = Permission {
+            resource: "identity".to_string(),
+            attr: Some("handle".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(identity.to_scope_string().unwrap(), "identity:handle");
+
+        let account = Permission {
+            resource: "account".to_string(),
+            attr: Some("email".to_string()),
+            action: vec!["manage".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(
+            account.to_scope_string().unwrap(),
+            "account:email?action=manage"
+        );
+
+        // Missing the field its kind requires: no grant.
+        assert!(Permission {
+            resource: "rpc".to_string(),
+            lxm: vec!["com.example.method".to_string()],
+            ..Default::default()
+        }
+        .to_scope_string()
+        .is_none());
+        // An unrecognised resource confers nothing.
+        assert!(Permission {
+            resource: "unknown-future-resource".to_string(),
+            ..Default::default()
+        }
+        .to_scope_string()
+        .is_none());
+    }
+
+    /// The bug this whole file exists to fix: a permission set naming only a
+    /// `repo:` grant (no `space:`) used to expand into nothing, so a session
+    /// that granted only `include:<nsid>` ended up with no `repo:` scope at
+    /// all and therefore an *unrestricted* repo session
+    /// (`is_granular_repo_session` requires a `Repo(_)` variant to engage
+    /// restriction). Expanding non-space entries closes that hole.
+    #[tokio::test]
+    async fn a_permission_set_only_grant_restricts_rather_than_failing_open() {
+        const REPO_ONLY_SET: &str = r#"{
+          "$type": "com.atproto.lexicon.schema",
+          "lexicon": 1,
+          "id": "app.example.repoAccess",
+          "defs": {
+            "main": {
+              "type": "permission-set",
+              "permissions": [
+                {
+                  "type": "permission",
+                  "resource": "repo",
+                  "action": ["create", "update", "delete"],
+                  "collection": ["app.bsky.feed.post"]
+                }
+              ]
+            }
+          }
+        }"#;
+        let record: SchemaRecord = serde_json::from_str(REPO_ONLY_SET).unwrap();
+        let scopes = resource_scopes_from_record(&record);
+        assert_eq!(scopes.len(), 1);
+
+        // Simulate what `expand_includes` produces for a session that
+        // granted only the permission set: `atproto` plus the resolved
+        // `repo:` scope, no bare `repo:` of its own.
+        let mut granted = vec!["atproto".to_string()];
+        granted.extend(scopes);
+        let granted_scopes = crate::oauth_scope::GrantedScopes::parse(&granted);
+        assert!(granted_scopes.is_granular_repo_session());
+        assert!(granted_scopes
+            .allows_repo("app.bsky.feed.post", crate::oauth_scope::RepoAction::Create));
+        assert!(!granted_scopes
+            .allows_repo("app.bsky.feed.like", crate::oauth_scope::RepoAction::Create));
+    }
+
     #[tokio::test]
     async fn an_unresolvable_set_confers_nothing_and_is_not_retried_immediately() {
         let resolver = PermissionSetResolver::new();
         // `.invalid` is reserved by RFC 2606 and never resolves.
-        let first = resolver.space_scopes("invalid.example.nothing").await;
+        let first = resolver.resolved_scopes("invalid.example.nothing").await;
         assert!(first.is_empty());
         // The failure is remembered, so the next call is a cache hit rather
         // than another DNS lookup.
@@ -395,7 +615,7 @@ mod tests {
     #[ignore = "requires network and a third-party PDS"]
     async fn resolves_the_real_bulleted_permission_set() {
         let resolver = PermissionSetResolver::new();
-        let scopes = resolver.space_scopes("app.bulleted.spaceAccess").await;
+        let scopes = resolver.resolved_scopes("app.bulleted.spaceAccess").await;
         assert_eq!(
             scopes,
             bulleted_scopes(),

--- a/rsky-pds/src/pipethrough.rs
+++ b/rsky-pds/src/pipethrough.rs
@@ -56,6 +56,7 @@ impl<'r> FromRequest<'r> for HandlerPipeThrough {
         match AccessStandard::from_request(req).await {
             Outcome::Success(output) => {
                 let AccessOutput { credentials, .. } = output.access;
+                let granted_scopes = credentials.as_ref().and_then(|c| c.granted_scopes.clone());
                 let requester: Option<String> = match credentials {
                     None => None,
                     Some(credentials) => credentials.did,
@@ -76,6 +77,13 @@ impl<'r> FromRequest<'r> for HandlerPipeThrough {
                     cfg: req.guard::<&State<ServerConfig>>().await.unwrap(),
                     actor_store: req.guard::<&State<ActorStore>>().await.unwrap(),
                 };
+                if let Err(api_error) = assert_rpc_scope(&granted_scopes, &proxy_req).await {
+                    req.local_cache(|| Some(api_error));
+                    return Outcome::Error((
+                        Status::Forbidden,
+                        anyhow::anyhow!("InsufficientScope"),
+                    ));
+                }
                 match pipethrough(
                     &proxy_req,
                     requester,
@@ -222,6 +230,38 @@ pub async fn pipethrough_procedure_post(
         .await
         .map_err(|error| pipethrough_error(&error))?;
     Ok(parse_proxy_res(res).await?)
+}
+
+/// Enforce a granular OAuth session's `rpc:` scope before a call is proxied
+/// to another service, mirroring [`crate::apis::assert_repo_scope`]'s shape
+/// at the seam every pipethrough request passes through (`bsky_api_get_forwarder`
+/// and friends all resolve to [`HandlerPipeThrough`]).
+///
+/// If the destination service can't be resolved, enforcement is skipped and
+/// the ordinary pipethrough call is left to surface that failure -- a scope
+/// check only makes sense once we know which service the call is bound for.
+pub async fn assert_rpc_scope(
+    granted_scopes: &Option<Vec<String>>,
+    req: &ProxyRequest<'_>,
+) -> Result<(), ApiError> {
+    let Some(granted) = granted_scopes else {
+        return Ok(());
+    };
+    let scopes = crate::oauth_scope::GrantedScopes::parse(granted);
+    if !scopes.is_granular_rpc_session() {
+        return Ok(());
+    }
+    let lxm = parse_req_nsid(req);
+    let Ok(UrlAndAud { aud, .. }) = format_url_and_aud(req, None).await else {
+        return Ok(());
+    };
+    if scopes.allows_rpc(&lxm, &aud) {
+        Ok(())
+    } else {
+        Err(ApiError::InsufficientScope(format!(
+            "Token scope does not permit calling {lxm} on {aud}"
+        )))
+    }
 }
 
 // Request setup/formatting

--- a/rsky-pds/src/pipethrough.rs
+++ b/rsky-pds/src/pipethrough.rs
@@ -232,28 +232,24 @@ pub async fn pipethrough_procedure_post(
     Ok(parse_proxy_res(res).await?)
 }
 
-/// Enforce a granular OAuth session's `rpc:` scope before a call is proxied
-/// to another service, mirroring [`crate::apis::assert_repo_scope`]'s shape
-/// at the seam every pipethrough request passes through (`bsky_api_get_forwarder`
-/// and friends all resolve to [`HandlerPipeThrough`]).
-///
-/// If the destination service can't be resolved, enforcement is skipped and
-/// the ordinary pipethrough call is left to surface that failure -- a scope
-/// check only makes sense once we know which service the call is bound for.
+/// Enforce an OAuth session's `rpc:` scope before a call is proxied to
+/// another service, at the seam every pipethrough request passes through
+/// (`bsky_api_get_forwarder` and friends all resolve to
+/// [`HandlerPipeThrough`]). Gating and `transition:generic` handling are
+/// [`crate::apis::scoped_session`]'s.
 pub async fn assert_rpc_scope(
     granted_scopes: &Option<Vec<String>>,
     req: &ProxyRequest<'_>,
 ) -> Result<(), ApiError> {
-    let Some(granted) = granted_scopes else {
+    let Some(scopes) = crate::apis::scoped_session(granted_scopes.as_ref(), true) else {
         return Ok(());
     };
-    let scopes = crate::oauth_scope::GrantedScopes::parse(granted);
-    if !scopes.is_granular_rpc_session() {
-        return Ok(());
-    }
     let lxm = parse_req_nsid(req);
-    let Ok(UrlAndAud { aud, .. }) = format_url_and_aud(req, None).await else {
-        return Ok(());
+    // An `rpc:` grant is bound to an audience, so a destination we cannot
+    // resolve is a destination we cannot show the call is scoped for.
+    let aud = match format_url_and_aud(req, None).await {
+        Ok(UrlAndAud { aud, .. }) => aud,
+        Err(error) => return Err(pipethrough_error(&error)),
     };
     if scopes.allows_rpc(&lxm, &aud) {
         Ok(())

--- a/rsky-pds/tests/oauth_tests.rs
+++ b/rsky-pds/tests/oauth_tests.rs
@@ -14,6 +14,18 @@ mod common;
 const LOOPBACK_CLIENT_ID: &str =
     "http://localhost?scope=atproto%20transition%3Ageneric&redirect_uri=http%3A%2F%2F127.0.0.1%3A8080%2Fcb";
 const REDIRECT_URI: &str = "http://127.0.0.1:8080/cb";
+
+/// A loopback client_id requesting exactly `scope` -- the loopback client's
+/// metadata is derived from its own URL, so `allowed_scopes` is exactly what
+/// this embeds and the PAR request below must ask for the same string.
+#[allow(dead_code)] // only the scoped-access-guard tests drive non-default scopes
+fn loopback_client_id(scope: &str) -> String {
+    format!(
+        "http://localhost?scope={}&redirect_uri={}",
+        url::form_urlencoded::byte_serialize(scope.as_bytes()).collect::<String>(),
+        url::form_urlencoded::byte_serialize(REDIRECT_URI.as_bytes()).collect::<String>(),
+    )
+}
 const PKCE_VERIFIER: &str = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
 const PKCE_CHALLENGE: &str = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
 
@@ -90,12 +102,12 @@ fn form_encode(pairs: &[(&str, &str)]) -> String {
     serializer.finish()
 }
 
-fn par_body(state: &str) -> String {
+fn par_body(client_id: &str, scope: &str, state: &str) -> String {
     form_encode(&[
-        ("client_id", LOOPBACK_CLIENT_ID),
+        ("client_id", client_id),
         ("response_type", "code"),
         ("redirect_uri", REDIRECT_URI),
-        ("scope", "atproto transition:generic"),
+        ("scope", scope),
         ("state", state),
         ("code_challenge", PKCE_CHALLENGE),
         ("code_challenge_method", "S256"),
@@ -105,6 +117,24 @@ fn par_body(state: &str) -> String {
 /// PAR with the standard `use_dpop_nonce` retry dance; returns the
 /// request_uri and the fresh server nonce.
 async fn run_par(client: &Client, key: &Jwk) -> (String, String) {
+    run_par_scoped(
+        client,
+        key,
+        LOOPBACK_CLIENT_ID,
+        "atproto transition:generic",
+    )
+    .await
+}
+
+/// [`run_par`], but for a client_id/scope other than the default loopback
+/// client, so a scoped-access-guard test can request a narrow grant (e.g.
+/// `atproto blob:image/*`) instead of `transition:generic`.
+async fn run_par_scoped(
+    client: &Client,
+    key: &Jwk,
+    client_id: &str,
+    scope: &str,
+) -> (String, String) {
     let htu = format!("{}/oauth/par", public_url(client));
     let response = client
         .post("/oauth/par")
@@ -113,7 +143,7 @@ async fn run_par(client: &Client, key: &Jwk) -> (String, String) {
             "DPoP",
             dpop_proof(key, "POST", &htu, None, None),
         ))
-        .body(par_body("state-123"))
+        .body(par_body(client_id, scope, "state-123"))
         .dispatch()
         .await;
     assert_eq!(response.status(), Status::BadRequest);
@@ -132,7 +162,7 @@ async fn run_par(client: &Client, key: &Jwk) -> (String, String) {
             "DPoP",
             dpop_proof(key, "POST", &htu, Some(&nonce), None),
         ))
-        .body(par_body("state-123"))
+        .body(par_body(client_id, scope, "state-123"))
         .dispatch()
         .await;
     assert_eq!(response.status(), Status::Created);
@@ -150,13 +180,10 @@ fn extract_csrf(html: &str) -> String {
     html[start..end].to_string()
 }
 
-fn authorize_path(request_uri: &str) -> String {
+fn authorize_path(client_id: &str, request_uri: &str) -> String {
     format!(
         "/oauth/authorize?{}",
-        form_encode(&[
-            ("client_id", LOOPBACK_CLIENT_ID),
-            ("request_uri", request_uri),
-        ])
+        form_encode(&[("client_id", client_id), ("request_uri", request_uri)])
     )
 }
 
@@ -167,7 +194,19 @@ struct AuthorizeSession {
 
 /// GET /oauth/authorize, returning the device cookie and csrf token.
 async fn open_authorize_page(client: &Client, request_uri: &str) -> AuthorizeSession {
-    let response = client.get(authorize_path(request_uri)).dispatch().await;
+    open_authorize_page_scoped(client, LOOPBACK_CLIENT_ID, request_uri).await
+}
+
+/// [`open_authorize_page`] for a non-default client_id.
+async fn open_authorize_page_scoped(
+    client: &Client,
+    client_id: &str,
+    request_uri: &str,
+) -> AuthorizeSession {
+    let response = client
+        .get(authorize_path(client_id, request_uri))
+        .dispatch()
+        .await;
     assert_eq!(response.status(), Status::Ok);
     let cookie = response
         .cookies()
@@ -189,13 +228,23 @@ async fn sign_in_and_accept(
     request_uri: &str,
     session: &AuthorizeSession,
 ) -> String {
+    sign_in_and_accept_scoped(client, LOOPBACK_CLIENT_ID, request_uri, session).await
+}
+
+/// [`sign_in_and_accept`] for a non-default client_id.
+async fn sign_in_and_accept_scoped(
+    client: &Client,
+    client_id: &str,
+    request_uri: &str,
+    session: &AuthorizeSession,
+) -> String {
     let response = client
         .post("/oauth/authorize/sign-in")
         .header(ContentType::Form)
         .cookie(("device-id", session.cookie.clone()))
         .body(form_encode(&[
             ("request_uri", request_uri),
-            ("client_id", LOOPBACK_CLIENT_ID),
+            ("client_id", client_id),
             ("csrf", &session.csrf),
             ("identifier", "foo@example.com"),
             ("password", "password"),
@@ -214,7 +263,7 @@ async fn sign_in_and_accept(
         .cookie(("device-id", session.cookie.clone()))
         .body(form_encode(&[
             ("request_uri", request_uri),
-            ("client_id", LOOPBACK_CLIENT_ID),
+            ("client_id", client_id),
             ("csrf", &session.csrf),
             ("did", "did:plc:khvyd3oiw46vif5gm7hijslk"),
         ]))
@@ -237,6 +286,17 @@ async fn sign_in_and_accept(
 }
 
 async fn exchange_code(client: &Client, key: &Jwk, code: &str, nonce: &str) -> Value {
+    exchange_code_scoped(client, LOOPBACK_CLIENT_ID, key, code, nonce).await
+}
+
+/// [`exchange_code`] for a non-default client_id.
+async fn exchange_code_scoped(
+    client: &Client,
+    client_id: &str,
+    key: &Jwk,
+    code: &str,
+    nonce: &str,
+) -> Value {
     let htu = format!("{}/oauth/token", public_url(client));
     let response = client
         .post("/oauth/token")
@@ -248,7 +308,7 @@ async fn exchange_code(client: &Client, key: &Jwk, code: &str, nonce: &str) -> V
         .body(form_encode(&[
             ("grant_type", "authorization_code"),
             ("code", code),
-            ("client_id", LOOPBACK_CLIENT_ID),
+            ("client_id", client_id),
             ("redirect_uri", REDIRECT_URI),
             ("code_verifier", PKCE_VERIFIER),
         ]))
@@ -503,6 +563,7 @@ async fn oauth_authorize_error_pages() {
 
     let response = client
         .get(authorize_path(
+            LOOPBACK_CLIENT_ID,
             "urn:ietf:params:oauth:request_uri:req-00000000000000000000000000000000",
         ))
         .dispatch()
@@ -597,7 +658,7 @@ async fn oauth_account_picker_select_flow() {
     // second round shows the signed-in account and supports select
     let (request_uri, _) = run_par(&client, &key).await;
     let response = client
-        .get(authorize_path(&request_uri))
+        .get(authorize_path(LOOPBACK_CLIENT_ID, &request_uri))
         .cookie(("device-id", session.cookie.clone()))
         .dispatch()
         .await;
@@ -651,7 +712,7 @@ async fn oauth_device_cookie_with_stale_session_is_replaced() {
     // a cookie naming a real device but a stale session id gets replaced
     let (request_uri, _) = run_par(&client, &key).await;
     let response = client
-        .get(authorize_path(&request_uri))
+        .get(authorize_path(LOOPBACK_CLIENT_ID, &request_uri))
         .cookie(("device-id", format!("{device_id}.ses-forged")))
         .dispatch()
         .await;
@@ -667,7 +728,7 @@ async fn oauth_device_cookie_with_stale_session_is_replaced() {
     // malformed cookies (no separator) are also replaced
     let (request_uri, _) = run_par(&client, &key).await;
     let response = client
-        .get(authorize_path(&request_uri))
+        .get(authorize_path(LOOPBACK_CLIENT_ID, &request_uri))
         .cookie(("device-id", "garbage-cookie"))
         .dispatch()
         .await;
@@ -723,4 +784,270 @@ async fn oauth_endpoint_edge_cases() {
     assert_eq!(response.status(), Status::BadRequest);
     let html = response.into_string().await.unwrap();
     assert!(html.contains("invalid CSRF token"));
+}
+
+// Scoped-access guard tests
+// ---------------------
+//
+// These prove the combinator guards in `auth_verifier.rs`
+// (`BlobScopedAccess`, `HandleScopedAccess`, `EmailScopedAccess`,
+// `AccountStatusScopedAccess`, `AccountRepoScopedAccess`) enforce their
+// resource scope through a real dispatched request over the full Rocket
+// stack -- DPoP verification, session lookup, and all -- rather than just
+// exercising the `assert_*_scope` helper in isolation. That is the point of
+// folding the assertion into the guard: a route that takes one of these
+// guards cannot get a `did` without the check having already run, so there
+// is no separate call in the handler body left to accidentally skip.
+//
+// `BlobScopedAccess` and `HandleScopedAccess` wrap `AccessStandardCheckTakedown`
+// and `AccountRepoScopedAccess<AccessStandard>` wraps `AccessStandard`, both
+// of which accept an OAuth session mapped to `AppPass`/`AppPassPrivileged` --
+// exactly what a granular-scope grant maps to (see
+// `auth_verifier::oauth_scopes_to_auth_scope`), so a real PAR/authorize/token
+// flow can reach them. `EmailScopedAccess`, `AccountStatusScopedAccess`, and
+// the default (`AccessFull`) `AccountRepoScopedAccess` wrap `AccessFull`,
+// which requires `AuthScope::Access` -- a scope only the legacy plain-JWT
+// `createSession` token type carries, and that token type always sets
+// `granted_scopes: None`. No OAuth grant can ever produce `AuthScope::Access`
+// (`oauth_scopes_to_auth_scope` only ever returns `AppPass`/`AppPassPrivileged`
+// or rejects), so those three guards' scope check is presently unreachable
+// through any live request; per-endpoint test coverage for them stays at the
+// `apis::tests` level added alongside `assert_account_scope` itself, which
+// exercises the identical helper this guard calls.
+
+/// Runs the full PAR -> authorize -> sign-in -> accept -> token-exchange
+/// dance for a fresh loopback client requesting exactly `scope`, returning a
+/// real DPoP-bound access token and the key it is bound to.
+async fn granular_access_token(client: &Client, scope: &str) -> (String, Jwk) {
+    let key = dpop_key();
+    let client_id = loopback_client_id(scope);
+    let (request_uri, nonce) = run_par_scoped(client, &key, &client_id, scope).await;
+    let session = open_authorize_page_scoped(client, &client_id, &request_uri).await;
+    let code = sign_in_and_accept_scoped(client, &client_id, &request_uri, &session).await;
+    let tokens = exchange_code_scoped(client, &client_id, &key, &code, &nonce).await;
+    (tokens["access_token"].as_str().unwrap().to_string(), key)
+}
+
+/// Dispatches an authenticated POST, retrying once with the server's DPoP
+/// nonce the same way a real client would (RFC 9449 §8), and returns the
+/// final status and parsed JSON body.
+async fn dispatch_scoped_post(
+    client: &Client,
+    path: &str,
+    access_token: &str,
+    key: &Jwk,
+    content_type: ContentType,
+    body: Vec<u8>,
+) -> (Status, Value) {
+    let htu = format!("{}{}", public_url(client), path);
+    let first = client
+        .post(path)
+        .header(content_type.clone())
+        .header(Header::new("Authorization", format!("DPoP {access_token}")))
+        .header(Header::new(
+            "DPoP",
+            dpop_proof(key, "POST", &htu, None, Some(access_token)),
+        ))
+        .body(body.clone())
+        .dispatch()
+        .await;
+    let response = if first.status() == Status::Unauthorized {
+        match first.headers().get_one("DPoP-Nonce").map(str::to_string) {
+            Some(nonce) => {
+                client
+                    .post(path)
+                    .header(content_type)
+                    .header(Header::new("Authorization", format!("DPoP {access_token}")))
+                    .header(Header::new(
+                        "DPoP",
+                        dpop_proof(key, "POST", &htu, Some(&nonce), Some(access_token)),
+                    ))
+                    .body(body)
+                    .dispatch()
+                    .await
+            }
+            None => first,
+        }
+    } else {
+        first
+    };
+    let status = response.status();
+    let text = response.into_string().await.unwrap_or_default();
+    let json_body = serde_json::from_str(&text).unwrap_or(Value::Null);
+    (status, json_body)
+}
+
+fn handle_domain(client: &Client) -> String {
+    client
+        .rocket()
+        .state::<rsky_pds::config::ServerConfig>()
+        .unwrap()
+        .identity
+        .service_handle_domains
+        .first()
+        .unwrap()
+        .clone()
+}
+
+#[tokio::test]
+async fn blob_scoped_access_allows_matching_mime_and_denies_mismatch() {
+    let (_dir, client) = get_oauth_client().await;
+    common::create_account(&client).await;
+    activate_test_account(&client).await;
+
+    // A `blob:image/*` grant permits uploading a png.
+    let (access_token, key) = granular_access_token(&client, "atproto blob:image/*").await;
+    let (status, body) = dispatch_scoped_post(
+        &client,
+        "/xrpc/com.atproto.repo.uploadBlob",
+        &access_token,
+        &key,
+        ContentType::PNG,
+        vec![0x89, 0x50, 0x4e, 0x47],
+    )
+    .await;
+    assert_eq!(status, Status::Ok, "body was {body}");
+    assert!(
+        body["blob"]["mimeType"].as_str().is_some(),
+        "body was {body}"
+    );
+
+    // The same grant does not cover a mismatched mime type.
+    let (access_token, key) = granular_access_token(&client, "atproto blob:image/*").await;
+    let (status, body) = dispatch_scoped_post(
+        &client,
+        "/xrpc/com.atproto.repo.uploadBlob",
+        &access_token,
+        &key,
+        ContentType::Plain,
+        b"not an image".to_vec(),
+    )
+    .await;
+    assert_eq!(status, Status::Forbidden, "body was {body}");
+    assert_eq!(body["error"], "InsufficientScope", "body was {body}");
+}
+
+#[tokio::test]
+async fn handle_scoped_access_allows_handle_and_denies_other_attr() {
+    let (_dir, client) = get_oauth_client().await;
+    common::create_account(&client).await;
+    activate_test_account(&client).await;
+    let domain = handle_domain(&client);
+
+    // An `identity:handle` grant clears `HandleScopedAccess` and reaches the
+    // handler, which then talks to the mock PLC directory to rotate the
+    // did:plc handle -- that mock only serves DID documents, not the PLC
+    // operation-log shape `plc::Client::update_handle` needs, so the request
+    // still fails past the guard. What matters here is that it is NOT
+    // rejected by the scope check.
+    let (access_token, key) = granular_access_token(&client, "atproto identity:handle").await;
+    let (status, body) = dispatch_scoped_post(
+        &client,
+        "/xrpc/com.atproto.identity.updateHandle",
+        &access_token,
+        &key,
+        ContentType::JSON,
+        json!({ "handle": format!("bar{domain}") })
+            .to_string()
+            .into_bytes(),
+    )
+    .await;
+    assert_ne!(status, Status::Forbidden, "body was {body}");
+    assert_ne!(body["error"], "InsufficientScope", "body was {body}");
+
+    // An `identity:` grant for an attribute this server does not recognise
+    // (this parser only accepts `handle`/`*`) is still a granular identity
+    // session -- it engages restriction -- but permits nothing.
+    let (access_token, key) = granular_access_token(&client, "atproto identity:invalid").await;
+    let (status, body) = dispatch_scoped_post(
+        &client,
+        "/xrpc/com.atproto.identity.updateHandle",
+        &access_token,
+        &key,
+        ContentType::JSON,
+        json!({ "handle": format!("baz{domain}") })
+            .to_string()
+            .into_bytes(),
+    )
+    .await;
+    assert_eq!(status, Status::Forbidden, "body was {body}");
+    assert_eq!(body["error"], "InsufficientScope", "body was {body}");
+}
+
+#[tokio::test]
+async fn account_repo_scoped_access_covers_submit_plc_operation() {
+    let (_dir, client) = get_oauth_client().await;
+    common::create_account(&client).await;
+    activate_test_account(&client).await;
+
+    // `account:repo?action=manage` clears `AccountRepoScopedAccess<AccessStandard>`
+    // and reaches the handler's own request-body validation, which rejects
+    // this empty operation -- proving the guard let the request through
+    // rather than stopping it at the scope check.
+    let (access_token, key) =
+        granular_access_token(&client, "atproto account:repo?action=manage").await;
+    let (status, body) = dispatch_scoped_post(
+        &client,
+        "/xrpc/com.atproto.identity.submitPlcOperation",
+        &access_token,
+        &key,
+        ContentType::JSON,
+        json!({ "operation": {} }).to_string().into_bytes(),
+    )
+    .await;
+    assert_ne!(body["error"], "InsufficientScope", "body was {body}");
+    assert_eq!(status, Status::BadRequest, "body was {body}");
+
+    // `account:repo` alone defaults to `action=read`, which does not satisfy
+    // the `Manage` check `submitPlcOperation` requires.
+    let (access_token, key) = granular_access_token(&client, "atproto account:repo").await;
+    let (status, body) = dispatch_scoped_post(
+        &client,
+        "/xrpc/com.atproto.identity.submitPlcOperation",
+        &access_token,
+        &key,
+        ContentType::JSON,
+        json!({ "operation": {} }).to_string().into_bytes(),
+    )
+    .await;
+    assert_eq!(status, Status::Forbidden, "body was {body}");
+    assert_eq!(body["error"], "InsufficientScope", "body was {body}");
+}
+
+/// `EmailScopedAccess`, `AccountStatusScopedAccess`, and the default
+/// `AccountRepoScopedAccess` all wrap `AccessFull`, which requires
+/// `AuthScope::Access` -- a scope only a legacy plain-JWT `createSession`
+/// token carries (see the module doc above). This is a regression check that
+/// the refactor did not break that, the only path currently able to reach
+/// them: a legacy session still clears `EmailScopedAccess` exactly as it
+/// cleared the plain `AccessFull` guard before this change.
+#[tokio::test]
+async fn email_scoped_access_still_accepts_a_legacy_session() {
+    let (_dir, client) = get_oauth_client().await;
+    let (identifier, password) = common::create_account(&client).await;
+    let response = client
+        .post("/xrpc/com.atproto.server.createSession")
+        .header(ContentType::JSON)
+        .body(json!({ "identifier": identifier, "password": password }).to_string())
+        .dispatch()
+        .await;
+    assert_eq!(response.status(), Status::Ok);
+    let session: Value = response.into_json().await.expect("session json");
+    let access_jwt = session["accessJwt"]
+        .as_str()
+        .expect("accessJwt")
+        .to_string();
+
+    let response = client
+        .post("/xrpc/com.atproto.server.updateEmail")
+        .header(ContentType::JSON)
+        .header(Header::new("Authorization", format!("Bearer {access_jwt}")))
+        .body(json!({ "email": "new-address@example.com" }).to_string())
+        .dispatch()
+        .await;
+    let status = response.status();
+    let text = response.into_string().await.unwrap_or_default();
+    let body: Value = serde_json::from_str(&text).unwrap_or(Value::Null);
+    assert_eq!(status, Status::Ok, "body was {body}");
+    assert_ne!(body["error"], "InsufficientScope", "body was {body}");
 }

--- a/rsky-pds/tests/oauth_tests.rs
+++ b/rsky-pds/tests/oauth_tests.rs
@@ -956,8 +956,7 @@ async fn handle_scoped_access_allows_handle_and_denies_other_attr() {
     assert_ne!(body["error"], "InsufficientScope", "body was {body}");
 
     // An `identity:` grant for an attribute this server does not recognise
-    // (this parser only accepts `handle`/`*`) is still a granular identity
-    // session -- it engages restriction -- but permits nothing.
+    // (this parser only accepts `handle`/`*`) permits nothing.
     let (access_token, key) = granular_access_token(&client, "atproto identity:invalid").await;
     let (status, body) = dispatch_scoped_post(
         &client,
@@ -972,6 +971,97 @@ async fn handle_scoped_access_allows_handle_and_denies_other_attr() {
     .await;
     assert_eq!(status, Status::Forbidden, "body was {body}");
     assert_eq!(body["error"], "InsufficientScope", "body was {body}");
+}
+
+/// The defect these guards were carrying: enforcement used to engage only
+/// when the session already held a grant of the resource's own kind, so a
+/// granular session scoped to one collection and nothing else got
+/// *unrestricted* access to every other resource. Absence of a grant is now a
+/// denial, proven here over the full stack.
+#[tokio::test]
+async fn a_repo_only_grant_is_denied_the_resources_it_does_not_name() {
+    let (_dir, client) = get_oauth_client().await;
+    common::create_account(&client).await;
+    activate_test_account(&client).await;
+    let domain = handle_domain(&client);
+    const REPO_ONLY: &str = "atproto repo:app.bsky.feed.post";
+
+    // No `blob:` grant: the upload is refused rather than waved through.
+    let (access_token, key) = granular_access_token(&client, REPO_ONLY).await;
+    let (status, body) = dispatch_scoped_post(
+        &client,
+        "/xrpc/com.atproto.repo.uploadBlob",
+        &access_token,
+        &key,
+        ContentType::PNG,
+        vec![0x89, 0x50, 0x4e, 0x47],
+    )
+    .await;
+    assert_eq!(status, Status::Forbidden, "body was {body}");
+    assert_eq!(body["error"], "InsufficientScope", "body was {body}");
+
+    // No `identity:` grant: the handle change is refused.
+    let (access_token, key) = granular_access_token(&client, REPO_ONLY).await;
+    let (status, body) = dispatch_scoped_post(
+        &client,
+        "/xrpc/com.atproto.identity.updateHandle",
+        &access_token,
+        &key,
+        ContentType::JSON,
+        json!({ "handle": format!("qux{domain}") })
+            .to_string()
+            .into_bytes(),
+    )
+    .await;
+    assert_eq!(status, Status::Forbidden, "body was {body}");
+    assert_eq!(body["error"], "InsufficientScope", "body was {body}");
+
+    // No `account:` grant: the PLC submission is refused.
+    let (access_token, key) = granular_access_token(&client, REPO_ONLY).await;
+    let (status, body) = dispatch_scoped_post(
+        &client,
+        "/xrpc/com.atproto.identity.submitPlcOperation",
+        &access_token,
+        &key,
+        ContentType::JSON,
+        json!({ "operation": {} }).to_string().into_bytes(),
+    )
+    .await;
+    assert_eq!(status, Status::Forbidden, "body was {body}");
+    assert_eq!(body["error"], "InsufficientScope", "body was {body}");
+}
+
+/// The companion fail-open on the same path: `assert_rpc_scope` used to
+/// return `Ok(())` when the destination service could not be resolved, so an
+/// audience-resolution error allowed the proxied call outright. An `rpc:`
+/// grant is bound to an audience, so an unresolvable one has to deny.
+///
+/// This mock appview is on loopback, which `is_safe_url` refuses outside dev
+/// mode -- so the aud never resolves here, and the request is refused with
+/// that failure rather than proxied. Before the fix a repo-only session got
+/// through this seam twice over: once for holding no `rpc:` grant, and again
+/// for the resolution error.
+#[tokio::test]
+async fn an_unresolvable_proxy_audience_denies_the_proxied_call() {
+    let (_dir, client) = get_oauth_client().await;
+    common::create_account(&client).await;
+    activate_test_account(&client).await;
+
+    let (access_token, key) =
+        granular_access_token(&client, "atproto repo:app.bsky.feed.post").await;
+    let (status, body) = dispatch_scoped_post(
+        &client,
+        "/xrpc/app.bsky.graph.muteActor",
+        &access_token,
+        &key,
+        ContentType::JSON,
+        json!({ "actor": "did:plc:someoneelse" })
+            .to_string()
+            .into_bytes(),
+    )
+    .await;
+    assert_eq!(status, Status::BadRequest, "body was {body}");
+    assert_eq!(body["error"], "InvalidRequest", "body was {body}");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Proposal 0011 defines five OAuth resource types: `repo`, `rpc`, `blob`, `identity`, `account`. rsky-pds parsed three and enforced one, so a granular OAuth token bought app-password-equivalent access outside record writes.

- Adds `Identity`/`Account` variants to the scope grammar, parsed with the same shorthand/query-form rules `repo:` already has.
- Expresses enforcement as request guards, so a handler declares its requirement in its signature rather than calling a check inline.
- Generalizes permission-set expansion: a set's `repo`/`rpc`/`blob`/`identity`/`account` entries previously expanded to nothing, and the resolved scopes are now fed through the same parser an inline scope goes through.
- **Gates scope checks on auth source rather than scope content.** The helpers previously required the session to already hold a grant of a resource before checking that resource, so a session granted only `repo:` had no `Blob`/`Rpc`/`Identity`/`Account` variants, every gate was false, and it reached unrestricted access on all four. A session with no granted scopes is exempt, `transition:generic` is exempt where the reference implementation says so, and every other OAuth session must produce a matching grant.
- Fixes a second fail-open where an audience `assert_rpc_scope` could not resolve returned `Ok(())` and proxied the call anyway.

| resource | parsed (before → after) | enforced (before → after) |
|---|---|---|
| repo | yes | yes (gate corrected) |
| blob | yes | no → **yes** |
| rpc | yes | no → **yes** |
| identity | no variant → yes | no → **yes** |
| account | no variant → yes | no → **yes** |

## Behavior change

Absence of a grant is now a denial. This affects granular OAuth sessions only — app passwords and legacy access tokens carry no granted scopes and are unaffected.

- A granular session must hold an explicit `rpc:<lxm>?aud=<did>` grant to use appview proxying. A client that requested `repo:`/`blob:` but no `rpc:` loses proxying it previously had. `transition:generic` sessions are exempt, so this does not affect clients using the legacy transition scopes.
- A session holding only `space:` grants is now denied `com.atproto.repo.*` writes and proxying.
- A deployment whose appview URL/DID is unset, or whose proxy target fails the SSRF check, now refuses granular-session proxying rather than allowing it. Worth a deploy-time config check.
- Permission-set resolution becomes load-bearing for access rather than only for narrowing: an unresolvable set now denies rather than silently widening, so a resolution outage becomes visible to clients.

## Transitional scopes, per the spec

The [OAuth spec](https://atproto.com/specs/oauth#transitional-scopes) defines `transition:generic` as repo writes, blob uploads, preferences, and service proxying — and explicitly **"no account management actions: change handle, change email, delete or deactivate account, migrate account"**. This PR now matches that exactly:

| | `transition:generic` |
|---|---|
| `repo:` write | permitted |
| `blob:` upload | permitted |
| `rpc:` proxying | permitted |
| `identity:` change handle | **denied** |
| `account:` change email / deactivate / migrate | **denied** |

`transition:email` is unaffected — it confers a read on the address, and every account guard here asks for `manage`.

The user-visible consequence: clients holding `atproto transition:generic transition:email transition:chat.bsky` now get 403 on `updateHandle`, `updateEmail`, `deactivateAccount` and the PLC operations, and must request the corresponding `identity:` / `account:` scope. That is the spec'"'"'s intent, but it is the change most likely to be noticed.

Unrelated and pre-existing, noted while checking the above: `com.atproto.server.getSession` returns the account email unconditionally, gating on no scope at all. Worth its own issue.

## Comparison with other implementations

Corrected after reading each codebase directly; an earlier draft of this description got the tranquil-pds claims wrong.

- **TypeScript reference** — `authorize` is a required field on the auth-verifier options type, so a route cannot be registered without declaring what it permits, and there are 27 explicit opt-out sites of two legible kinds. Permission-set expansion happens at token issuance and an unresolvable set throws rather than returning empty.
- **tranquil-pds** — enforces all five at handlers (identity at 4, account at 7, rpc at 2), with a typestate proof that is compile-time enforced for repo writes. Its gate keys on auth source rather than scope content, which is the shape adopted here; it has no fail-open equivalent, and an empty expansion is a hard error that refuses the token.
- **cocoon** — parses seven resources and fails closed on unparseable scopes at PAR/authorize, but enforces only `repo` and `blob`, and `importRepo` carries no scope check at all.

Enforcement here remains opt-in per route: a new route can take a plain auth guard and get no check. Making the declaration mandatory is tracked separately.

## Test plan

- [x] `cargo fmt` clean (two pre-existing violations on main in `password.rs` and `get_service_auth.rs` are untouched)
- [x] `cargo clippy -p rsky-pds --all-targets --no-deps -- -D warnings` clean
- [x] `cargo test -p rsky-pds` — 386 passed, 0 failed, 1 pre-existing ignored (incl. a case pinning the full transition:generic surface)
- [x] `cargo build --release -p rsky-pds`
- [x] Three tests that asserted the fail-open as intended are inverted
- [x] New: a `repo:`-only grant is denied the four resources it does not name; an empty scope set, an `include:` resolving to nothing, and an unparseable scope are each denied all five; `transition:generic` keeps its legacy reach; a session without granted scopes is unaffected
- [x] New end-to-end through the full Rocket/DPoP stack: a `repo:`-only session gets 403 on uploadBlob, updateHandle and submitPlcOperation; an unresolvable proxy audience refuses instead of proxying
- [ ] Confirm against a real granular OAuth client that the `rpc:` requirement does not strand it
- [ ] Confirm the transition-scope surface above against a real client before deploy
