### PR TITLE
fix(pds): correct inverted service-auth privilege check

### DIFF
--- a/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
+++ b/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
@@ -10,7 +10,39 @@ use rocket::serde::json::Json;
 use rocket::State;
 use rsky_common::time::{from_micros_to_utc, HOUR, MINUTE};
 use rsky_lexicon::com::atproto::server::GetServiceAuthOutput;
+use rsky_syntax::did::ensure_valid_did;
 use std::time::SystemTime;
+
+/// Denies a request for a service-auth token when the *requested* method
+/// (`lxm`) is privileged (the `chat.bsky.*` surface plus
+/// `com.atproto.server.createAccount`) and the *caller's own* session is not
+/// itself privileged.
+///
+/// Mirrors the upstream TS reference (`getServiceAuth.ts`):
+/// `lxm != null && PRIVILEGED_METHODS.has(lxm) && !isAccessPrivileged(scope)`.
+///
+/// This is intentionally the inverse of a naive "gate privileged sessions"
+/// check: a plain (non-privileged) app-password session must never be able
+/// to mint a token for a privileged method such as
+/// `chat.bsky.convo.getMessages`, while a fully-privileged session (full
+/// `Access` or `AppPassPrivileged`) must be allowed to request a token for
+/// any method, privileged or not.
+fn ensure_lxm_access(lxm: &str, is_privileged: bool) -> Result<()> {
+    if PRIVILEGED_METHODS.contains(lxm) && !is_privileged {
+        bail!("insufficient access to request a service auth token for the following method: {lxm}");
+    }
+    Ok(())
+}
+
+/// Validates that `aud` is a syntactically valid atproto DID, optionally
+/// followed by a `#serviceId` fragment (e.g. `did:web:example.com#atproto_labeler`),
+/// matching the upstream check `isAtprotoDid(aud) || isAtprotoDidRefAbsolute(aud)`.
+fn ensure_valid_aud(aud: &str) -> Result<()> {
+    let did_part = aud.split('#').next().unwrap_or(aud);
+    ensure_valid_did(did_part).map_err(|_| {
+        anyhow::anyhow!("aud must be a valid atproto DID or did#serviceId reference")
+    })
+}
 
 pub async fn inner_get_service_auth(
     aud: String,
@@ -21,6 +53,7 @@ pub async fn inner_get_service_auth(
 ) -> Result<String> {
     let credentials = auth.access.credentials.unwrap();
     let did = credentials.clone().did.unwrap();
+    ensure_valid_aud(&aud)?;
     // `exp` is seconds since the epoch (RFC 7519 §4.1.4).
     if let Some(exp) = exp {
         let system_time = SystemTime::now();
@@ -38,9 +71,7 @@ pub async fn inner_get_service_auth(
         if PROTECTED_METHODS.contains(lxm.as_str()) {
             bail!("cannot request a service auth token for the following protected method: {lxm}");
         }
-        if credentials.is_privileged.unwrap_or(false) && PRIVILEGED_METHODS.contains(lxm.as_str()) {
-            bail!("insufficient access to request a service auth token for the following method: {lxm}");
-        }
+        ensure_lxm_access(lxm.as_str(), credentials.is_privileged.unwrap_or(false))?;
     }
     let keypair = actor_store.keypair(&did).await?;
     create_service_jwt(
@@ -76,5 +107,73 @@ pub async fn get_service_auth(
             tracing::error!("Internal Error: {error}");
             Err(ApiError::RuntimeError)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CHAT_LXM: &str = "chat.bsky.convo.getMessages";
+    const CREATE_ACCOUNT_LXM: &str = "com.atproto.server.createAccount";
+    const NON_PRIVILEGED_LXM: &str = "app.bsky.feed.getTimeline";
+
+    // --- ensure_lxm_access: the privilege gate that was previously inverted ---
+    //
+    // These four tests are written to fail against the *old* (backwards)
+    // condition `is_privileged && PRIVILEGED_METHODS.contains(lxm)` and pass
+    // against the fixed condition `PRIVILEGED_METHODS.contains(lxm) &&
+    // !is_privileged`. This was confirmed by temporarily restoring the old
+    // condition locally and observing `plain_app_password_session_is_denied_for_chat_method`
+    // and `plain_app_password_session_is_denied_for_create_account` fail (they
+    // passed under the old code, i.e. incorrectly allowed access), before
+    // re-applying the fix.
+
+    #[test]
+    fn plain_app_password_session_is_denied_for_chat_method() {
+        // A plain (non-privileged) app-password session must NOT be able to
+        // mint a service-auth token for a chat.bsky.* method.
+        assert!(ensure_lxm_access(CHAT_LXM, false).is_err());
+    }
+
+    #[test]
+    fn plain_app_password_session_is_denied_for_create_account() {
+        assert!(ensure_lxm_access(CREATE_ACCOUNT_LXM, false).is_err());
+    }
+
+    #[test]
+    fn privileged_session_is_allowed_for_chat_method() {
+        // A fully-privileged session (full `Access` or `AppPassPrivileged`)
+        // must be allowed to request a token for a chat.bsky.* method.
+        assert!(ensure_lxm_access(CHAT_LXM, true).is_ok());
+    }
+
+    #[test]
+    fn privileged_session_is_allowed_for_create_account() {
+        assert!(ensure_lxm_access(CREATE_ACCOUNT_LXM, true).is_ok());
+    }
+
+    #[test]
+    fn non_privileged_method_is_allowed_regardless_of_privilege_level() {
+        // Non-privileged methods must be allowed regardless of the caller's
+        // privilege level.
+        assert!(ensure_lxm_access(NON_PRIVILEGED_LXM, false).is_ok());
+        assert!(ensure_lxm_access(NON_PRIVILEGED_LXM, true).is_ok());
+    }
+
+    // --- ensure_valid_aud ---
+
+    #[test]
+    fn aud_validation_rejects_non_did_values() {
+        assert!(ensure_valid_aud("not-a-did").is_err());
+        assert!(ensure_valid_aud("https://example.com").is_err());
+        assert!(ensure_valid_aud("").is_err());
+    }
+
+    #[test]
+    fn aud_validation_accepts_plain_did_and_service_ref() {
+        assert!(ensure_valid_aud("did:web:example.com").is_ok());
+        assert!(ensure_valid_aud("did:plc:7iza6de2dwap2sbkpav7c6c6").is_ok());
+        assert!(ensure_valid_aud("did:web:example.com#atproto_labeler").is_ok());
     }
 }

--- a/rsky-pds/src/auth_verifier.rs
+++ b/rsky-pds/src/auth_verifier.rs
@@ -80,6 +80,14 @@ impl AuthScope {
             _ => bail!("Invalid AuthScope: `{scope:?}` is not a valid auth scope"),
         }
     }
+
+    /// Whether a session carrying this scope is "privileged" -- i.e. allowed
+    /// to request service-auth tokens for privileged methods
+    /// (`chat.bsky.*`, `com.atproto.server.createAccount`). True only for a
+    /// full `Access` session or an `AppPassPrivileged` app password.
+    pub fn is_privileged(&self) -> bool {
+        matches!(self, AuthScope::Access | AuthScope::AppPassPrivileged)
+    }
 }
 
 pub enum RoleStatus {
@@ -860,7 +868,7 @@ pub async fn validate_bearer_access_token(
         audience,
         ..
     } = validate_bearer_token(request, scopes, Some(options))?;
-    let is_privileged = [AuthScope::Access, AuthScope::AppPassPrivileged].contains(&scope);
+    let is_privileged = scope.is_privileged();
     Ok(AccessOutput {
         credentials: Some(Credentials {
             r#type: "access".to_string(),
@@ -1049,6 +1057,7 @@ async fn validate_dpop_access_token(
         check_deactivated.unwrap_or(false),
     )
     .await?;
+    let is_privileged = scope.is_privileged();
     Ok(AccessOutput {
         credentials: Some(Credentials {
             r#type: "oauth".to_string(),
@@ -1059,7 +1068,7 @@ async fn validate_dpop_access_token(
             token_id: Some(verified.token_id),
             aud: None,
             iss: None,
-            is_privileged: None,
+            is_privileged: Some(is_privileged),
         }),
         artifacts: Some(token),
     })
@@ -1146,6 +1155,7 @@ pub async fn validate_access_token(
         check_deactivated.unwrap_or(false),
     )
     .await?;
+    let is_privileged = scope.is_privileged();
     Ok(AccessOutput {
         credentials: Some(Credentials {
             r#type: "access".to_string(),
@@ -1156,7 +1166,7 @@ pub async fn validate_access_token(
             token_id: None,
             aud: None,
             iss: None,
-            is_privileged: None,
+            is_privileged: Some(is_privileged),
         }),
         artifacts: Some(token),
     })

--- a/rsky-pds/tests/signing_key_tests.rs
+++ b/rsky-pds/tests/signing_key_tests.rs
@@ -171,3 +171,98 @@ async fn the_did_document_is_validated_against_the_accounts_own_key() {
     assert!(!valid_did(token).await);
     set_published_signing_key(None);
 }
+
+/// A full-access session (ordinary password login, `AuthScope::Access`) is
+/// privileged and must be allowed to mint a service-auth token for a
+/// privileged `chat.bsky.*` method.
+///
+/// This is an end-to-end regression test for `Credentials.is_privileged`
+/// actually being populated from the session's real scope inside
+/// `validate_access_token` / `validate_dpop_access_token`
+/// (`auth_verifier.rs`), rather than being hardcoded to `None`. That bug sat
+/// upstream of `getServiceAuth`'s own privilege check: with `is_privileged`
+/// always `None` (-> `false`), a corrected `getServiceAuth` condition would
+/// deny *every* privileged-method request, including this one, regardless of
+/// session type. A unit test of the extracted `ensure_lxm_access` helper
+/// alone cannot catch this, because the bug is in how its `is_privileged`
+/// input gets constructed, not in the helper itself.
+#[tokio::test]
+async fn full_access_session_is_allowed_service_auth_for_a_privileged_chat_method() {
+    let (_dir, client) = common::get_client().await;
+    let token = account(&client, "did:plc:eeeeeeeeeeeeeeeeeeeeeeee", "erin").await;
+
+    let response = client
+        .get(
+            "/xrpc/com.atproto.server.getServiceAuth\
+             ?aud=did:web:appview.invalid&lxm=chat.bsky.convo.getMessages",
+        )
+        .header(Header::new("Authorization", format!("Bearer {token}")))
+        .dispatch()
+        .await;
+    assert_eq!(response.status(), Status::Ok);
+    let body: serde_json::Value = response.into_json().await.unwrap();
+    assert!(body["token"].as_str().is_some());
+}
+
+/// A plain app-password session (`AuthScope::AppPass`, not privileged) must
+/// be denied a service-auth token for a privileged `chat.bsky.*` method,
+/// even though the same account's full-access session is allowed one above.
+#[tokio::test]
+async fn app_password_session_is_denied_service_auth_for_a_privileged_chat_method() {
+    let (_dir, client) = common::get_client().await;
+    let full_token = account(&client, "did:plc:ffffffffffffffffffffffff", "frank").await;
+
+    let response = client
+        .post("/xrpc/com.atproto.server.createAppPassword")
+        .header(ContentType::JSON)
+        .header(Header::new("Authorization", format!("Bearer {full_token}")))
+        .body(json!({ "name": "test app password" }).to_string())
+        .dispatch()
+        .await;
+    assert_eq!(response.status(), Status::Ok);
+    let body: serde_json::Value = response.into_json().await.unwrap();
+    let app_password = body["password"].as_str().unwrap().to_string();
+
+    let domain = client
+        .rocket()
+        .state::<ServerConfig>()
+        .unwrap()
+        .identity
+        .service_handle_domains
+        .first()
+        .unwrap()
+        .clone();
+    let response = client
+        .post("/xrpc/com.atproto.server.createSession")
+        .header(ContentType::JSON)
+        .body(
+            json!({
+                "identifier": format!("frank{domain}"),
+                "password": app_password,
+            })
+            .to_string(),
+        )
+        .dispatch()
+        .await;
+    assert_eq!(response.status(), Status::Ok);
+    let body: serde_json::Value = response.into_json().await.unwrap();
+    let app_password_token = body["accessJwt"].as_str().unwrap().to_string();
+
+    let response = client
+        .get(
+            "/xrpc/com.atproto.server.getServiceAuth\
+             ?aud=did:web:appview.invalid&lxm=chat.bsky.convo.getMessages",
+        )
+        .header(Header::new(
+            "Authorization",
+            format!("Bearer {app_password_token}"),
+        ))
+        .dispatch()
+        .await;
+    assert_ne!(
+        response.status(),
+        Status::Ok,
+        "a plain app-password session must not be able to mint a service-auth \
+         token for a privileged chat.bsky.* method"
+    );
+}


### PR DESCRIPTION
## Summary
`com.atproto.server.getServiceAuth` had its privilege check backwards: rsky denied a service-auth token when the caller **was** privileged, and allowed it otherwise. The TS reference denies when the requested method is privileged **and the caller is not**. In practice this meant a plain app-password session could mint a service-auth token for privileged `chat.bsky.*` methods (read DMs, send messages, list conversations, export account data), while legitimately privileged clients were incorrectly rejected.

- Fixes the condition to match upstream exactly: deny iff `PRIVILEGED_METHODS.contains(lxm) && !is_privileged`.
- Adds `aud` DID-format validation on the same endpoint (cocoon independently validates this too via a struct tag, confirming it's an established pattern worth having).
- **Found and fixed a second, more serious bug surfaced by testing the first fix end-to-end**: `is_privileged` was hardcoded to `None` in the real request path (`validate_access_token`/`validate_dpop_access_token` in `auth_verifier.rs`, which is what `AccessFull`/`AccessPrivileged` actually use) — so in production the corrected condition alone would have denied **every** `chat.bsky.*` service-auth request, including from legitimately privileged sessions. Extracted a shared `AuthScope::is_privileged()` helper and applied it at all three call sites that build `Credentials`.
- Compared against cocoon and tranquil-pds: cocoon has no `PRIVILEGED_METHODS` concept at all (mints for any lxm short of recursive tokens); tranquil-pds uses a positive-grant scope check that can't produce this class of inversion by construction, and also implements the takedown carve-out directly in its `get_service_auth` handler — confirming that carve-out belongs at the endpoint, which rsky does not yet do (flagged, not fixed here — rsky's `AccessFull` guard doesn't currently enforce takedown status at all, so adding the carve-out first needs the underlying check plumbed in, which is out of scope for this fix).

## Test plan
- [x] Unit tests on the extracted condition, verified to fail against the original inverted logic and pass against the fix
- [x] Two new end-to-end Rocket integration tests in `tests/signing_key_tests.rs` (real login → bearer token → `GET /xrpc/com.atproto.server.getServiceAuth`): a full-access session is allowed for a privileged method; an app-password session is denied. Verified the first test actually catches the `is_privileged`-always-`None` bug by reverting it locally and watching the test fail (500 instead of 200) before re-applying the fix.
- [x] `cargo build -p rsky-pds` clean, `cargo test -p rsky-pds` — all suites green (310+ lib tests, `signing_key_tests` 5/5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)