### PR TITLE
refactor(pds): make an OAuth scope declaration required to learn the requester

### DIFF
--- a/rsky-pds/src/apis/app/bsky/actor/get_preferences.rs
+++ b/rsky-pds/src/apis/app/bsky/actor/get_preferences.rs
@@ -1,7 +1,7 @@
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessStandard;
+use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
 use anyhow::Result;
 use rocket::serde::json::Json;
 use rocket::State;
@@ -9,11 +9,11 @@ use rsky_lexicon::app::bsky::actor::{GetPreferencesOutput, RefPreferences};
 
 async fn inner_get_preferences(
     blobstore_factory: &State<BlobstoreFactory>,
-    auth: AccessStandard,
+    auth: Scoped<NoScopeRequired>,
     actor_store: &State<ActorStore>,
 ) -> Result<GetPreferencesOutput> {
-    let auth = auth.access.credentials.unwrap();
-    let requester = auth.did.unwrap().clone();
+    let credentials = auth.credentials().await?.clone().unwrap();
+    let requester = auth.did().await?;
     let actor_store = actor_store
         .read(
             requester.clone(),
@@ -22,7 +22,7 @@ async fn inner_get_preferences(
         .await?;
     let preferences: Vec<RefPreferences> = actor_store
         .pref
-        .get_preferences(Some("app.bsky".to_string()), auth.scope.unwrap())
+        .get_preferences(Some("app.bsky".to_string()), credentials.scope.unwrap())
         .await?;
 
     Ok(GetPreferencesOutput { preferences })
@@ -34,7 +34,7 @@ async fn inner_get_preferences(
 #[rocket::get("/xrpc/app.bsky.actor.getPreferences")]
 pub async fn get_preferences(
     blobstore_factory: &State<BlobstoreFactory>,
-    auth: AccessStandard,
+    auth: Scoped<NoScopeRequired>,
     actor_store: &State<ActorStore>,
 ) -> Result<Json<GetPreferencesOutput>, ApiError> {
     match inner_get_preferences(blobstore_factory, auth, actor_store).await {

--- a/rsky-pds/src/apis/app/bsky/actor/get_profile.rs
+++ b/rsky-pds/src/apis/app/bsky/actor/get_profile.rs
@@ -2,7 +2,7 @@ use crate::account_manager::AccountManager;
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessStandard;
+use crate::auth_verifier::scope::{RpcProxy, Scoped};
 use crate::config::ServerConfig;
 use crate::read_after_write::types::LocalRecords;
 use crate::read_after_write::util::{handle_read_after_write, ReadAfterWriteResponse};
@@ -18,17 +18,14 @@ const METHOD_NSID: &str = "app.bsky.actor.getProfile";
 pub async fn inner_get_profile(
     // Forwarded by original url in pipethrough
     _actor: String,
-    auth: AccessStandard,
+    auth: Scoped<RpcProxy>,
     res: HandlerPipeThrough,
     blobstore_factory: &State<BlobstoreFactory>,
     state_local_viewer: &State<SharedLocalViewer>,
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<ProfileViewDetailed>, ApiError> {
-    let requester: Option<String> = match auth.access.credentials {
-        None => None,
-        Some(credentials) => credentials.did,
-    };
+    let requester: Option<String> = auth.did_opt().await?;
     match requester {
         None => Ok(ReadAfterWriteResponse::HandlerPipeThrough(res)),
         Some(requester) => {
@@ -56,7 +53,7 @@ pub async fn inner_get_profile(
 pub async fn get_profile(
     // Handle or DID of account to fetch profile of.
     actor: String,
-    auth: AccessStandard,
+    auth: Scoped<RpcProxy>,
     res: HandlerPipeThrough,
     blobstore_factory: &State<BlobstoreFactory>,
     state_local_viewer: &State<SharedLocalViewer>,

--- a/rsky-pds/src/apis/app/bsky/actor/get_profiles.rs
+++ b/rsky-pds/src/apis/app/bsky/actor/get_profiles.rs
@@ -2,7 +2,7 @@ use crate::account_manager::AccountManager;
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessStandard;
+use crate::auth_verifier::scope::{RpcProxy, Scoped};
 use crate::config::ServerConfig;
 use crate::read_after_write::types::LocalRecords;
 use crate::read_after_write::util::{handle_read_after_write, ReadAfterWriteResponse};
@@ -17,17 +17,14 @@ const METHOD_NSID: &str = "app.bsky.actor.getProfiles";
 
 pub async fn inner_get_profiles(
     _actors: Vec<String>,
-    auth: AccessStandard,
+    auth: Scoped<RpcProxy>,
     res: HandlerPipeThrough,
     blobstore_factory: &State<BlobstoreFactory>,
     state_local_viewer: &State<SharedLocalViewer>,
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<GetProfilesOutput>, ApiError> {
-    let requester: String = match auth.access.credentials {
-        None => "".to_string(),
-        Some(credentials) => credentials.did.unwrap_or("".to_string()),
-    };
+    let requester: String = auth.did_opt().await?.unwrap_or_default();
     let read_afer_write_response = handle_read_after_write(
         METHOD_NSID.to_string(),
         requester,
@@ -48,7 +45,7 @@ pub async fn inner_get_profiles(
 #[rocket::get("/xrpc/app.bsky.actor.getProfiles?<actors>")]
 pub async fn get_profiles(
     actors: Vec<String>,
-    auth: AccessStandard,
+    auth: Scoped<RpcProxy>,
     res: HandlerPipeThrough,
     blobstore_factory: &State<BlobstoreFactory>,
     state_local_viewer: &State<SharedLocalViewer>,

--- a/rsky-pds/src/apis/app/bsky/actor/put_preferences.rs
+++ b/rsky-pds/src/apis/app/bsky/actor/put_preferences.rs
@@ -1,7 +1,7 @@
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessStandard;
+use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
 use anyhow::Result;
 use rocket::serde::json::Json;
 use rocket::State;
@@ -10,12 +10,12 @@ use rsky_lexicon::app::bsky::actor::PutPreferencesInput;
 async fn inner_put_preferences(
     body: Json<PutPreferencesInput>,
     blobstore_factory: &State<BlobstoreFactory>,
-    auth: AccessStandard,
+    auth: Scoped<NoScopeRequired>,
     actor_store: &State<ActorStore>,
 ) -> Result<(), ApiError> {
     let PutPreferencesInput { preferences } = body.into_inner();
-    let auth = auth.access.credentials.unwrap();
-    let requester = auth.did.unwrap().clone();
+    let credentials = auth.credentials().await?.clone().unwrap();
+    let requester = auth.did().await?;
     let actor_store = actor_store
         .transact(
             requester.clone(),
@@ -24,7 +24,11 @@ async fn inner_put_preferences(
         .await?;
     actor_store
         .pref
-        .put_preferences(preferences, "app.bsky".to_string(), auth.scope.unwrap())
+        .put_preferences(
+            preferences,
+            "app.bsky".to_string(),
+            credentials.scope.unwrap(),
+        )
         .await?;
     Ok(())
 }
@@ -38,7 +42,7 @@ async fn inner_put_preferences(
 pub async fn put_preferences(
     body: Json<PutPreferencesInput>,
     blobstore_factory: &State<BlobstoreFactory>,
-    auth: AccessStandard,
+    auth: Scoped<NoScopeRequired>,
     actor_store: &State<ActorStore>,
 ) -> Result<(), ApiError> {
     match inner_put_preferences(body, blobstore_factory, auth, actor_store).await {

--- a/rsky-pds/src/apis/app/bsky/feed/get_actor_likes.rs
+++ b/rsky-pds/src/apis/app/bsky/feed/get_actor_likes.rs
@@ -2,7 +2,7 @@ use crate::account_manager::AccountManager;
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessStandard;
+use crate::auth_verifier::scope::{RpcProxy, Scoped};
 use crate::config::ServerConfig;
 use crate::read_after_write::types::LocalRecords;
 use crate::read_after_write::util::{handle_read_after_write, ReadAfterWriteResponse};
@@ -20,17 +20,14 @@ pub async fn inner_get_actor_likes(
     _actor: String,
     _limit: Option<u8>,
     _cursor: Option<String>,
-    auth: AccessStandard,
+    auth: Scoped<RpcProxy>,
     res: HandlerPipeThrough,
     blobstore_factory: &State<BlobstoreFactory>,
     state_local_viewer: &State<SharedLocalViewer>,
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<AuthorFeed>> {
-    let requester: Option<String> = match auth.access.credentials {
-        None => None,
-        Some(credentials) => credentials.did,
-    };
+    let requester: Option<String> = auth.did_opt().await?;
     match requester {
         None => Ok(ReadAfterWriteResponse::HandlerPipeThrough(res)),
         Some(requester) => {
@@ -58,7 +55,7 @@ pub async fn get_actor_likes(
     actor: String,
     limit: Option<u8>,
     cursor: Option<String>,
-    auth: AccessStandard,
+    auth: Scoped<RpcProxy>,
     res: HandlerPipeThrough,
     blobstore_factory: &State<BlobstoreFactory>,
     state_local_viewer: &State<SharedLocalViewer>,

--- a/rsky-pds/src/apis/app/bsky/feed/get_author_feed.rs
+++ b/rsky-pds/src/apis/app/bsky/feed/get_author_feed.rs
@@ -2,7 +2,7 @@ use crate::account_manager::AccountManager;
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessStandard;
+use crate::auth_verifier::scope::{RpcProxy, Scoped};
 use crate::config::ServerConfig;
 use crate::read_after_write::types::LocalRecords;
 use crate::read_after_write::util::{handle_read_after_write, ReadAfterWriteResponse};
@@ -22,17 +22,14 @@ pub async fn inner_get_author_feed(
     _limit: Option<u8>,
     _cursor: Option<String>,
     _filter: Option<String>,
-    auth: AccessStandard,
+    auth: Scoped<RpcProxy>,
     res: HandlerPipeThrough,
     blobstore_factory: &State<BlobstoreFactory>,
     state_local_viewer: &State<SharedLocalViewer>,
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<AuthorFeed>> {
-    let requester: Option<String> = match auth.access.credentials {
-        None => None,
-        Some(credentials) => credentials.did,
-    };
+    let requester: Option<String> = auth.did_opt().await?;
     match requester {
         None => Ok(ReadAfterWriteResponse::HandlerPipeThrough(res)),
         Some(requester) => {
@@ -61,7 +58,7 @@ pub async fn get_author_feed(
     limit: Option<u8>,
     cursor: Option<String>,
     filter: Option<String>, // Combinations of post/repost types to include in response.
-    auth: AccessStandard,
+    auth: Scoped<RpcProxy>,
     res: HandlerPipeThrough,
     blobstore_factory: &State<BlobstoreFactory>,
     state_local_viewer: &State<SharedLocalViewer>,

--- a/rsky-pds/src/apis/app/bsky/feed/get_feed.rs
+++ b/rsky-pds/src/apis/app/bsky/feed/get_feed.rs
@@ -1,10 +1,10 @@
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
-use crate::auth_verifier::{AccessOutput, AccessStandard};
+use crate::auth_verifier::scope::{RpcProxy, Scoped};
 use crate::config::ServerConfig;
 use crate::pipethrough::{pipethrough, OverrideOpts, ProxyRequest};
 use crate::read_after_write::util::ReadAfterWriteResponse;
-use crate::xrpc_server::types::{HandlerPipeThrough, InvalidRequestError};
+use crate::xrpc_server::types::HandlerPipeThrough;
 use crate::{SharedATPAgent, SharedIdResolver};
 use anyhow::{anyhow, Result};
 use atrium_api::app::bsky::feed::get_feed_generator::{
@@ -32,12 +32,14 @@ impl<'r> FromRequest<'r> for GetFeedPipeThrough {
     type Error = anyhow::Error;
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        match AccessStandard::from_request(req).await {
-            Outcome::Success(output) => {
-                let AccessOutput { credentials, .. } = output.access;
-                let requester: Option<String> = match credentials {
-                    None => None,
-                    Some(credentials) => credentials.did,
+        match Scoped::<RpcProxy>::from_request(req).await {
+            Outcome::Success(auth) => {
+                let requester: Option<String> = match auth.did_opt().await {
+                    Ok(requester) => requester,
+                    Err(api_error) => {
+                        req.local_cache(|| Some(api_error));
+                        return Outcome::Error((Status::Forbidden, anyhow!("InsufficientScope")));
+                    }
                 };
                 if let Some(limit) = req.query_value::<Option<u8>>("limit") {
                     match limit {
@@ -156,10 +158,7 @@ impl<'r> FromRequest<'r> for GetFeedPipeThrough {
             }
             Outcome::Error(err) => {
                 req.local_cache(|| Some(ApiError::InvalidRequest(err.1.to_string())));
-                Outcome::Error((
-                    Status::BadRequest,
-                    anyhow::Error::new(InvalidRequestError::AuthError(err.1)),
-                ))
+                Outcome::Error((Status::BadRequest, anyhow::Error::new(err.1)))
             }
             _ => panic!("Unexpected outcome during Pipethrough"),
         }

--- a/rsky-pds/src/apis/app/bsky/feed/get_post_thread.rs
+++ b/rsky-pds/src/apis/app/bsky/feed/get_post_thread.rs
@@ -2,7 +2,7 @@ use crate::account_manager::AccountManager;
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessStandard;
+use crate::auth_verifier::scope::{RpcProxy, Scoped};
 use crate::config::ServerConfig;
 use crate::models::{ErrorCode, ErrorMessageResponse};
 use crate::read_after_write::types::{LocalRecords, RecordDescript};
@@ -45,7 +45,7 @@ pub async fn inner_get_post_thread(
     uri: String,
     depth: u16,
     parentHeight: u16,
-    auth: AccessStandard,
+    auth: Scoped<RpcProxy>,
     res: Result<HandlerPipeThrough>,
     blobstore_factory: &State<BlobstoreFactory>,
     state_local_viewer: &State<SharedLocalViewer>,
@@ -54,9 +54,8 @@ pub async fn inner_get_post_thread(
     account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<GetPostThreadOutput>> {
     let requester: String = auth
-        .access
-        .credentials
-        .and_then(|credentials| credentials.did)
+        .did_opt()
+        .await?
         .ok_or_else(|| anyhow!("Missing account did on authenticated request"))?;
     match res {
         Ok(res) => {
@@ -128,7 +127,7 @@ pub async fn get_post_thread(
     uri: String,               // Reference (AT-URI) to post record.
     depth: Option<u16>,        // How many levels of reply depth should be included in response.
     parentHeight: Option<u16>, // How many levels of parent (and grandparent, etc.) post to include.
-    auth: AccessStandard,
+    auth: Scoped<RpcProxy>,
     res: Result<HandlerPipeThrough>,
     blobstore_factory: &State<BlobstoreFactory>,
     state_local_viewer: &State<SharedLocalViewer>,

--- a/rsky-pds/src/apis/app/bsky/feed/get_timeline.rs
+++ b/rsky-pds/src/apis/app/bsky/feed/get_timeline.rs
@@ -2,7 +2,7 @@ use crate::account_manager::AccountManager;
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessStandard;
+use crate::auth_verifier::scope::{RpcProxy, Scoped};
 use crate::config::ServerConfig;
 use crate::read_after_write::types::LocalRecords;
 use crate::read_after_write::util::{handle_read_after_write, ReadAfterWriteResponse};
@@ -20,17 +20,14 @@ pub async fn inner_get_timeline(
     _algorithm: Option<String>,
     _limit: Option<u8>,
     _cursor: Option<String>,
-    auth: AccessStandard,
+    auth: Scoped<RpcProxy>,
     res: HandlerPipeThrough,
     blobstore_factory: &State<BlobstoreFactory>,
     state_local_viewer: &State<SharedLocalViewer>,
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<ReadAfterWriteResponse<AuthorFeed>> {
-    let requester: Option<String> = match auth.access.credentials {
-        None => None,
-        Some(credentials) => credentials.did,
-    };
+    let requester: Option<String> = auth.did_opt().await?;
     match requester {
         None => Ok(ReadAfterWriteResponse::HandlerPipeThrough(res)),
         Some(requester) => {
@@ -59,7 +56,7 @@ pub async fn get_timeline(
     algorithm: Option<String>,
     limit: Option<u8>,
     cursor: Option<String>,
-    auth: AccessStandard,
+    auth: Scoped<RpcProxy>,
     res: HandlerPipeThrough,
     blobstore_factory: &State<BlobstoreFactory>,
     state_local_viewer: &State<SharedLocalViewer>,

--- a/rsky-pds/src/apis/app/bsky/notification/register_push.rs
+++ b/rsky-pds/src/apis/app/bsky/notification/register_push.rs
@@ -1,7 +1,7 @@
 use crate::actor_store::ActorStore;
 use crate::apis::app::bsky::util::get_did_doc;
 use crate::apis::ApiError;
-use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
+use crate::auth_verifier::scope::{RpcCall, RpcTarget, Scoped};
 use crate::auth_verifier::AccessStandardSignupQueued;
 use crate::config::ServerConfig;
 use crate::{context, SharedIdResolver, APP_USER_AGENT};
@@ -21,7 +21,7 @@ use rsky_repo::types::Ids;
 
 pub async fn inner_register_push(
     body: Json<RegisterPushInput>,
-    auth: Scoped<NoScopeRequired, AccessStandardSignupQueued>,
+    auth: Scoped<RpcCall, AccessStandardSignupQueued>,
     cfg: &State<ServerConfig>,
     app_view_url: String,
     id_resolver: &State<SharedIdResolver>,
@@ -33,11 +33,13 @@ pub async fn inner_register_push(
         platform,
         app_id,
     } = body.into_inner();
-    let did: String = auth
-        .did_opt()
-        .await?
-        .ok_or_else(|| anyhow!("Missing account did on authenticated request"))?;
     let nsid = Ids::AppBskyNotificationRegisterPush.as_str().to_string();
+    let did: String = auth
+        .did_for(&RpcTarget {
+            lxm: nsid.clone(),
+            aud: service_did.clone(),
+        })
+        .await?;
     let auth_headers =
         context::service_auth_headers(actor_store, &did, &service_did, &nsid).await?;
 
@@ -111,7 +113,7 @@ pub async fn inner_register_push(
 )]
 pub async fn register_push(
     body: Json<RegisterPushInput>,
-    auth: Scoped<NoScopeRequired, AccessStandardSignupQueued>,
+    auth: Scoped<RpcCall, AccessStandardSignupQueued>,
     cfg: &State<ServerConfig>,
     id_resolver: &State<SharedIdResolver>,
     actor_store: &State<ActorStore>,

--- a/rsky-pds/src/apis/app/bsky/notification/register_push.rs
+++ b/rsky-pds/src/apis/app/bsky/notification/register_push.rs
@@ -1,6 +1,7 @@
 use crate::actor_store::ActorStore;
 use crate::apis::app::bsky::util::get_did_doc;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
 use crate::auth_verifier::AccessStandardSignupQueued;
 use crate::config::ServerConfig;
 use crate::{context, SharedIdResolver, APP_USER_AGENT};
@@ -20,7 +21,7 @@ use rsky_repo::types::Ids;
 
 pub async fn inner_register_push(
     body: Json<RegisterPushInput>,
-    auth: AccessStandardSignupQueued,
+    auth: Scoped<NoScopeRequired, AccessStandardSignupQueued>,
     cfg: &State<ServerConfig>,
     app_view_url: String,
     id_resolver: &State<SharedIdResolver>,
@@ -33,9 +34,8 @@ pub async fn inner_register_push(
         app_id,
     } = body.into_inner();
     let did: String = auth
-        .access
-        .credentials
-        .and_then(|credentials| credentials.did)
+        .did_opt()
+        .await?
         .ok_or_else(|| anyhow!("Missing account did on authenticated request"))?;
     let nsid = Ids::AppBskyNotificationRegisterPush.as_str().to_string();
     let auth_headers =
@@ -111,7 +111,7 @@ pub async fn inner_register_push(
 )]
 pub async fn register_push(
     body: Json<RegisterPushInput>,
-    auth: AccessStandardSignupQueued,
+    auth: Scoped<NoScopeRequired, AccessStandardSignupQueued>,
     cfg: &State<ServerConfig>,
     id_resolver: &State<SharedIdResolver>,
     actor_store: &State<ActorStore>,

--- a/rsky-pds/src/apis/app/bsky/notification/unregister_push.rs
+++ b/rsky-pds/src/apis/app/bsky/notification/unregister_push.rs
@@ -1,10 +1,10 @@
 use crate::actor_store::ActorStore;
 use crate::apis::app::bsky::notification::register_push::get_endpoint;
 use crate::apis::ApiError;
-use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
+use crate::auth_verifier::scope::{RpcCall, RpcTarget, Scoped};
 use crate::config::ServerConfig;
 use crate::{context, SharedIdResolver, APP_USER_AGENT};
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use rocket::serde::json::Json;
 use rocket::State;
 use rsky_lexicon::app::bsky::notification::RegisterPushInput;
@@ -12,18 +12,20 @@ use rsky_repo::types::Ids;
 
 pub async fn inner_unregister_push(
     body: Json<RegisterPushInput>,
-    auth: Scoped<NoScopeRequired>,
+    auth: Scoped<RpcCall>,
     cfg: &State<ServerConfig>,
     app_view_url: String,
     id_resolver: &State<SharedIdResolver>,
     actor_store: &State<ActorStore>,
 ) -> Result<()> {
     let input = body.into_inner();
-    let did: String = auth
-        .did_opt()
-        .await?
-        .ok_or_else(|| anyhow!("Missing account did on authenticated request"))?;
     let nsid = Ids::AppBskyNotificationUnregisterPush.as_str().to_string();
+    let did: String = auth
+        .did_for(&RpcTarget {
+            lxm: nsid.clone(),
+            aud: input.service_did.clone(),
+        })
+        .await?;
     let auth_headers =
         context::service_auth_headers(actor_store, &did, &input.service_did, &nsid).await?;
 
@@ -63,7 +65,7 @@ pub async fn inner_unregister_push(
 )]
 pub async fn unregister_push(
     body: Json<RegisterPushInput>,
-    auth: Scoped<NoScopeRequired>,
+    auth: Scoped<RpcCall>,
     cfg: &State<ServerConfig>,
     id_resolver: &State<SharedIdResolver>,
     actor_store: &State<ActorStore>,

--- a/rsky-pds/src/apis/app/bsky/notification/unregister_push.rs
+++ b/rsky-pds/src/apis/app/bsky/notification/unregister_push.rs
@@ -1,7 +1,7 @@
 use crate::actor_store::ActorStore;
 use crate::apis::app::bsky::notification::register_push::get_endpoint;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessStandard;
+use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
 use crate::config::ServerConfig;
 use crate::{context, SharedIdResolver, APP_USER_AGENT};
 use anyhow::{anyhow, bail, Result};
@@ -12,7 +12,7 @@ use rsky_repo::types::Ids;
 
 pub async fn inner_unregister_push(
     body: Json<RegisterPushInput>,
-    auth: AccessStandard,
+    auth: Scoped<NoScopeRequired>,
     cfg: &State<ServerConfig>,
     app_view_url: String,
     id_resolver: &State<SharedIdResolver>,
@@ -20,9 +20,8 @@ pub async fn inner_unregister_push(
 ) -> Result<()> {
     let input = body.into_inner();
     let did: String = auth
-        .access
-        .credentials
-        .and_then(|credentials| credentials.did)
+        .did_opt()
+        .await?
         .ok_or_else(|| anyhow!("Missing account did on authenticated request"))?;
     let nsid = Ids::AppBskyNotificationUnregisterPush.as_str().to_string();
     let auth_headers =
@@ -64,7 +63,7 @@ pub async fn inner_unregister_push(
 )]
 pub async fn unregister_push(
     body: Json<RegisterPushInput>,
-    auth: AccessStandard,
+    auth: Scoped<NoScopeRequired>,
     cfg: &State<ServerConfig>,
     id_resolver: &State<SharedIdResolver>,
     actor_store: &State<ActorStore>,

--- a/rsky-pds/src/apis/com/atproto/identity/get_recommended_did_credentials.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/get_recommended_did_credentials.rs
@@ -3,7 +3,7 @@ use crate::account_manager::AccountManager;
 use crate::actor_store::ActorStore;
 use crate::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessStandard;
+use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
 use crate::config::ServerConfig;
 use rocket::serde::json::Json;
 use rocket::State;
@@ -14,12 +14,12 @@ use serde_json::json;
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/com.atproto.identity.getRecommendedDidCredentials")]
 pub async fn get_recommended_did_credentials(
-    auth: AccessStandard,
+    auth: Scoped<NoScopeRequired>,
     cfg: &State<ServerConfig>,
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<Json<GetRecommendedDidCredentialsResponse>, ApiError> {
-    let requester = auth.access.credentials.unwrap().did.unwrap();
+    let requester = auth.did().await?;
     let availability_flags = AvailabilityFlags {
         include_taken_down: Some(true),
         include_deactivated: Some(true),

--- a/rsky-pds/src/apis/com/atproto/identity/request_plc_operation_signature.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/request_plc_operation_signature.rs
@@ -1,7 +1,7 @@
 use crate::account_manager::helpers::account::{ActorAccount, AvailabilityFlags};
 use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
-use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
+use crate::auth_verifier::scope::{IdentityFull, Scoped};
 use crate::auth_verifier::AccessFull;
 use crate::mailer::{send_plc_operation, TokenParam};
 use crate::models::models::EmailTokenPurpose;
@@ -73,7 +73,7 @@ async fn do_plc_operation(account: &ActorAccount, token: String) -> Result<(), A
 #[rocket::post("/xrpc/com.atproto.identity.requestPlcOperationSignature")]
 #[tracing::instrument(skip_all)]
 pub async fn request_plc_operation_signature(
-    auth: Scoped<NoScopeRequired, AccessFull>,
+    auth: Scoped<IdentityFull, AccessFull>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     let requester = auth.did().await?;

--- a/rsky-pds/src/apis/com/atproto/identity/request_plc_operation_signature.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/request_plc_operation_signature.rs
@@ -1,26 +1,10 @@
 use crate::account_manager::helpers::account::{ActorAccount, AvailabilityFlags};
 use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
 use crate::auth_verifier::AccessFull;
 use crate::mailer::{send_plc_operation, TokenParam};
 use crate::models::models::EmailTokenPurpose;
-
-#[tracing::instrument(skip_all)]
-async fn get_requester_did(auth: &AccessFull) -> Result<String, ApiError> {
-    match &auth.access.credentials {
-        None => {
-            tracing::error!("Failed to find access credentials");
-            Err(ApiError::RuntimeError)
-        }
-        Some(res) => match &res.did {
-            None => {
-                tracing::error!("Failed to find did");
-                Err(ApiError::RuntimeError)
-            }
-            Some(did) => Ok(did.clone()),
-        },
-    }
-}
 
 #[tracing::instrument(skip_all)]
 async fn get_account(
@@ -89,10 +73,10 @@ async fn do_plc_operation(account: &ActorAccount, token: String) -> Result<(), A
 #[rocket::post("/xrpc/com.atproto.identity.requestPlcOperationSignature")]
 #[tracing::instrument(skip_all)]
 pub async fn request_plc_operation_signature(
-    auth: AccessFull,
+    auth: Scoped<NoScopeRequired, AccessFull>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
-    let requester = get_requester_did(&auth).await?;
+    let requester = auth.did().await?;
     let account = get_account(requester.as_str(), &account_manager).await?;
     let token = create_email_token(requester.as_str(), &account_manager).await?;
     do_plc_operation(&account, token).await?;

--- a/rsky-pds/src/apis/com/atproto/identity/sign_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/sign_plc_operation.rs
@@ -1,7 +1,8 @@
 use crate::account_manager::AccountManager;
 use crate::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccountRepoScopedAccess;
+use crate::auth_verifier::scope::{AccountRepo, Scoped};
+use crate::auth_verifier::AccessFull;
 use crate::models::models::EmailTokenPurpose;
 use crate::plc;
 use crate::plc::operations::create_update_op;
@@ -20,10 +21,10 @@ use std::collections::BTreeMap;
 pub async fn sign_plc_operation(
     body: Json<SignPlcOperationRequest>,
     // `AccessFull` (its pre-existing tier) via the guard's default `Base`.
-    auth: AccountRepoScopedAccess,
+    auth: Scoped<AccountRepo, AccessFull>,
     account_manager: AccountManager,
 ) -> Result<Json<Operation>, ApiError> {
-    let did = auth.access.credentials.unwrap().did.unwrap();
+    let did = auth.did().await?;
     let request = body.into_inner();
     let token = request.token.clone();
 

--- a/rsky-pds/src/apis/com/atproto/identity/sign_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/sign_plc_operation.rs
@@ -1,7 +1,7 @@
 use crate::account_manager::AccountManager;
 use crate::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::apis::ApiError;
-use crate::auth_verifier::scope::{AccountRepo, Scoped};
+use crate::auth_verifier::scope::{IdentityFull, Scoped};
 use crate::auth_verifier::AccessFull;
 use crate::models::models::EmailTokenPurpose;
 use crate::plc;
@@ -21,7 +21,7 @@ use std::collections::BTreeMap;
 pub async fn sign_plc_operation(
     body: Json<SignPlcOperationRequest>,
     // `AccessFull` (its pre-existing tier) via the guard's default `Base`.
-    auth: Scoped<AccountRepo, AccessFull>,
+    auth: Scoped<IdentityFull, AccessFull>,
     account_manager: AccountManager,
 ) -> Result<Json<Operation>, ApiError> {
     let did = auth.did().await?;

--- a/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
@@ -3,7 +3,8 @@ use crate::account_manager::AccountManager;
 use crate::actor_store::ActorStore;
 use crate::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::apis::ApiError;
-use crate::auth_verifier::{AccessStandard, AccountRepoScopedAccess};
+use crate::auth_verifier::scope::{AccountRepo, Scoped};
+use crate::auth_verifier::AccessStandard;
 use crate::config::ServerConfig;
 use crate::plc::types::{OpOrTombstone, Operation};
 use crate::{plc, SharedIdResolver, SharedSequencer};
@@ -11,23 +12,6 @@ use rocket::serde::json::Json;
 use rocket::State;
 use rsky_crypto::utils::encode_did_key;
 use rsky_lexicon::com::atproto::identity::SubmitPlcOperationRequest;
-
-#[tracing::instrument(skip_all)]
-fn get_requester_did(auth: &AccountRepoScopedAccess<AccessStandard>) -> Result<String, ApiError> {
-    match &auth.access.credentials {
-        None => {
-            tracing::error!("Failed to find access credentials");
-            Err(ApiError::RuntimeError)
-        }
-        Some(res) => match &res.did {
-            None => {
-                tracing::error!("Failed to find did");
-                Err(ApiError::RuntimeError)
-            }
-            Some(did) => Ok(did.clone()),
-        },
-    }
-}
 
 #[tracing::instrument(skip_all)]
 async fn validate_plc_request(
@@ -167,14 +151,14 @@ pub async fn submit_plc_operation(
     body: Json<SubmitPlcOperationRequest>,
     // `AccessStandard` (its pre-existing tier, app passwords included) named
     // explicitly since it differs from the guard's default `Base`.
-    auth: AccountRepoScopedAccess<AccessStandard>,
+    auth: Scoped<AccountRepo, AccessStandard>,
     sequencer: &State<SharedSequencer>,
     id_resolver: &State<SharedIdResolver>,
     server_config: &State<ServerConfig>,
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
-    let did = get_requester_did(&auth)?;
+    let did = auth.did().await?;
 
     //Validate and transform request
     let op = validate_operation_body(body.into_inner())?;

--- a/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/submit_plc_operation.rs
@@ -3,7 +3,7 @@ use crate::account_manager::AccountManager;
 use crate::actor_store::ActorStore;
 use crate::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::apis::ApiError;
-use crate::auth_verifier::scope::{AccountRepo, Scoped};
+use crate::auth_verifier::scope::{IdentityFull, Scoped};
 use crate::auth_verifier::AccessStandard;
 use crate::config::ServerConfig;
 use crate::plc::types::{OpOrTombstone, Operation};
@@ -151,7 +151,7 @@ pub async fn submit_plc_operation(
     body: Json<SubmitPlcOperationRequest>,
     // `AccessStandard` (its pre-existing tier, app passwords included) named
     // explicitly since it differs from the guard's default `Base`.
-    auth: Scoped<AccountRepo, AccessStandard>,
+    auth: Scoped<IdentityFull, AccessStandard>,
     sequencer: &State<SharedSequencer>,
     id_resolver: &State<SharedIdResolver>,
     server_config: &State<ServerConfig>,

--- a/rsky-pds/src/apis/com/atproto/identity/update_handle.rs
+++ b/rsky-pds/src/apis/com/atproto/identity/update_handle.rs
@@ -2,7 +2,8 @@ use crate::account_manager::helpers::account::AvailabilityFlags;
 use crate::account_manager::AccountManager;
 use crate::apis::com::atproto::server::PDS_PLC_ROTATION_KEYPAIR;
 use crate::apis::ApiError;
-use crate::auth_verifier::HandleScopedAccess;
+use crate::auth_verifier::scope::{IdentityHandle, Scoped};
+use crate::auth_verifier::AccessStandardCheckTakedown;
 use crate::config::ServerConfig;
 use crate::handle::{normalize_and_validate_handle, HandleValidationContext, HandleValidationOpts};
 use crate::{plc, SharedIdResolver, SharedSequencer};
@@ -18,11 +19,11 @@ async fn inner_update_handle(
     sequencer: &State<SharedSequencer>,
     server_config: &State<ServerConfig>,
     id_resolver: &State<SharedIdResolver>,
-    auth: HandleScopedAccess,
+    auth: Scoped<IdentityHandle, AccessStandardCheckTakedown>,
     account_manager: AccountManager,
 ) -> Result<()> {
     let UpdateHandleInput { handle } = body.into_inner();
-    let requester = auth.access.credentials.unwrap().did.unwrap();
+    let requester = auth.did().await?;
 
     let opts = HandleValidationOpts {
         handle,
@@ -92,7 +93,7 @@ pub async fn update_handle(
     sequencer: &State<SharedSequencer>,
     server_config: &State<ServerConfig>,
     id_resolver: &State<SharedIdResolver>,
-    auth: HandleScopedAccess,
+    auth: Scoped<IdentityHandle, AccessStandardCheckTakedown>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     match inner_update_handle(

--- a/rsky-pds/src/apis/com/atproto/moderation/create_report.rs
+++ b/rsky-pds/src/apis/com/atproto/moderation/create_report.rs
@@ -1,5 +1,5 @@
 use crate::apis::{ApiError, ProxyResponder};
-use crate::auth_verifier::AccessStandard;
+use crate::auth_verifier::scope::{RpcProxy, Scoped};
 use crate::pipethrough::{pipethrough_error, pipethrough_procedure, ProxyRequest};
 use rocket::http::Header;
 use rocket::serde::json::Json;
@@ -24,12 +24,12 @@ pub fn validate_report_input(input: &CreateReportInput) -> Result<(), ApiError> 
 )]
 pub async fn create_report(
     body: Json<CreateReportInput>,
-    auth: AccessStandard,
+    auth: Scoped<RpcProxy>,
     req: ProxyRequest<'_>,
 ) -> Result<ProxyResponder, ApiError> {
     let input = body.into_inner();
     validate_report_input(&input)?;
-    let requester: Option<String> = auth.access.credentials.and_then(|c| c.did);
+    let requester: Option<String> = auth.did_opt().await?;
     match pipethrough_procedure(&req, requester, Some(input)).await {
         Ok(res) => {
             let content_length = Header::new("content-length", res.buffer.len().to_string());

--- a/rsky-pds/src/apis/com/atproto/repo/apply_writes.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/apply_writes.rs
@@ -3,6 +3,7 @@ use crate::account_manager::AccountManager;
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{RepoTarget, RepoWrite, Scoped};
 use crate::auth_verifier::AccessStandardIncludeChecks;
 use crate::repo::prepare::{
     prepare_create, prepare_delete, prepare_update, PrepareCreateOpts, PrepareDeleteOpts,
@@ -23,7 +24,7 @@ use std::str::FromStr;
 
 async fn inner_apply_writes(
     body: Json<ApplyWritesInput>,
-    auth: AccessStandardIncludeChecks,
+    requester: String,
     sequencer: &State<SharedSequencer>,
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,
@@ -51,7 +52,7 @@ async fn inner_apply_writes(
             bail!("Account is deactivated")
         }
         let did = account.did;
-        if did != auth.access.credentials.unwrap().did.unwrap() {
+        if did != requester {
             bail!("AuthRequiredError")
         }
         let did: &String = &did;
@@ -164,30 +165,32 @@ async fn inner_apply_writes(
 #[rocket::post("/xrpc/com.atproto.repo.applyWrites", format = "json", data = "<body>")]
 pub async fn apply_writes(
     body: Json<ApplyWritesInput>,
-    auth: AccessStandardIncludeChecks,
+    auth: Scoped<RepoWrite, AccessStandardIncludeChecks>,
     sequencer: &State<SharedSequencer>,
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<Json<ApplyWritesOutput>, ApiError> {
     tracing::debug!("@LOG: debug apply_writes {body:#?}");
-    for write in &body.writes {
-        let (collection, action) = match write {
+    let targets: Vec<RepoTarget> = body
+        .writes
+        .iter()
+        .map(|write| match write {
             ApplyWritesInputRefWrite::Create(w) => {
-                (&w.collection, crate::oauth_scope::RepoAction::Create)
+                RepoTarget::new(w.collection.clone(), crate::oauth_scope::RepoAction::Create)
             }
             ApplyWritesInputRefWrite::Update(w) => {
-                (&w.collection, crate::oauth_scope::RepoAction::Update)
+                RepoTarget::new(w.collection.clone(), crate::oauth_scope::RepoAction::Update)
             }
             ApplyWritesInputRefWrite::Delete(w) => {
-                (&w.collection, crate::oauth_scope::RepoAction::Delete)
+                RepoTarget::new(w.collection.clone(), crate::oauth_scope::RepoAction::Delete)
             }
-        };
-        crate::apis::assert_repo_scope(&auth.access.credentials, collection, action)?;
-    }
+        })
+        .collect();
+    let requester = auth.did_for(&targets).await?;
     match inner_apply_writes(
         body,
-        auth,
+        requester,
         sequencer,
         blobstore_factory,
         actor_store,

--- a/rsky-pds/src/apis/com/atproto/repo/create_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/create_record.rs
@@ -3,6 +3,7 @@ use crate::account_manager::AccountManager;
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{RepoTarget, RepoWrite, Scoped};
 use crate::auth_verifier::AccessStandardIncludeChecks;
 use crate::repo::prepare::{prepare_create, prepare_delete, PrepareCreateOpts, PrepareDeleteOpts};
 use crate::SharedSequencer;
@@ -17,7 +18,7 @@ use std::str::FromStr;
 
 async fn inner_create_record(
     body: Json<CreateRecordInput>,
-    auth: AccessStandardIncludeChecks,
+    requester: String,
     sequencer: &State<SharedSequencer>,
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,
@@ -45,7 +46,7 @@ async fn inner_create_record(
             bail!("Account is deactivated")
         }
         let did = account.did;
-        if did != auth.access.credentials.unwrap().did.unwrap() {
+        if did != requester {
             bail!("AuthRequiredError")
         }
         let swap_commit_cid = match swap_commit {
@@ -118,21 +119,22 @@ async fn inner_create_record(
 )]
 pub async fn create_record(
     body: Json<CreateRecordInput>,
-    auth: AccessStandardIncludeChecks,
+    auth: Scoped<RepoWrite, AccessStandardIncludeChecks>,
     sequencer: &State<SharedSequencer>,
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<Json<CreateRecordOutput>, ApiError> {
     tracing::debug!("@LOG: debug create_record {body:#?}");
-    crate::apis::assert_repo_scope(
-        &auth.access.credentials,
-        &body.collection,
-        crate::oauth_scope::RepoAction::Create,
-    )?;
+    let requester = auth
+        .did_for(&vec![RepoTarget::new(
+            body.collection.clone(),
+            crate::oauth_scope::RepoAction::Create,
+        )])
+        .await?;
     match inner_create_record(
         body,
-        auth,
+        requester,
         sequencer,
         blobstore_factory,
         actor_store,

--- a/rsky-pds/src/apis/com/atproto/repo/delete_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/delete_record.rs
@@ -3,6 +3,7 @@ use crate::account_manager::AccountManager;
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{RepoTarget, RepoWrite, Scoped};
 use crate::auth_verifier::AccessStandardIncludeChecks;
 use crate::repo::prepare::{prepare_delete, PrepareDeleteOpts};
 use crate::SharedSequencer;
@@ -17,7 +18,7 @@ use std::str::FromStr;
 
 async fn inner_delete_record(
     body: Json<DeleteRecordInput>,
-    auth: AccessStandardIncludeChecks,
+    requester: String,
     sequencer: &State<SharedSequencer>,
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,
@@ -44,7 +45,7 @@ async fn inner_delete_record(
         Some(account) if account.deactivated_at.is_some() => bail!("Account is deactivated"),
         Some(account) => {
             let did = account.did;
-            if did != auth.access.credentials.unwrap().did.unwrap() {
+            if did != requester {
                 bail!("AuthRequiredError")
             }
 
@@ -99,20 +100,21 @@ async fn inner_delete_record(
 )]
 pub async fn delete_record(
     body: Json<DeleteRecordInput>,
-    auth: AccessStandardIncludeChecks,
+    auth: Scoped<RepoWrite, AccessStandardIncludeChecks>,
     sequencer: &State<SharedSequencer>,
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
-    crate::apis::assert_repo_scope(
-        &auth.access.credentials,
-        &body.collection,
-        crate::oauth_scope::RepoAction::Delete,
-    )?;
+    let requester = auth
+        .did_for(&vec![RepoTarget::new(
+            body.collection.clone(),
+            crate::oauth_scope::RepoAction::Delete,
+        )])
+        .await?;
     match inner_delete_record(
         body,
-        auth,
+        requester,
         sequencer,
         blobstore_factory,
         actor_store,

--- a/rsky-pds/src/apis/com/atproto/repo/import_repo.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/import_repo.rs
@@ -1,6 +1,7 @@
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{AccountRepo, Scoped};
 use crate::auth_verifier::AccessFullImport;
 use crate::repo::prepare::{
     prepare_create, prepare_delete, prepare_update, PrepareCreateOpts, PrepareDeleteOpts,
@@ -73,12 +74,12 @@ impl<'r> FromData<'r> for ImportRepoInput {
 #[tracing::instrument(skip_all)]
 #[rocket::post("/xrpc/com.atproto.repo.importRepo", data = "<import_repo_input>")]
 pub async fn import_repo(
-    auth: AccessFullImport,
+    auth: Scoped<AccountRepo, AccessFullImport>,
     import_repo_input: ImportRepoInput,
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,
 ) -> Result<(), ApiError> {
-    let requester = auth.access.credentials.unwrap().did.unwrap();
+    let requester = auth.did().await?;
     let mut actor_store = actor_store
         .transact(
             requester.clone(),

--- a/rsky-pds/src/apis/com/atproto/repo/list_missing_blobs.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/list_missing_blobs.rs
@@ -2,6 +2,7 @@ use crate::actor_store::blob::ListMissingBlobsOpts;
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
 use crate::auth_verifier::AccessFull;
 use anyhow::Result;
 use rocket::serde::json::Json;
@@ -13,11 +14,11 @@ use rsky_lexicon::com::atproto::repo::ListMissingBlobsOutput;
 pub async fn list_missing_blobs(
     limit: Option<u16>,
     cursor: Option<String>,
-    auth: AccessFull,
+    auth: Scoped<NoScopeRequired, AccessFull>,
     actor_store: &State<ActorStore>,
     blobstore_factory: &State<BlobstoreFactory>,
 ) -> Result<Json<ListMissingBlobsOutput>, ApiError> {
-    let did = auth.access.credentials.unwrap().did.unwrap();
+    let did = auth.did().await?;
     let limit: u16 = limit.unwrap_or(500);
 
     let actor_store = actor_store

--- a/rsky-pds/src/apis/com/atproto/repo/put_record.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/put_record.rs
@@ -3,6 +3,7 @@ use crate::account_manager::AccountManager;
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{RepoTarget, RepoWrite, Scoped};
 use crate::auth_verifier::AccessStandardIncludeChecks;
 use crate::repo::prepare::{prepare_create, prepare_update, PrepareCreateOpts, PrepareUpdateOpts};
 use crate::SharedSequencer;
@@ -18,7 +19,7 @@ use std::str::FromStr;
 #[tracing::instrument(skip_all)]
 async fn inner_put_record(
     body: Json<PutRecordInput>,
-    auth: AccessStandardIncludeChecks,
+    requester: String,
     sequencer: &State<SharedSequencer>,
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,
@@ -47,7 +48,7 @@ async fn inner_put_record(
             bail!("Account is deactivated")
         }
         let did = account.did;
-        if did != auth.access.credentials.unwrap().did.unwrap() {
+        if did != requester {
             bail!("AuthRequiredError")
         }
         let uri = AtUri::make(did.clone(), Some(collection.clone()), Some(rkey.clone()))?;
@@ -126,26 +127,28 @@ async fn inner_put_record(
 #[rocket::post("/xrpc/com.atproto.repo.putRecord", format = "json", data = "<body>")]
 pub async fn put_record(
     body: Json<PutRecordInput>,
-    auth: AccessStandardIncludeChecks,
+    auth: Scoped<RepoWrite, AccessStandardIncludeChecks>,
     sequencer: &State<SharedSequencer>,
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<Json<PutRecordOutput>, ApiError> {
     tracing::debug!("@LOG: debug put_record {body:#?}");
-    crate::apis::assert_repo_scope(
-        &auth.access.credentials,
-        &body.collection,
-        crate::oauth_scope::RepoAction::Create,
-    )?;
-    crate::apis::assert_repo_scope(
-        &auth.access.credentials,
-        &body.collection,
-        crate::oauth_scope::RepoAction::Update,
-    )?;
+    let requester = auth
+        .did_for(&vec![
+            RepoTarget::new(
+                body.collection.clone(),
+                crate::oauth_scope::RepoAction::Create,
+            ),
+            RepoTarget::new(
+                body.collection.clone(),
+                crate::oauth_scope::RepoAction::Update,
+            ),
+        ])
+        .await?;
     match inner_put_record(
         body,
-        auth,
+        requester,
         sequencer,
         blobstore_factory,
         actor_store,

--- a/rsky-pds/src/apis/com/atproto/repo/upload_blob.rs
+++ b/rsky-pds/src/apis/com/atproto/repo/upload_blob.rs
@@ -1,7 +1,8 @@
 use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
-use crate::auth_verifier::BlobScopedAccess;
+use crate::auth_verifier::scope::{BlobUpload, Scoped};
+use crate::auth_verifier::AccessStandardCheckTakedown;
 use anyhow::Result;
 use rocket::data::{Data, ToByteUnit};
 use rocket::http::Status;
@@ -36,13 +37,13 @@ impl<'r> FromRequest<'r> for ContentType {
 }
 
 async fn inner_upload_blob(
-    auth: BlobScopedAccess,
+    auth: Scoped<BlobUpload, AccessStandardCheckTakedown>,
     blob: Data<'_>,
     content_type: ContentType,
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,
 ) -> Result<BlobOutput> {
-    let requester = auth.access.credentials.unwrap().did.unwrap();
+    let requester = auth.did().await?;
 
     let bytes = blob.open(100.mebibytes()).into_bytes().await?.into_inner();
     let actor_store = actor_store
@@ -97,7 +98,7 @@ pub async fn upload_blob(
     // guard's rejection before `BlobScopedAccess` re-reads the same header
     // to run the `blob:` scope check.
     content_type: ContentType,
-    auth: BlobScopedAccess,
+    auth: Scoped<BlobUpload, AccessStandardCheckTakedown>,
     blob: Data<'_>,
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,

--- a/rsky-pds/src/apis/com/atproto/server/activate_account.rs
+++ b/rsky-pds/src/apis/com/atproto/server/activate_account.rs
@@ -4,6 +4,7 @@ use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::com::atproto::server::assert_valid_did_documents_for_service;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{OAuthForbidden, Scoped};
 use crate::auth_verifier::AccessFull;
 use crate::SharedSequencer;
 use rocket::State;
@@ -11,13 +12,13 @@ use rsky_syntax::handle::INVALID_HANDLE;
 
 #[tracing::instrument(skip_all)]
 async fn inner_activate_account(
-    auth: AccessFull,
+    auth: Scoped<OAuthForbidden, AccessFull>,
     sequencer: &State<SharedSequencer>,
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
-    let requester = auth.access.credentials.unwrap().did.unwrap();
+    let requester = auth.did().await?;
     assert_valid_did_documents_for_service(actor_store, requester.clone()).await?;
 
     let account = account_manager
@@ -60,7 +61,7 @@ async fn inner_activate_account(
 #[tracing::instrument(skip_all)]
 #[rocket::post("/xrpc/com.atproto.server.activateAccount")]
 pub async fn activate_account(
-    auth: AccessFull,
+    auth: Scoped<OAuthForbidden, AccessFull>,
     sequencer: &State<SharedSequencer>,
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,

--- a/rsky-pds/src/apis/com/atproto/server/check_account_status.rs
+++ b/rsky-pds/src/apis/com/atproto/server/check_account_status.rs
@@ -3,6 +3,7 @@ use crate::actor_store::blobstore::BlobstoreFactory;
 use crate::actor_store::ActorStore;
 use crate::apis::com::atproto::server::is_valid_did_doc_for_service;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
 use crate::auth_verifier::AccessFull;
 use anyhow::Result;
 use futures::try_join;
@@ -11,12 +12,12 @@ use rocket::State;
 use rsky_lexicon::com::atproto::server::CheckAccountStatusOutput;
 
 async fn inner_check_account_status(
-    auth: AccessFull,
+    auth: Scoped<NoScopeRequired, AccessFull>,
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,
 ) -> Result<CheckAccountStatusOutput> {
-    let requester = auth.access.credentials.unwrap().did.unwrap();
+    let requester = auth.did().await?;
 
     let mut reader = actor_store
         .read(
@@ -59,7 +60,7 @@ async fn inner_check_account_status(
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/com.atproto.server.checkAccountStatus")]
 pub async fn check_account_status(
-    auth: AccessFull,
+    auth: Scoped<NoScopeRequired, AccessFull>,
     blobstore_factory: &State<BlobstoreFactory>,
     actor_store: &State<ActorStore>,
     account_manager: AccountManager,

--- a/rsky-pds/src/apis/com/atproto/server/confirm_email.rs
+++ b/rsky-pds/src/apis/com/atproto/server/confirm_email.rs
@@ -1,6 +1,7 @@
 use crate::account_manager::helpers::account::AvailabilityFlags;
 use crate::account_manager::{AccountManager, ConfirmEmailOpts};
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
 use crate::auth_verifier::AccessStandardIncludeChecks;
 use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::server::ConfirmEmailInput;
@@ -8,10 +9,10 @@ use rsky_lexicon::com::atproto::server::ConfirmEmailInput;
 #[tracing::instrument(skip_all)]
 async fn inner_confirm_email(
     body: Json<ConfirmEmailInput>,
-    auth: AccessStandardIncludeChecks,
+    auth: Scoped<NoScopeRequired, AccessStandardIncludeChecks>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
-    let did = auth.access.credentials.unwrap().did.unwrap();
+    let did = auth.did().await?;
 
     let user = match account_manager
         .get_account(
@@ -65,7 +66,7 @@ async fn inner_confirm_email(
 )]
 pub async fn confirm_email(
     body: Json<ConfirmEmailInput>,
-    auth: AccessStandardIncludeChecks,
+    auth: Scoped<NoScopeRequired, AccessStandardIncludeChecks>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     match inner_confirm_email(body, auth, account_manager).await {

--- a/rsky-pds/src/apis/com/atproto/server/confirm_email.rs
+++ b/rsky-pds/src/apis/com/atproto/server/confirm_email.rs
@@ -1,7 +1,7 @@
 use crate::account_manager::helpers::account::AvailabilityFlags;
 use crate::account_manager::{AccountManager, ConfirmEmailOpts};
 use crate::apis::ApiError;
-use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
+use crate::auth_verifier::scope::{AccountEmail, Scoped};
 use crate::auth_verifier::AccessStandardIncludeChecks;
 use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::server::ConfirmEmailInput;
@@ -9,7 +9,7 @@ use rsky_lexicon::com::atproto::server::ConfirmEmailInput;
 #[tracing::instrument(skip_all)]
 async fn inner_confirm_email(
     body: Json<ConfirmEmailInput>,
-    auth: Scoped<NoScopeRequired, AccessStandardIncludeChecks>,
+    auth: Scoped<AccountEmail, AccessStandardIncludeChecks>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     let did = auth.did().await?;
@@ -66,7 +66,7 @@ async fn inner_confirm_email(
 )]
 pub async fn confirm_email(
     body: Json<ConfirmEmailInput>,
-    auth: Scoped<NoScopeRequired, AccessStandardIncludeChecks>,
+    auth: Scoped<AccountEmail, AccessStandardIncludeChecks>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     match inner_confirm_email(body, auth, account_manager).await {

--- a/rsky-pds/src/apis/com/atproto/server/create_app_password.rs
+++ b/rsky-pds/src/apis/com/atproto/server/create_app_password.rs
@@ -1,5 +1,6 @@
 use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{OAuthForbidden, Scoped};
 use crate::auth_verifier::AccessFull;
 use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::server::{CreateAppPasswordInput, CreateAppPasswordOutput};
@@ -12,12 +13,12 @@ use rsky_lexicon::com::atproto::server::{CreateAppPasswordInput, CreateAppPasswo
 )]
 pub async fn create_app_password(
     body: Json<CreateAppPasswordInput>,
-    auth: AccessFull,
+    auth: Scoped<OAuthForbidden, AccessFull>,
     account_manager: AccountManager,
 ) -> Result<Json<CreateAppPasswordOutput>, ApiError> {
     let CreateAppPasswordInput { name } = body.into_inner();
     match account_manager
-        .create_app_password(auth.access.credentials.unwrap().did.unwrap(), name)
+        .create_app_password(auth.did().await?, name)
         .await
     {
         Ok(app_password) => Ok(Json(app_password)),

--- a/rsky-pds/src/apis/com/atproto/server/deactivate_account.rs
+++ b/rsky-pds/src/apis/com/atproto/server/deactivate_account.rs
@@ -1,6 +1,7 @@
 use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccountStatusScopedAccess;
+use crate::auth_verifier::scope::{AccountStatus, Scoped};
+use crate::auth_verifier::AccessFull;
 use anyhow::Result;
 use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::server::DeactivateAccountInput;
@@ -13,10 +14,10 @@ use rsky_lexicon::com::atproto::server::DeactivateAccountInput;
 )]
 pub async fn deactivate_account(
     body: Json<DeactivateAccountInput>,
-    auth: AccountStatusScopedAccess,
+    auth: Scoped<AccountStatus, AccessFull>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
-    let did = auth.access.credentials.unwrap().did.unwrap();
+    let did = auth.did().await?;
     let DeactivateAccountInput { delete_after } = body.into_inner();
     match account_manager.deactivate_account(&did, delete_after).await {
         Ok(()) => Ok(()),

--- a/rsky-pds/src/apis/com/atproto/server/get_account_invite_codes.rs
+++ b/rsky-pds/src/apis/com/atproto/server/get_account_invite_codes.rs
@@ -2,6 +2,7 @@ use crate::account_manager::helpers::invite::CodeDetail;
 use crate::account_manager::AccountManager;
 use crate::apis::com::atproto::server::gen_invite_codes;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{OAuthForbidden, Scoped};
 use crate::auth_verifier::AccessFull;
 use anyhow::{bail, Result};
 use chrono::NaiveDateTime;
@@ -84,10 +85,10 @@ fn calculate_codes_to_create(opts: CalculateCodesToCreateOpts) -> Result<(usize,
 async fn inner_get_account_invite_codes(
     include_used: bool,
     create_available: bool,
-    auth: AccessFull,
+    auth: Scoped<OAuthForbidden, AccessFull>,
     account_manager: AccountManager,
 ) -> Result<GetAccountInviteCodesOutput> {
-    let requester = auth.access.credentials.unwrap().did.unwrap();
+    let requester = auth.did().await?;
     let account = account_manager.get_account(&requester, None).await?;
     let mut user_codes = account_manager.get_account_invite_codes(&requester).await?;
 
@@ -147,7 +148,7 @@ async fn inner_get_account_invite_codes(
 pub async fn get_account_invite_codes(
     includeUsed: bool,
     createAvailable: bool,
-    auth: AccessFull,
+    auth: Scoped<OAuthForbidden, AccessFull>,
     account_manager: AccountManager,
 ) -> Result<Json<GetAccountInviteCodesOutput>, ApiError> {
     match inner_get_account_invite_codes(includeUsed, createAvailable, auth, account_manager).await

--- a/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
+++ b/rsky-pds/src/apis/com/atproto/server/get_service_auth.rs
@@ -1,6 +1,7 @@
 use crate::account_manager::helpers::auth::{create_service_jwt, ServiceJwtParams};
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
 use crate::auth_verifier::AccessFull;
 use crate::pipethrough::{PRIVILEGED_METHODS, PROTECTED_METHODS};
 use anyhow::{bail, Result};
@@ -48,10 +49,10 @@ pub async fn inner_get_service_auth(
     aud: String,
     exp: Option<u64>,
     lxm: Option<String>,
-    auth: AccessFull,
+    auth: Scoped<NoScopeRequired, AccessFull>,
     actor_store: &State<ActorStore>,
 ) -> Result<String> {
-    let credentials = auth.access.credentials.unwrap();
+    let credentials = auth.credentials().await?.clone().unwrap();
     let did = credentials.clone().did.unwrap();
     ensure_valid_aud(&aud)?;
     // `exp` is seconds since the epoch (RFC 7519 §4.1.4).
@@ -98,7 +99,7 @@ pub async fn get_service_auth(
     exp: Option<u64>,
     // Lexicon (XRPC) method to bind the requested token to
     lxm: Option<String>,
-    auth: AccessFull,
+    auth: Scoped<NoScopeRequired, AccessFull>,
     actor_store: &State<ActorStore>,
 ) -> Result<Json<GetServiceAuthOutput>, ApiError> {
     match inner_get_service_auth(aud, exp, lxm, auth, actor_store).await {

--- a/rsky-pds/src/apis/com/atproto/server/get_session.rs
+++ b/rsky-pds/src/apis/com/atproto/server/get_session.rs
@@ -1,6 +1,6 @@
 use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
-use crate::auth_verifier::AccessStandard;
+use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
 use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::server::GetSessionOutput;
 use rsky_syntax::handle::INVALID_HANDLE;
@@ -8,10 +8,10 @@ use rsky_syntax::handle::INVALID_HANDLE;
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/com.atproto.server.getSession")]
 pub async fn get_session(
-    auth: AccessStandard,
+    auth: Scoped<NoScopeRequired>,
     account_manager: AccountManager,
 ) -> Result<Json<GetSessionOutput>, ApiError> {
-    let did = auth.access.credentials.unwrap().did.unwrap();
+    let did = auth.did().await?;
     match account_manager.get_account(&did, None).await {
         Ok(Some(user)) => Ok(Json(GetSessionOutput {
             handle: user.handle.unwrap_or(INVALID_HANDLE.to_string()),

--- a/rsky-pds/src/apis/com/atproto/server/list_app_passwords.rs
+++ b/rsky-pds/src/apis/com/atproto/server/list_app_passwords.rs
@@ -1,5 +1,6 @@
 use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{OAuthForbidden, Scoped};
 use crate::auth_verifier::AccessFull;
 use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::server::{AppPassword, ListAppPasswordsOutput};
@@ -7,10 +8,10 @@ use rsky_lexicon::com::atproto::server::{AppPassword, ListAppPasswordsOutput};
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/com.atproto.server.listAppPasswords")]
 pub async fn list_app_passwords(
-    auth: AccessFull,
+    auth: Scoped<OAuthForbidden, AccessFull>,
     account_manager: AccountManager,
 ) -> Result<Json<ListAppPasswordsOutput>, ApiError> {
-    let did = auth.access.credentials.unwrap().did.unwrap();
+    let did = auth.did().await?;
     match account_manager.list_app_passwords(&did).await {
         Ok(passwords) => {
             let passwords: Vec<AppPassword> = passwords

--- a/rsky-pds/src/apis/com/atproto/server/request_account_delete.rs
+++ b/rsky-pds/src/apis/com/atproto/server/request_account_delete.rs
@@ -1,6 +1,7 @@
 use crate::account_manager::helpers::account::AvailabilityFlags;
 use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{OAuthForbidden, Scoped};
 use crate::auth_verifier::AccessStandardIncludeChecks;
 use crate::mailer;
 use crate::mailer::TokenParam;
@@ -8,10 +9,10 @@ use crate::models::models::EmailTokenPurpose;
 use anyhow::{bail, Result};
 
 async fn inner_request_account_delete(
-    auth: AccessStandardIncludeChecks,
+    auth: Scoped<OAuthForbidden, AccessStandardIncludeChecks>,
     account_manager: AccountManager,
 ) -> Result<()> {
-    let did = auth.access.credentials.unwrap().did.unwrap();
+    let did = auth.did().await?;
     let account = account_manager
         .get_account(
             &did,
@@ -39,7 +40,7 @@ async fn inner_request_account_delete(
 #[tracing::instrument(skip_all)]
 #[rocket::post("/xrpc/com.atproto.server.requestAccountDelete")]
 pub async fn request_account_delete(
-    auth: AccessStandardIncludeChecks,
+    auth: Scoped<OAuthForbidden, AccessStandardIncludeChecks>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     match inner_request_account_delete(auth, account_manager).await {

--- a/rsky-pds/src/apis/com/atproto/server/request_email_confirmation.rs
+++ b/rsky-pds/src/apis/com/atproto/server/request_email_confirmation.rs
@@ -1,6 +1,7 @@
 use crate::account_manager::helpers::account::AvailabilityFlags;
 use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{AccountEmail, Scoped};
 use crate::auth_verifier::AccessStandardIncludeChecks;
 use crate::mailer;
 use crate::mailer::TokenParam;
@@ -8,10 +9,10 @@ use crate::models::models::EmailTokenPurpose;
 use anyhow::{bail, Result};
 
 async fn inner_request_email_confirmation(
-    auth: AccessStandardIncludeChecks,
+    auth: Scoped<AccountEmail, AccessStandardIncludeChecks>,
     account_manager: AccountManager,
 ) -> Result<()> {
-    let did = auth.access.credentials.unwrap().did.unwrap();
+    let did = auth.did().await?;
     let account = account_manager
         .get_account(
             &did,
@@ -39,7 +40,7 @@ async fn inner_request_email_confirmation(
 #[tracing::instrument(skip_all)]
 #[rocket::post("/xrpc/com.atproto.server.requestEmailConfirmation")]
 pub async fn request_email_confirmation(
-    auth: AccessStandardIncludeChecks,
+    auth: Scoped<AccountEmail, AccessStandardIncludeChecks>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     match inner_request_email_confirmation(auth, account_manager).await {

--- a/rsky-pds/src/apis/com/atproto/server/request_email_update.rs
+++ b/rsky-pds/src/apis/com/atproto/server/request_email_update.rs
@@ -1,6 +1,7 @@
 use crate::account_manager::helpers::account::AvailabilityFlags;
 use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{OAuthForbidden, Scoped};
 use crate::auth_verifier::AccessStandardIncludeChecks;
 use crate::mailer;
 use crate::mailer::TokenParam;
@@ -10,10 +11,10 @@ use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::server::RequestEmailUpdateOutput;
 
 async fn inner_request_email_update(
-    auth: AccessStandardIncludeChecks,
+    auth: Scoped<OAuthForbidden, AccessStandardIncludeChecks>,
     account_manager: AccountManager,
 ) -> Result<RequestEmailUpdateOutput> {
-    let did = auth.access.credentials.unwrap().did.unwrap();
+    let did = auth.did().await?;
     let account = account_manager
         .get_account(
             &did,
@@ -45,7 +46,7 @@ async fn inner_request_email_update(
 #[tracing::instrument(skip_all)]
 #[rocket::post("/xrpc/com.atproto.server.requestEmailUpdate")]
 pub async fn request_email_update(
-    auth: AccessStandardIncludeChecks,
+    auth: Scoped<OAuthForbidden, AccessStandardIncludeChecks>,
     account_manager: AccountManager,
 ) -> Result<Json<RequestEmailUpdateOutput>, ApiError> {
     match inner_request_email_update(auth, account_manager).await {

--- a/rsky-pds/src/apis/com/atproto/server/request_password_reset.rs
+++ b/rsky-pds/src/apis/com/atproto/server/request_password_reset.rs
@@ -1,6 +1,7 @@
 use crate::account_manager::helpers::account::AvailabilityFlags;
 use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
 use crate::auth_verifier::AccessStandardIncludeChecks;
 use crate::mailer;
 use crate::mailer::IdentifierAndTokenParams;
@@ -56,7 +57,7 @@ async fn inner_request_password_reset(
 )]
 pub async fn request_password_reset(
     body: Json<RequestPasswordResetInput>,
-    _auth: AccessStandardIncludeChecks,
+    _auth: Scoped<NoScopeRequired, AccessStandardIncludeChecks>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     match inner_request_password_reset(body, account_manager).await {

--- a/rsky-pds/src/apis/com/atproto/server/revoke_app_password.rs
+++ b/rsky-pds/src/apis/com/atproto/server/revoke_app_password.rs
@@ -1,5 +1,6 @@
 use crate::account_manager::AccountManager;
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{OAuthForbidden, Scoped};
 use crate::auth_verifier::AccessFull;
 use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::server::RevokeAppPasswordInput;
@@ -12,11 +13,11 @@ use rsky_lexicon::com::atproto::server::RevokeAppPasswordInput;
 )]
 pub async fn revoke_app_password(
     body: Json<RevokeAppPasswordInput>,
-    auth: AccessFull,
+    auth: Scoped<OAuthForbidden, AccessFull>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     let RevokeAppPasswordInput { name } = body.into_inner();
-    let requester = auth.access.credentials.unwrap().did.unwrap();
+    let requester = auth.did().await?;
 
     match account_manager.revoke_app_password(requester, name).await {
         Ok(_) => Ok(()),

--- a/rsky-pds/src/apis/com/atproto/server/update_email.rs
+++ b/rsky-pds/src/apis/com/atproto/server/update_email.rs
@@ -1,7 +1,8 @@
 use crate::account_manager::helpers::account::{AccountHelperError, AvailabilityFlags};
 use crate::account_manager::{AccountManager, UpdateEmailOpts};
 use crate::apis::ApiError;
-use crate::auth_verifier::EmailScopedAccess;
+use crate::auth_verifier::scope::{AccountEmail, Scoped};
+use crate::auth_verifier::AccessFull;
 use crate::models::models::EmailTokenPurpose;
 use anyhow::{bail, Result};
 use rocket::serde::json::Json;
@@ -9,10 +10,10 @@ use rsky_lexicon::com::atproto::server::UpdateEmailInput;
 
 async fn inner_update_email(
     body: Json<UpdateEmailInput>,
-    auth: EmailScopedAccess,
+    auth: Scoped<AccountEmail, AccessFull>,
     account_manager: AccountManager,
 ) -> Result<()> {
-    let did = auth.access.credentials.unwrap().did.unwrap();
+    let did = auth.did().await?;
     let UpdateEmailInput { email, token } = body.into_inner();
     if !mailchecker::is_valid(&email) {
         bail!("This email address is not supported, please use a different email.")
@@ -63,7 +64,7 @@ async fn inner_update_email(
 )]
 pub async fn update_email(
     body: Json<UpdateEmailInput>,
-    auth: EmailScopedAccess,
+    auth: Scoped<AccountEmail, AccessFull>,
     account_manager: AccountManager,
 ) -> Result<(), ApiError> {
     match inner_update_email(body, auth, account_manager).await {

--- a/rsky-pds/src/apis/com/atproto/temp/check_signup_queue.rs
+++ b/rsky-pds/src/apis/com/atproto/temp/check_signup_queue.rs
@@ -1,4 +1,5 @@
 use crate::apis::ApiError;
+use crate::auth_verifier::scope::{OAuthForbidden, Scoped};
 use crate::auth_verifier::AccessStandardSignupQueued;
 use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::temp::CheckSignupQueueOutput;
@@ -8,7 +9,7 @@ use rsky_lexicon::com::atproto::temp::CheckSignupQueueOutput;
 #[tracing::instrument(skip_all)]
 #[rocket::get("/xrpc/com.atproto.temp.checkSignupQueue")]
 pub async fn check_signup_queue(
-    _auth: AccessStandardSignupQueued,
+    _auth: Scoped<OAuthForbidden, AccessStandardSignupQueued>,
 ) -> Result<Json<CheckSignupQueueOutput>, ApiError> {
     Ok(Json(CheckSignupQueueOutput {
         activated: true,

--- a/rsky-pds/src/apis/mod.rs
+++ b/rsky-pds/src/apis/mod.rs
@@ -1,9 +1,10 @@
-use crate::auth_verifier::{AccessStandard, AuthError, AuthScope, Credentials};
+use crate::auth_verifier::scope::{RpcProxy, Scoped};
+use crate::auth_verifier::{AuthError, AuthScope, Credentials};
 use crate::handle;
 use crate::handle::errors::ErrorKind;
 use crate::pipethrough::{
-    assert_rpc_scope, pipethrough_error, pipethrough_procedure, pipethrough_procedure_post,
-    ProxyRequest, PRIVILEGED_METHODS,
+    pipethrough_error, pipethrough_procedure, pipethrough_procedure_post, ProxyRequest,
+    PRIVILEGED_METHODS,
 };
 use anyhow::{Error, Result};
 use rocket::http::{ContentType, Header, Status};
@@ -171,20 +172,11 @@ pub fn assert_account_scope(
 pub async fn bsky_api_get_forwarder(
     nsid: Nsid,
     query: Option<&str>,
-    auth: AccessStandard,
+    auth: Scoped<RpcProxy>,
     req: ProxyRequest<'_>,
 ) -> Result<ProxyResponder, ApiError> {
-    assert_valid_token_method(&nsid.0, &auth.access.credentials)?;
-    let granted_scopes = auth
-        .access
-        .credentials
-        .as_ref()
-        .and_then(|c| c.granted_scopes.clone());
-    assert_rpc_scope(&granted_scopes, &req).await?;
-    let requester: Option<String> = match auth.access.credentials {
-        None => None,
-        Some(credentials) => credentials.did,
-    };
+    assert_valid_token_method(&nsid.0, auth.credentials().await?)?;
+    let requester: Option<String> = auth.did_opt().await?;
     match pipethrough_procedure::<()>(&req, requester, None).await {
         Ok(res) => {
             let headers = res.headers.expect("Upstream responded without headers.");
@@ -209,20 +201,11 @@ pub async fn bsky_api_get_forwarder(
 pub async fn bsky_api_post_forwarder(
     body: Data<'_>,
     nsid: Nsid,
-    auth: AccessStandard,
+    auth: Scoped<RpcProxy>,
     req: ProxyRequest<'_>,
 ) -> Result<ProxyResponder, ApiError> {
-    assert_valid_token_method(&nsid.0, &auth.access.credentials)?;
-    let granted_scopes = auth
-        .access
-        .credentials
-        .as_ref()
-        .and_then(|c| c.granted_scopes.clone());
-    assert_rpc_scope(&granted_scopes, &req).await?;
-    let requester: Option<String> = match auth.access.credentials {
-        None => None,
-        Some(credentials) => credentials.did,
-    };
+    assert_valid_token_method(&nsid.0, auth.credentials().await?)?;
+    let requester: Option<String> = auth.did_opt().await?;
 
     let res = pipethrough_procedure_post(&req, requester, Some(body)).await?;
     let headers = res.headers.expect("Upstream responded without headers.");
@@ -267,6 +250,14 @@ pub enum ApiError {
     /// Error passed through from an upstream service: status code, error, message
     UpstreamResponse(u16, String, String),
 }
+
+impl std::fmt::Display for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for ApiError {}
 
 #[derive(Serialize)]
 pub struct ErrorBody {

--- a/rsky-pds/src/apis/mod.rs
+++ b/rsky-pds/src/apis/mod.rs
@@ -143,6 +143,22 @@ pub fn assert_identity_scope(
     )
 }
 
+/// Enforce an OAuth session's `rpc:` scope on an outbound call to a known
+/// audience, for callers that resolve the audience themselves rather than
+/// through the `atproto-proxy` header.
+pub fn assert_rpc_target(
+    credentials: &Option<Credentials>,
+    lxm: &str,
+    aud: &str,
+) -> Result<(), ApiError> {
+    assert_scope(
+        credentials,
+        true,
+        |scopes| scopes.allows_rpc(lxm, aud),
+        || format!("Token scope does not permit calling {lxm} on {aud}"),
+    )
+}
+
 /// Enforce an OAuth session's `account:` scope on an account-level mutation
 /// (email, deactivation/activation, PLC rotation).
 ///
@@ -839,6 +855,42 @@ mod tests {
             "account:email?action=manage",
         ]);
         assert!(assert_account_scope(&with_account, "email", AccountAction::Manage).is_ok());
+    }
+
+    /// `registerPush` and `unregisterPush` mint service auth and call the
+    /// notification service, so they need the `rpc:` grant that governs
+    /// reaching outward -- against the audience the request body names.
+    #[test]
+    fn an_rpc_target_is_checked_against_the_audience_the_body_names() {
+        let lxm = "app.bsky.notification.registerPush";
+        let aud = "did:web:notif.example.com";
+
+        // The matching grant permits it; a wildcard audience does too.
+        let exact = creds(&["atproto", &format!("rpc:{lxm}?aud={aud}")]);
+        assert!(assert_rpc_target(&exact, lxm, aud).is_ok());
+        let wildcard = creds(&["atproto", &format!("rpc:{lxm}?aud=*")]);
+        assert!(assert_rpc_target(&wildcard, lxm, aud).is_ok());
+
+        // A grant for a different audience does not.
+        let other_aud = creds(&[
+            "atproto",
+            &format!("rpc:{lxm}?aud=did:web:someone-else.example.com"),
+        ]);
+        assert!(assert_rpc_target(&other_aud, lxm, aud).is_err());
+
+        // Nor does a grant for a different method, nor no rpc grant at all.
+        let other_lxm = creds(&[
+            "atproto",
+            &format!("rpc:app.bsky.feed.getTimeline?aud={aud}"),
+        ]);
+        assert!(assert_rpc_target(&other_lxm, lxm, aud).is_err());
+        assert!(
+            assert_rpc_target(&creds(&["atproto", "repo:app.bsky.feed.post"]), lxm, aud).is_err()
+        );
+
+        // Legacy sessions are unaffected, as everywhere else.
+        assert!(assert_rpc_target(&creds(&["atproto", "transition:generic"]), lxm, aud).is_ok());
+        assert!(assert_rpc_target(&None, lxm, aud).is_ok());
     }
 
     /// App passwords and legacy access tokens carry no `granted_scopes`;

--- a/rsky-pds/src/auth_verifier.rs
+++ b/rsky-pds/src/auth_verifier.rs
@@ -22,6 +22,8 @@ use std::str;
 use std::sync::LazyLock;
 use thiserror::Error;
 
+pub mod scope;
+
 const INFINITY: u64 = u64::MAX;
 
 /// True when `err` is jwt-simple's expiry error (`JWTError::TokenHasExpired`),
@@ -287,7 +289,7 @@ pub async fn access_check(
 }
 
 pub struct AccessFullImport {
-    pub access: AccessOutput,
+    access: AccessOutput,
 }
 
 #[rocket::async_trait]
@@ -361,7 +363,7 @@ impl<'r> FromRequest<'r> for AccessSpace {
 }
 
 pub struct AccessFull {
-    pub access: AccessOutput,
+    access: AccessOutput,
 }
 
 #[rocket::async_trait]
@@ -381,7 +383,7 @@ impl<'r> FromRequest<'r> for AccessFull {
 }
 
 pub struct AccessPrivileged {
-    pub access: AccessOutput,
+    access: AccessOutput,
 }
 
 #[rocket::async_trait]
@@ -407,7 +409,7 @@ impl<'r> FromRequest<'r> for AccessPrivileged {
 }
 
 pub struct AccessStandard {
-    pub access: AccessOutput,
+    access: AccessOutput,
 }
 
 /// One access verification per request, shared between guards. The
@@ -454,7 +456,7 @@ impl<'r> FromRequest<'r> for AccessStandard {
 
 #[derive(Clone)]
 pub struct AccessStandardIncludeChecks {
-    pub access: AccessOutput,
+    access: AccessOutput,
 }
 
 #[rocket::async_trait]
@@ -488,7 +490,7 @@ impl<'r> FromRequest<'r> for AccessStandardIncludeChecks {
 
 #[derive(Clone)]
 pub struct AccessStandardCheckTakedown {
-    pub access: AccessOutput,
+    access: AccessOutput,
 }
 
 #[rocket::async_trait]
@@ -520,229 +522,8 @@ impl<'r> FromRequest<'r> for AccessStandardCheckTakedown {
     }
 }
 
-// Scoped-access guards
-// ---------------------
-//
-// Each of these folds a proposal-0011 resource-scope assertion into the
-// request guard itself, wrapping one of the plain `Access*` guards above.
-// Before this, a handler took a plain access guard and made a separate
-// `assert_*_scope` call as the first line of its body -- easy to add when a
-// route is first written, just as easy to forget when a route is copied or
-// refactored later, and invisible at the type level either way. A route that
-// asks for one of these can only get a `did` by way of the assertion having
-// already passed, closing the same "guard succeeded, follow-up check silently
-// skipped" failure mode the service-auth fix in PR #252 closed elsewhere.
-//
-// `assert_*_scope` (in `crate::apis`) is unchanged; this only relocates where
-// it is called from.
-
-/// A guard whose only content is an already-verified [`AccessOutput`],
-/// implemented by every plain `Access*` guard above. Lets a scoped-access
-/// guard be generic over which one it wraps instead of duplicating each
-/// guard's own session/takedown/deactivation handling.
-trait AccessGuard {
-    fn into_access(self) -> AccessOutput;
-}
-
-impl AccessGuard for AccessStandard {
-    fn into_access(self) -> AccessOutput {
-        self.access
-    }
-}
-
-impl AccessGuard for AccessStandardCheckTakedown {
-    fn into_access(self) -> AccessOutput {
-        self.access
-    }
-}
-
-impl AccessGuard for AccessFull {
-    fn into_access(self) -> AccessOutput {
-        self.access
-    }
-}
-
-/// Runs `Base`'s own request-guard logic unchanged, then applies `assert` to
-/// the credentials it produces. `assert` failing is the only way this can
-/// still fail once `Base` has already succeeded.
-async fn assert_scoped<'r, Base>(
-    req: &'r Request<'_>,
-    assert: impl FnOnce(&Option<Credentials>) -> Result<(), ApiError>,
-) -> Outcome<AccessOutput, ApiError>
-where
-    Base: AccessGuard + FromRequest<'r, Error = AuthError>,
-{
-    match Base::from_request(req).await {
-        Outcome::Success(base) => {
-            let access = base.into_access();
-            match assert(&access.credentials) {
-                Ok(()) => Outcome::Success(access),
-                Err(api_error) => {
-                    req.local_cache(|| Some(api_error.clone()));
-                    Outcome::Error((Status::Forbidden, api_error))
-                }
-            }
-        }
-        Outcome::Error((status, auth_error)) => {
-            let api_error = ApiError::from(&auth_error);
-            req.local_cache(|| Some(api_error.clone()));
-            Outcome::Error((status, api_error))
-        }
-        Outcome::Forward(level) => Outcome::Forward(level),
-    }
-}
-
-/// [`AccessStandardCheckTakedown`] narrowed by the session's `blob:` scope
-/// (proposal 0011), for `com.atproto.repo.uploadBlob`. Reads the mime type
-/// straight off the request the same way the route's own `ContentType` guard
-/// does; put `ContentType` ahead of this guard in a route's parameter list so
-/// a request with no content type still gets that guard's own rejection
-/// first.
-pub struct BlobScopedAccess {
-    pub access: AccessOutput,
-}
-
-#[rocket::async_trait]
-impl<'r> FromRequest<'r> for BlobScopedAccess {
-    type Error = ApiError;
-
-    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        let mime = req
-            .content_type()
-            .map(ToString::to_string)
-            .unwrap_or_default();
-        match assert_scoped::<AccessStandardCheckTakedown>(req, |credentials| {
-            crate::apis::assert_blob_scope(credentials, &mime)
-        })
-        .await
-        {
-            Outcome::Success(access) => Outcome::Success(Self { access }),
-            Outcome::Error(error) => Outcome::Error(error),
-            Outcome::Forward(level) => Outcome::Forward(level),
-        }
-    }
-}
-
-/// [`AccessStandardCheckTakedown`] narrowed by the session's `identity:handle`
-/// scope, for `com.atproto.identity.updateHandle`.
-pub struct HandleScopedAccess {
-    pub access: AccessOutput,
-}
-
-#[rocket::async_trait]
-impl<'r> FromRequest<'r> for HandleScopedAccess {
-    type Error = ApiError;
-
-    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        match assert_scoped::<AccessStandardCheckTakedown>(req, |credentials| {
-            crate::apis::assert_identity_scope(credentials, "handle")
-        })
-        .await
-        {
-            Outcome::Success(access) => Outcome::Success(Self { access }),
-            Outcome::Error(error) => Outcome::Error(error),
-            Outcome::Forward(level) => Outcome::Forward(level),
-        }
-    }
-}
-
-/// [`AccessFull`] narrowed by the session's `account:email?action=manage`
-/// scope, for `com.atproto.server.updateEmail`.
-pub struct EmailScopedAccess {
-    pub access: AccessOutput,
-}
-
-#[rocket::async_trait]
-impl<'r> FromRequest<'r> for EmailScopedAccess {
-    type Error = ApiError;
-
-    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        match assert_scoped::<AccessFull>(req, |credentials| {
-            crate::apis::assert_account_scope(
-                credentials,
-                "email",
-                crate::oauth_scope::AccountAction::Manage,
-            )
-        })
-        .await
-        {
-            Outcome::Success(access) => Outcome::Success(Self { access }),
-            Outcome::Error(error) => Outcome::Error(error),
-            Outcome::Forward(level) => Outcome::Forward(level),
-        }
-    }
-}
-
-/// [`AccessFull`] narrowed by the session's `account:status?action=manage`
-/// scope, for `com.atproto.server.deactivateAccount`.
-pub struct AccountStatusScopedAccess {
-    pub access: AccessOutput,
-}
-
-#[rocket::async_trait]
-impl<'r> FromRequest<'r> for AccountStatusScopedAccess {
-    type Error = ApiError;
-
-    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        match assert_scoped::<AccessFull>(req, |credentials| {
-            crate::apis::assert_account_scope(
-                credentials,
-                "status",
-                crate::oauth_scope::AccountAction::Manage,
-            )
-        })
-        .await
-        {
-            Outcome::Success(access) => Outcome::Success(Self { access }),
-            Outcome::Error(error) => Outcome::Error(error),
-            Outcome::Forward(level) => Outcome::Forward(level),
-        }
-    }
-}
-
-/// [`AccessFull`] (the default `Base`) or [`AccessStandard`] narrowed by the
-/// session's `account:repo?action=manage` scope, for the two PLC-rotation
-/// endpoints. `Base` is generic rather than fixed because the two endpoints
-/// keep different, pre-existing access tiers -- `signPlcOperation` requires a
-/// full session (`Base = AccessFull`, the default, so it can be named as
-/// plain `AccountRepoScopedAccess`) while `submitPlcOperation` also accepts
-/// app-password sessions (`Base = AccessStandard`, named explicitly). Both
-/// share this one assertion instead of two copies of it, without silently
-/// widening or narrowing either endpoint's tier to match the other's.
-pub struct AccountRepoScopedAccess<Base = AccessFull> {
-    pub access: AccessOutput,
-    _base: std::marker::PhantomData<Base>,
-}
-
-#[rocket::async_trait]
-impl<'r, Base> FromRequest<'r> for AccountRepoScopedAccess<Base>
-where
-    Base: AccessGuard + FromRequest<'r, Error = AuthError>,
-{
-    type Error = ApiError;
-
-    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        match assert_scoped::<Base>(req, |credentials| {
-            crate::apis::assert_account_scope(
-                credentials,
-                "repo",
-                crate::oauth_scope::AccountAction::Manage,
-            )
-        })
-        .await
-        {
-            Outcome::Success(access) => Outcome::Success(Self {
-                access,
-                _base: std::marker::PhantomData,
-            }),
-            Outcome::Error(error) => Outcome::Error(error),
-            Outcome::Forward(level) => Outcome::Forward(level),
-        }
-    }
-}
-
 pub struct AccessStandardSignupQueued {
-    pub access: AccessOutput,
+    access: AccessOutput,
 }
 
 #[rocket::async_trait]

--- a/rsky-pds/src/auth_verifier/scope.rs
+++ b/rsky-pds/src/auth_verifier/scope.rs
@@ -114,7 +114,7 @@ pub trait ScopeDecl: Send + Sync + 'static {
 ///
 /// A route that takes a plain access guard authenticates and learns nothing:
 ///
-/// ```compile_fail
+/// ```compile_fail,E0616
 /// use rsky_pds::auth_verifier::AccessStandard;
 ///
 /// fn requester(auth: AccessStandard) -> Option<String> {
@@ -124,7 +124,7 @@ pub trait ScopeDecl: Send + Sync + 'static {
 ///
 /// A deferred declaration's handler cannot skip the value the check needs:
 ///
-/// ```compile_fail
+/// ```compile_fail,E0599
 /// use rsky_pds::auth_verifier::scope::{RepoWrite, Scoped};
 ///
 /// async fn requester(auth: Scoped<RepoWrite>) -> Option<String> {

--- a/rsky-pds/src/auth_verifier/scope.rs
+++ b/rsky-pds/src/auth_verifier/scope.rs
@@ -469,6 +469,36 @@ impl ScopeDecl for RepoWrite {
 /// `rpc:<nsid>`, for the proxied-XRPC surface. The proxy target is rebuilt
 /// from the request here so the check runs before the handler body, matching
 /// where every other declaration runs.
+/// The method and audience an [`RpcCall`] is checked against.
+pub struct RpcTarget {
+    pub lxm: String,
+    pub aud: String,
+}
+
+/// `rpc:<lxm>?aud=<did>` for an outbound call whose audience comes from the
+/// request body rather than the `atproto-proxy` header.
+///
+/// Deferred, because the audience is not known until the body is parsed --
+/// the same reason the reference implementation asserts these in the handler.
+/// [`RpcProxy`] covers the header-routed case instead.
+pub struct RpcCall;
+
+#[rocket::async_trait]
+impl ScopeDecl for RpcCall {
+    type Target = RpcTarget;
+
+    async fn precheck(
+        _req: &Request<'_>,
+        _credentials: &Option<Credentials>,
+    ) -> Result<(), ApiError> {
+        Ok(())
+    }
+
+    async fn check(credentials: &Option<Credentials>, target: &RpcTarget) -> Result<(), ApiError> {
+        crate::apis::assert_rpc_target(credentials, &target.lxm, &target.aud)
+    }
+}
+
 pub struct RpcProxy;
 
 #[rocket::async_trait]

--- a/rsky-pds/src/auth_verifier/scope.rs
+++ b/rsky-pds/src/auth_verifier/scope.rs
@@ -334,6 +334,32 @@ impl ScopeDecl for IdentityHandle {
 }
 
 /// `account:email?action=manage`, for `com.atproto.server.updateEmail`.
+/// `identity:*`, for the PLC operation endpoints.
+///
+/// A PLC operation rewrites the DID document: it can rotate the signing key,
+/// repoint the PDS, and hand the account to someone else irreversibly. The
+/// reference implementation puts that behind the identity wildcard rather than
+/// any `account:` grant, and warns on it at the consent screen. Gating it on
+/// `account:repo?action=manage` -- the scope `importRepo` needs -- would let a
+/// client granted migration capability take the account.
+pub struct IdentityFull;
+
+#[rocket::async_trait]
+impl ScopeDecl for IdentityFull {
+    type Target = ();
+
+    async fn precheck(
+        _req: &Request<'_>,
+        credentials: &Option<Credentials>,
+    ) -> Result<(), ApiError> {
+        crate::apis::assert_identity_scope(credentials, "*")
+    }
+
+    async fn check(_credentials: &Option<Credentials>, _target: &()) -> Result<(), ApiError> {
+        Ok(())
+    }
+}
+
 pub struct AccountEmail;
 
 #[rocket::async_trait]

--- a/rsky-pds/src/auth_verifier/scope.rs
+++ b/rsky-pds/src/auth_verifier/scope.rs
@@ -1,0 +1,636 @@
+//! The scope-declaration seam.
+//!
+//! A route cannot learn who is calling it without first naming what that
+//! caller must be permitted to do. [`Scoped`] is the only type in the crate
+//! that hands out an authenticated requester's DID, and it is generic over a
+//! [`ScopeDecl`] -- so the declaration is written in the route's signature or
+//! the route does not compile.
+//!
+//! This is the Rust analog of the reference PDS's `authorize` field, which is
+//! required (not optional) on every OAuth-capable auth verifier's options,
+//! combined with tranquil-pds's trick of making the authenticated subject
+//! reachable only through a scope proof.
+//!
+//! Two declarations mean "nothing is required here", mirroring the reference
+//! implementation's two opt-out spellings, and both are one grep away:
+//!
+//! ```text
+//! rg 'Scoped<(NoScopeRequired|OAuthForbidden)' rsky-pds/src
+//! ```
+//!
+//! The reference implementation has a third kind that reads identically to the
+//! first: an empty `authorize` body whose check actually runs in the handler,
+//! distinguished only by a code comment. Here that kind is
+//! `Target != ()`, so it cannot be mistaken for an opt-out and cannot be
+//! declared without being checked.
+
+use super::{
+    AccessFull, AccessFullImport, AccessOutput, AccessPrivileged, AccessStandard,
+    AccessStandardCheckTakedown, AccessStandardIncludeChecks, AccessStandardSignupQueued,
+    AuthError, Credentials,
+};
+use crate::apis::ApiError;
+use crate::oauth_scope::{AccountAction, RepoAction};
+use rocket::http::Status;
+use rocket::request::{FromRequest, Outcome, Request};
+use std::marker::PhantomData;
+
+/// Capability token for [`AccessTier::verify`]. Its field is private to this
+/// module, so no route can mint one and pull an [`AccessOutput`] out of a
+/// tier directly.
+pub struct Verified(());
+
+/// A session-authentication tier: the "who is this and is the account in good
+/// standing" half of a route's auth, with no scope opinion of its own.
+///
+/// Implemented only for the plain `Access*` guards in the parent module. Their
+/// `access` field is private, so a route that names one of them as a request
+/// guard authenticates and learns nothing; [`Scoped`] is the only way through.
+#[rocket::async_trait]
+pub trait AccessTier: Send + Sync + 'static {
+    #[doc(hidden)]
+    async fn verify(req: &Request<'_>, proof: Verified) -> Outcome<AccessOutput, AuthError>;
+}
+
+macro_rules! access_tier {
+    ($($guard:ty),+ $(,)?) => {$(
+        #[rocket::async_trait]
+        impl AccessTier for $guard {
+            async fn verify(
+                req: &Request<'_>,
+                _proof: Verified,
+            ) -> Outcome<AccessOutput, AuthError> {
+                match <$guard as FromRequest>::from_request(req).await {
+                    Outcome::Success(guard) => Outcome::Success(guard.access),
+                    Outcome::Error(error) => Outcome::Error(error),
+                    Outcome::Forward(level) => Outcome::Forward(level),
+                }
+            }
+        }
+    )+};
+}
+
+access_tier!(
+    AccessStandard,
+    AccessStandardCheckTakedown,
+    AccessStandardIncludeChecks,
+    AccessStandardSignupQueued,
+    AccessFull,
+    AccessFullImport,
+    AccessPrivileged,
+);
+
+/// What a route declares it requires of the calling session.
+///
+/// Every declaration states both halves explicitly, because a declaration
+/// that could be half-written is a declaration that can be half-forgotten:
+///
+/// - [`precheck`](ScopeDecl::precheck) is what can be settled from the request
+///   alone, and runs in the request guard before the handler body.
+/// - [`check`](ScopeDecl::check) is what needs a value only the handler knows
+///   (the collection of a record write, say), and runs when the handler asks
+///   for the requester. A declaration with `Target = ()` needs nothing more
+///   and writes `Ok(())`.
+#[rocket::async_trait]
+pub trait ScopeDecl: Send + Sync + 'static {
+    /// The value this requirement is checked against. `()` when the request
+    /// itself carries everything the check needs.
+    type Target: Send + Sync;
+
+    async fn precheck(req: &Request<'_>, credentials: &Option<Credentials>)
+        -> Result<(), ApiError>;
+
+    async fn check(
+        credentials: &Option<Credentials>,
+        target: &Self::Target,
+    ) -> Result<(), ApiError>;
+}
+
+/// An authenticated session that has declared, in `D`, what it must be
+/// permitted to do.
+///
+/// The requester's DID is reachable only from here, and only through an
+/// accessor that has run `D`'s check.
+///
+/// A route that takes a plain access guard authenticates and learns nothing:
+///
+/// ```compile_fail
+/// use rsky_pds::auth_verifier::AccessStandard;
+///
+/// fn requester(auth: AccessStandard) -> Option<String> {
+///     auth.access.credentials.and_then(|c| c.did)
+/// }
+/// ```
+///
+/// A deferred declaration's handler cannot skip the value the check needs:
+///
+/// ```compile_fail
+/// use rsky_pds::auth_verifier::scope::{RepoWrite, Scoped};
+///
+/// async fn requester(auth: Scoped<RepoWrite>) -> Option<String> {
+///     auth.did().await.ok()
+/// }
+/// ```
+pub struct Scoped<D: ScopeDecl, Base: AccessTier = AccessStandard> {
+    access: AccessOutput,
+    _decl: PhantomData<fn() -> (D, Base)>,
+}
+
+impl<D: ScopeDecl, Base: AccessTier> Clone for Scoped<D, Base> {
+    fn clone(&self) -> Self {
+        Self {
+            access: self.access.clone(),
+            _decl: PhantomData,
+        }
+    }
+}
+
+#[rocket::async_trait]
+impl<'r, D: ScopeDecl, Base: AccessTier> FromRequest<'r> for Scoped<D, Base> {
+    type Error = ApiError;
+
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        match Base::verify(req, Verified(())).await {
+            Outcome::Success(access) => match D::precheck(req, &access.credentials).await {
+                Ok(()) => Outcome::Success(Self {
+                    access,
+                    _decl: PhantomData,
+                }),
+                Err(api_error) => {
+                    req.local_cache(|| Some(api_error.clone()));
+                    Outcome::Error((Status::Forbidden, api_error))
+                }
+            },
+            Outcome::Error((status, auth_error)) => {
+                let api_error = ApiError::from(&auth_error);
+                req.local_cache(|| Some(api_error.clone()));
+                Outcome::Error((status, api_error))
+            }
+            Outcome::Forward(level) => Outcome::Forward(level),
+        }
+    }
+}
+
+impl<D: ScopeDecl, Base: AccessTier> Scoped<D, Base> {
+    /// The verified session, once `D`'s requirement has been checked against
+    /// `target`.
+    pub async fn credentials_for(
+        &self,
+        target: &D::Target,
+    ) -> Result<&Option<Credentials>, ApiError> {
+        D::check(&self.access.credentials, target).await?;
+        Ok(&self.access.credentials)
+    }
+
+    /// The requester's DID, once `D`'s requirement has been checked against
+    /// `target`.
+    pub async fn did_for(&self, target: &D::Target) -> Result<String, ApiError> {
+        match self
+            .credentials_for(target)
+            .await?
+            .as_ref()
+            .and_then(|c| c.did.clone())
+        {
+            Some(did) => Ok(did),
+            None => Err(ApiError::AuthRequiredError(
+                "Session carries no subject".to_string(),
+            )),
+        }
+    }
+}
+
+/// Accessors for declarations that need nothing from the handler. The bound
+/// is what keeps a deferred declaration's handler from skipping its check:
+/// with `Target != ()` these methods do not exist.
+impl<D: ScopeDecl<Target = ()>, Base: AccessTier> Scoped<D, Base> {
+    pub async fn credentials(&self) -> Result<&Option<Credentials>, ApiError> {
+        self.credentials_for(&()).await
+    }
+
+    pub async fn did(&self) -> Result<String, ApiError> {
+        self.did_for(&()).await
+    }
+
+    /// The requester's DID when the route treats an unauthenticated session
+    /// as anonymous rather than an error.
+    pub async fn did_opt(&self) -> Result<Option<String>, ApiError> {
+        Ok(self
+            .credentials_for(&())
+            .await?
+            .as_ref()
+            .and_then(|c| c.did.clone()))
+    }
+}
+
+/// True for a session minted by the OAuth provider, which is exactly the set
+/// of sessions that carry the proposal-0011 scope grammar. App passwords and
+/// legacy `createSession` tokens carry no grants and are never OAuth.
+fn is_oauth_session(credentials: &Option<Credentials>) -> bool {
+    credentials
+        .as_ref()
+        .map(|c| c.granted_scopes.is_some())
+        .unwrap_or(false)
+}
+
+// Declarations
+// ------------
+//
+// The two opt-outs first, mirroring the reference implementation's two
+// spellings of "no scope requirement here", then one declaration per
+// proposal-0011 resource.
+
+/// No OAuth scope requirement: any session this route's tier admits may call
+/// it. The reference implementation spells this `authorize: () => {}`.
+pub struct NoScopeRequired;
+
+#[rocket::async_trait]
+impl ScopeDecl for NoScopeRequired {
+    type Target = ();
+
+    async fn precheck(
+        _req: &Request<'_>,
+        _credentials: &Option<Credentials>,
+    ) -> Result<(), ApiError> {
+        Ok(())
+    }
+
+    async fn check(_credentials: &Option<Credentials>, _target: &()) -> Result<(), ApiError> {
+        Ok(())
+    }
+}
+
+/// OAuth sessions cannot reach this route at all; only app passwords and
+/// legacy `createSession` tokens may call it. The reference implementation
+/// spells this `authorize: () => { throw new ForbiddenError(...) }`, and uses
+/// it for the account-lifecycle and credential-management surface: operations
+/// that belong to the account holder acting directly, never to a client acting
+/// on their behalf.
+pub struct OAuthForbidden;
+
+#[rocket::async_trait]
+impl ScopeDecl for OAuthForbidden {
+    type Target = ();
+
+    async fn precheck(
+        _req: &Request<'_>,
+        credentials: &Option<Credentials>,
+    ) -> Result<(), ApiError> {
+        if is_oauth_session(credentials) {
+            return Err(ApiError::InsufficientScope(
+                "OAuth credentials are not supported for this endpoint".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn check(_credentials: &Option<Credentials>, _target: &()) -> Result<(), ApiError> {
+        Ok(())
+    }
+}
+
+/// `blob:<mime>`, for `com.atproto.repo.uploadBlob`. The mime comes off the
+/// request the same way the route's own `ContentType` guard reads it; put
+/// `ContentType` ahead of this guard in a route's parameter list so a request
+/// with no content type still gets that guard's rejection first.
+pub struct BlobUpload;
+
+#[rocket::async_trait]
+impl ScopeDecl for BlobUpload {
+    type Target = ();
+
+    async fn precheck(
+        req: &Request<'_>,
+        credentials: &Option<Credentials>,
+    ) -> Result<(), ApiError> {
+        let mime = req
+            .content_type()
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        crate::apis::assert_blob_scope(credentials, &mime)
+    }
+
+    async fn check(_credentials: &Option<Credentials>, _target: &()) -> Result<(), ApiError> {
+        Ok(())
+    }
+}
+
+/// `identity:handle`, for `com.atproto.identity.updateHandle`.
+pub struct IdentityHandle;
+
+#[rocket::async_trait]
+impl ScopeDecl for IdentityHandle {
+    type Target = ();
+
+    async fn precheck(
+        _req: &Request<'_>,
+        credentials: &Option<Credentials>,
+    ) -> Result<(), ApiError> {
+        crate::apis::assert_identity_scope(credentials, "handle")
+    }
+
+    async fn check(_credentials: &Option<Credentials>, _target: &()) -> Result<(), ApiError> {
+        Ok(())
+    }
+}
+
+/// `account:email?action=manage`, for `com.atproto.server.updateEmail`.
+pub struct AccountEmail;
+
+#[rocket::async_trait]
+impl ScopeDecl for AccountEmail {
+    type Target = ();
+
+    async fn precheck(
+        _req: &Request<'_>,
+        credentials: &Option<Credentials>,
+    ) -> Result<(), ApiError> {
+        crate::apis::assert_account_scope(credentials, "email", AccountAction::Manage)
+    }
+
+    async fn check(_credentials: &Option<Credentials>, _target: &()) -> Result<(), ApiError> {
+        Ok(())
+    }
+}
+
+/// `account:status?action=manage`, for the account activation endpoints.
+pub struct AccountStatus;
+
+#[rocket::async_trait]
+impl ScopeDecl for AccountStatus {
+    type Target = ();
+
+    async fn precheck(
+        _req: &Request<'_>,
+        credentials: &Option<Credentials>,
+    ) -> Result<(), ApiError> {
+        crate::apis::assert_account_scope(credentials, "status", AccountAction::Manage)
+    }
+
+    async fn check(_credentials: &Option<Credentials>, _target: &()) -> Result<(), ApiError> {
+        Ok(())
+    }
+}
+
+/// `account:repo?action=manage`, for the PLC-rotation endpoints.
+pub struct AccountRepo;
+
+#[rocket::async_trait]
+impl ScopeDecl for AccountRepo {
+    type Target = ();
+
+    async fn precheck(
+        _req: &Request<'_>,
+        credentials: &Option<Credentials>,
+    ) -> Result<(), ApiError> {
+        crate::apis::assert_account_scope(credentials, "repo", AccountAction::Manage)
+    }
+
+    async fn check(_credentials: &Option<Credentials>, _target: &()) -> Result<(), ApiError> {
+        Ok(())
+    }
+}
+
+/// One collection/action pair a handler is about to write.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RepoTarget {
+    pub collection: String,
+    pub action: RepoAction,
+}
+
+impl RepoTarget {
+    pub fn new(collection: impl Into<String>, action: RepoAction) -> Self {
+        Self {
+            collection: collection.into(),
+            action,
+        }
+    }
+}
+
+/// `repo:<collection>`, for the record-write endpoints. Deferred, because the
+/// collection is in the request body: the handler names every collection it
+/// is about to touch and gets the requester back, or gets an error.
+pub struct RepoWrite;
+
+#[rocket::async_trait]
+impl ScopeDecl for RepoWrite {
+    type Target = Vec<RepoTarget>;
+
+    async fn precheck(
+        _req: &Request<'_>,
+        _credentials: &Option<Credentials>,
+    ) -> Result<(), ApiError> {
+        Ok(())
+    }
+
+    async fn check(
+        credentials: &Option<Credentials>,
+        targets: &Vec<RepoTarget>,
+    ) -> Result<(), ApiError> {
+        // Declaring nothing is not a declaration; an empty list would
+        // otherwise hand back the DID with no write ever checked.
+        if targets.is_empty() {
+            return Err(ApiError::InsufficientScope(
+                "No repo write was declared for this request".to_string(),
+            ));
+        }
+        for target in targets {
+            crate::apis::assert_repo_scope(credentials, &target.collection, target.action)?;
+        }
+        Ok(())
+    }
+}
+
+/// `rpc:<nsid>`, for the proxied-XRPC surface. The proxy target is rebuilt
+/// from the request here so the check runs before the handler body, matching
+/// where every other declaration runs.
+pub struct RpcProxy;
+
+#[rocket::async_trait]
+impl ScopeDecl for RpcProxy {
+    type Target = ();
+
+    async fn precheck(
+        req: &Request<'_>,
+        credentials: &Option<Credentials>,
+    ) -> Result<(), ApiError> {
+        let granted_scopes = credentials.as_ref().and_then(|c| c.granted_scopes.clone());
+        if granted_scopes.is_none() {
+            return Ok(());
+        }
+        match crate::pipethrough::ProxyRequest::from_request(req).await {
+            Outcome::Success(proxy_req) => {
+                crate::pipethrough::assert_rpc_scope(&granted_scopes, &proxy_req).await
+            }
+            _ => Err(ApiError::RuntimeError),
+        }
+    }
+
+    async fn check(_credentials: &Option<Credentials>, _target: &()) -> Result<(), ApiError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth_verifier::AuthScope;
+    use rocket::http::ContentType;
+    use rocket::local::asynchronous::Client;
+
+    fn session(granted_scopes: Option<Vec<String>>) -> Option<Credentials> {
+        Some(Credentials {
+            r#type: "test".to_string(),
+            did: Some("did:plc:test".to_string()),
+            scope: Some(AuthScope::AppPass),
+            granted_scopes,
+            audience: None,
+            token_id: None,
+            aud: None,
+            iss: None,
+            is_privileged: None,
+        })
+    }
+
+    fn oauth_session(granted: &[&str]) -> Option<Credentials> {
+        session(Some(granted.iter().map(|s| s.to_string()).collect()))
+    }
+
+    /// App passwords and legacy `createSession` tokens carry no grants.
+    fn legacy_session() -> Option<Credentials> {
+        session(None)
+    }
+
+    async fn client() -> Client {
+        Client::untracked(rocket::build())
+            .await
+            .expect("local client")
+    }
+
+    #[tokio::test]
+    async fn no_scope_required_permits_every_session() {
+        let client = client().await;
+        let request = client.get("/");
+        let req = request.inner();
+        assert!(NoScopeRequired::precheck(
+            req,
+            &oauth_session(&["atproto", "repo:app.bsky.feed.post"])
+        )
+        .await
+        .is_ok());
+        assert!(NoScopeRequired::precheck(req, &legacy_session())
+            .await
+            .is_ok());
+        assert!(NoScopeRequired::precheck(req, &None).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn oauth_forbidden_rejects_an_oauth_session_and_permits_an_app_password() {
+        let client = client().await;
+        let request = client.get("/");
+        let req = request.inner();
+        assert!(matches!(
+            OAuthForbidden::precheck(req, &oauth_session(&["atproto", "transition:generic"])).await,
+            Err(ApiError::InsufficientScope(_))
+        ));
+        assert!(OAuthForbidden::precheck(req, &legacy_session())
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn blob_upload_reads_the_mime_off_the_request() {
+        let client = client().await;
+        let request = client.post("/").header(ContentType::PNG);
+        assert!(BlobUpload::precheck(
+            request.inner(),
+            &oauth_session(&["atproto", "blob:image/*"])
+        )
+        .await
+        .is_ok());
+        let request = client.post("/").header(ContentType::Plain);
+        assert!(matches!(
+            BlobUpload::precheck(
+                request.inner(),
+                &oauth_session(&["atproto", "blob:image/*"])
+            )
+            .await,
+            Err(ApiError::InsufficientScope(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn identity_and_account_declarations_narrow_their_attribute() {
+        let client = client().await;
+        let request = client.post("/");
+        let req = request.inner();
+        assert!(
+            IdentityHandle::precheck(req, &oauth_session(&["atproto", "identity:handle"]))
+                .await
+                .is_ok()
+        );
+        assert!(matches!(
+            IdentityHandle::precheck(req, &oauth_session(&["atproto", "identity:invalid"])).await,
+            Err(ApiError::InsufficientScope(_))
+        ));
+        assert!(AccountEmail::precheck(
+            req,
+            &oauth_session(&["atproto", "account:email?action=manage"])
+        )
+        .await
+        .is_ok());
+        assert!(matches!(
+            AccountEmail::precheck(req, &oauth_session(&["atproto", "account:email"])).await,
+            Err(ApiError::InsufficientScope(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn repo_write_checks_every_declared_target() {
+        let granted = oauth_session(&["atproto", "repo:app.bsky.feed.post"]);
+        assert!(RepoWrite::check(
+            &granted,
+            &vec![RepoTarget::new("app.bsky.feed.post", RepoAction::Create)]
+        )
+        .await
+        .is_ok());
+        // One uncovered collection in a batch denies the whole batch.
+        assert!(matches!(
+            RepoWrite::check(
+                &granted,
+                &vec![
+                    RepoTarget::new("app.bsky.feed.post", RepoAction::Create),
+                    RepoTarget::new("app.bsky.feed.like", RepoAction::Create),
+                ]
+            )
+            .await,
+            Err(ApiError::InsufficientScope(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn repo_write_refuses_an_empty_declaration() {
+        assert!(matches!(
+            RepoWrite::check(&oauth_session(&["atproto", "repo:*"]), &vec![]).await,
+            Err(ApiError::InsufficientScope(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn legacy_sessions_clear_every_declaration() {
+        let client = client().await;
+        let request = client.post("/").header(ContentType::Plain);
+        let req = request.inner();
+        let legacy = legacy_session();
+        assert!(BlobUpload::precheck(req, &legacy).await.is_ok());
+        assert!(IdentityHandle::precheck(req, &legacy).await.is_ok());
+        assert!(AccountEmail::precheck(req, &legacy).await.is_ok());
+        assert!(AccountStatus::precheck(req, &legacy).await.is_ok());
+        assert!(AccountRepo::precheck(req, &legacy).await.is_ok());
+        assert!(RepoWrite::check(
+            &legacy,
+            &vec![RepoTarget::new("app.bsky.feed.post", RepoAction::Create)]
+        )
+        .await
+        .is_ok());
+    }
+}

--- a/rsky-pds/src/pipethrough.rs
+++ b/rsky-pds/src/pipethrough.rs
@@ -1,6 +1,6 @@
 use crate::actor_store::ActorStore;
 use crate::apis::ApiError;
-use crate::auth_verifier::{AccessOutput, AccessStandard};
+use crate::auth_verifier::scope::{RpcProxy, Scoped};
 use crate::config::{ServerConfig, ServiceConfig};
 use crate::xrpc_server::types::{HandlerPipeThrough, InvalidRequestError, XRPCError};
 use crate::{context, SharedIdResolver, APP_USER_AGENT};
@@ -53,13 +53,17 @@ impl<'r> FromRequest<'r> for HandlerPipeThrough {
 
     #[tracing::instrument(skip_all)]
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        match AccessStandard::from_request(req).await {
-            Outcome::Success(output) => {
-                let AccessOutput { credentials, .. } = output.access;
-                let granted_scopes = credentials.as_ref().and_then(|c| c.granted_scopes.clone());
-                let requester: Option<String> = match credentials {
-                    None => None,
-                    Some(credentials) => credentials.did,
+        match Scoped::<RpcProxy>::from_request(req).await {
+            Outcome::Success(auth) => {
+                let requester: Option<String> = match auth.did_opt().await {
+                    Ok(requester) => requester,
+                    Err(api_error) => {
+                        req.local_cache(|| Some(api_error));
+                        return Outcome::Error((
+                            Status::Forbidden,
+                            anyhow::anyhow!("InsufficientScope"),
+                        ));
+                    }
                 };
                 let headers = req.headers().clone().into_iter().fold(
                     BTreeMap::new(),
@@ -77,13 +81,6 @@ impl<'r> FromRequest<'r> for HandlerPipeThrough {
                     cfg: req.guard::<&State<ServerConfig>>().await.unwrap(),
                     actor_store: req.guard::<&State<ActorStore>>().await.unwrap(),
                 };
-                if let Err(api_error) = assert_rpc_scope(&granted_scopes, &proxy_req).await {
-                    req.local_cache(|| Some(api_error));
-                    return Outcome::Error((
-                        Status::Forbidden,
-                        anyhow::anyhow!("InsufficientScope"),
-                    ));
-                }
                 match pipethrough(
                     &proxy_req,
                     requester,
@@ -113,10 +110,7 @@ impl<'r> FromRequest<'r> for HandlerPipeThrough {
             }
             Outcome::Error(err) => {
                 req.local_cache(|| Some(ApiError::RuntimeError));
-                Outcome::Error((
-                    Status::BadRequest,
-                    anyhow::Error::new(InvalidRequestError::AuthError(err.1)),
-                ))
+                Outcome::Error((Status::BadRequest, anyhow::Error::new(err.1)))
             }
             _ => panic!("Unexpected outcome during Pipethrough"),
         }

--- a/rsky-pds/tests/oauth_tests.rs
+++ b/rsky-pds/tests/oauth_tests.rs
@@ -786,34 +786,31 @@ async fn oauth_endpoint_edge_cases() {
     assert!(html.contains("invalid CSRF token"));
 }
 
-// Scoped-access guard tests
-// ---------------------
+// Scope-declaration seam tests
+// ---------------------------
 //
-// These prove the combinator guards in `auth_verifier.rs`
-// (`BlobScopedAccess`, `HandleScopedAccess`, `EmailScopedAccess`,
-// `AccountStatusScopedAccess`, `AccountRepoScopedAccess`) enforce their
-// resource scope through a real dispatched request over the full Rocket
-// stack -- DPoP verification, session lookup, and all -- rather than just
-// exercising the `assert_*_scope` helper in isolation. That is the point of
-// folding the assertion into the guard: a route that takes one of these
-// guards cannot get a `did` without the check having already run, so there
-// is no separate call in the handler body left to accidentally skip.
+// These prove that the declaration a route names in its signature
+// (`Scoped<Decl, Tier>`, see `auth_verifier::scope`) is enforced through a
+// real dispatched request over the full Rocket stack -- DPoP verification,
+// session lookup, and all -- rather than just exercising the `assert_*_scope`
+// helper in isolation. That is the point of the seam: a route cannot get a
+// `did` without the check having already run, so there is no separate call in
+// the handler body left to accidentally skip.
 //
-// `BlobScopedAccess` and `HandleScopedAccess` wrap `AccessStandardCheckTakedown`
-// and `AccountRepoScopedAccess<AccessStandard>` wraps `AccessStandard`, both
-// of which accept an OAuth session mapped to `AppPass`/`AppPassPrivileged` --
-// exactly what a granular-scope grant maps to (see
-// `auth_verifier::oauth_scopes_to_auth_scope`), so a real PAR/authorize/token
-// flow can reach them. `EmailScopedAccess`, `AccountStatusScopedAccess`, and
-// the default (`AccessFull`) `AccountRepoScopedAccess` wrap `AccessFull`,
-// which requires `AuthScope::Access` -- a scope only the legacy plain-JWT
-// `createSession` token type carries, and that token type always sets
-// `granted_scopes: None`. No OAuth grant can ever produce `AuthScope::Access`
-// (`oauth_scopes_to_auth_scope` only ever returns `AppPass`/`AppPassPrivileged`
-// or rejects), so those three guards' scope check is presently unreachable
-// through any live request; per-endpoint test coverage for them stays at the
-// `apis::tests` level added alongside `assert_account_scope` itself, which
-// exercises the identical helper this guard calls.
+// Which declarations a real OAuth flow can reach is decided by the tier the
+// route pairs them with. `AccessStandard` and `AccessStandardCheckTakedown`
+// accept an OAuth session mapped to `AppPass`/`AppPassPrivileged` -- exactly
+// what a granular-scope grant maps to (see
+// `auth_verifier::oauth_scopes_to_auth_scope`) -- so `BlobUpload`,
+// `IdentityHandle`, `RepoWrite` and `AccountRepo` on `AccessStandard` are
+// reachable here. `AccessFull` requires `AuthScope::Access`, a scope only the
+// legacy plain-JWT `createSession` token type carries, and that token type
+// always sets `granted_scopes: None`. No OAuth grant can ever produce
+// `AuthScope::Access`, so `AccountEmail`, `AccountStatus`, `OAuthForbidden`
+// and the `AccessFull` pairing of `AccountRepo` are presently unreachable
+// through any live OAuth request; their coverage is the declaration-level
+// unit tests in `auth_verifier::scope::tests`, plus the legacy-session
+// regression checks at the end of this file.
 
 /// Runs the full PAR -> authorize -> sign-in -> accept -> token-exchange
 /// dance for a fresh loopback client requesting exactly `scope`, returning a
@@ -890,7 +887,7 @@ fn handle_domain(client: &Client) -> String {
 }
 
 #[tokio::test]
-async fn blob_scoped_access_allows_matching_mime_and_denies_mismatch() {
+async fn blob_upload_declaration_allows_matching_mime_and_denies_mismatch() {
     let (_dir, client) = get_oauth_client().await;
     common::create_account(&client).await;
     activate_test_account(&client).await;
@@ -928,13 +925,13 @@ async fn blob_scoped_access_allows_matching_mime_and_denies_mismatch() {
 }
 
 #[tokio::test]
-async fn handle_scoped_access_allows_handle_and_denies_other_attr() {
+async fn identity_handle_declaration_allows_handle_and_denies_other_attr() {
     let (_dir, client) = get_oauth_client().await;
     common::create_account(&client).await;
     activate_test_account(&client).await;
     let domain = handle_domain(&client);
 
-    // An `identity:handle` grant clears `HandleScopedAccess` and reaches the
+    // An `identity:handle` grant clears the `IdentityHandle` declaration and reaches the
     // handler, which then talks to the mock PLC directory to rotate the
     // did:plc handle -- that mock only serves DID documents, not the PLC
     // operation-log shape `plc::Client::update_handle` needs, so the request
@@ -1065,12 +1062,12 @@ async fn an_unresolvable_proxy_audience_denies_the_proxied_call() {
 }
 
 #[tokio::test]
-async fn account_repo_scoped_access_covers_submit_plc_operation() {
+async fn account_repo_declaration_covers_submit_plc_operation() {
     let (_dir, client) = get_oauth_client().await;
     common::create_account(&client).await;
     activate_test_account(&client).await;
 
-    // `account:repo?action=manage` clears `AccountRepoScopedAccess<AccessStandard>`
+    // `account:repo?action=manage` clears `Scoped<AccountRepo, AccessStandard>`
     // and reaches the handler's own request-body validation, which rejects
     // this empty operation -- proving the guard let the request through
     // rather than stopping it at the scope check.
@@ -1104,15 +1101,14 @@ async fn account_repo_scoped_access_covers_submit_plc_operation() {
     assert_eq!(body["error"], "InsufficientScope", "body was {body}");
 }
 
-/// `EmailScopedAccess`, `AccountStatusScopedAccess`, and the default
-/// `AccountRepoScopedAccess` all wrap `AccessFull`, which requires
-/// `AuthScope::Access` -- a scope only a legacy plain-JWT `createSession`
-/// token carries (see the module doc above). This is a regression check that
-/// the refactor did not break that, the only path currently able to reach
-/// them: a legacy session still clears `EmailScopedAccess` exactly as it
-/// cleared the plain `AccessFull` guard before this change.
+/// `AccountEmail`, `AccountStatus` and the `AccessFull` pairing of
+/// `AccountRepo` sit on `AccessFull`, which requires `AuthScope::Access` -- a
+/// scope only a legacy plain-JWT `createSession` token carries (see the module
+/// doc above). This is a regression check on the only path currently able to
+/// reach them: a legacy session still clears `AccountEmail` exactly as it
+/// cleared the plain `AccessFull` guard before the seam.
 #[tokio::test]
-async fn email_scoped_access_still_accepts_a_legacy_session() {
+async fn account_email_declaration_still_accepts_a_legacy_session() {
     let (_dir, client) = get_oauth_client().await;
     let (identifier, password) = common::create_account(&client).await;
     let response = client
@@ -1133,6 +1129,144 @@ async fn email_scoped_access_still_accepts_a_legacy_session() {
         .header(ContentType::JSON)
         .header(Header::new("Authorization", format!("Bearer {access_jwt}")))
         .body(json!({ "email": "new-address@example.com" }).to_string())
+        .dispatch()
+        .await;
+    let status = response.status();
+    let text = response.into_string().await.unwrap_or_default();
+    let body: Value = serde_json::from_str(&text).unwrap_or(Value::Null);
+    assert_eq!(status, Status::Ok, "body was {body}");
+    assert_ne!(body["error"], "InsufficientScope", "body was {body}");
+}
+
+/// Dispatches an authenticated GET, retrying once with the server's DPoP
+/// nonce the same way a real client would.
+async fn dispatch_scoped_get(
+    client: &Client,
+    path: &str,
+    access_token: &str,
+    key: &Jwk,
+) -> (Status, Value) {
+    let htu = format!("{}{}", public_url(client), path);
+    let send = |nonce: Option<String>| {
+        client
+            .get(path)
+            .header(Header::new("Authorization", format!("DPoP {access_token}")))
+            .header(Header::new(
+                "DPoP",
+                dpop_proof(key, "GET", &htu, nonce.as_deref(), Some(access_token)),
+            ))
+            .dispatch()
+    };
+    let first = send(None).await;
+    let response = if first.status() == Status::Unauthorized {
+        match first.headers().get_one("DPoP-Nonce").map(str::to_string) {
+            Some(nonce) => send(Some(nonce)).await,
+            None => first,
+        }
+    } else {
+        first
+    };
+    let status = response.status();
+    let text = response.into_string().await.unwrap_or_default();
+    (status, serde_json::from_str(&text).unwrap_or(Value::Null))
+}
+
+/// `com.atproto.repo.createRecord` declares `Scoped<RepoWrite, ...>`, whose
+/// check is deferred: the handler names the collection it is about to write
+/// and only then gets the requester back. A grant covering one collection
+/// must not reach another.
+#[tokio::test]
+async fn repo_write_declaration_confines_the_collection_it_is_given() {
+    let (_dir, client) = get_oauth_client().await;
+    common::create_account(&client).await;
+    activate_test_account(&client).await;
+    let scope = "atproto repo:app.bsky.feed.post";
+
+    // The granted collection reaches the handler.
+    let (access_token, key) = granular_access_token(&client, scope).await;
+    let (status, body) = dispatch_scoped_post(
+        &client,
+        "/xrpc/com.atproto.repo.createRecord",
+        &access_token,
+        &key,
+        ContentType::JSON,
+        json!({
+            "repo": "did:web:missing.invalid",
+            "collection": "app.bsky.feed.post",
+            "record": { "$type": "app.bsky.feed.post", "text": "hi", "createdAt": "2024-01-01T00:00:00Z" }
+        })
+        .to_string()
+        .into_bytes(),
+    )
+    .await;
+    assert_ne!(status, Status::Forbidden, "body was {body}");
+    assert_ne!(body["error"], "InsufficientScope", "body was {body}");
+
+    // A different collection is refused before the handler runs at all.
+    let (access_token, key) = granular_access_token(&client, scope).await;
+    let (status, body) = dispatch_scoped_post(
+        &client,
+        "/xrpc/com.atproto.repo.createRecord",
+        &access_token,
+        &key,
+        ContentType::JSON,
+        json!({
+            "repo": "did:web:missing.invalid",
+            "collection": "app.bsky.feed.like",
+            "record": { "$type": "app.bsky.feed.like" }
+        })
+        .to_string()
+        .into_bytes(),
+    )
+    .await;
+    assert_eq!(status, Status::Forbidden, "body was {body}");
+    assert_eq!(body["error"], "InsufficientScope", "body was {body}");
+}
+
+/// `com.atproto.server.getSession` declares `Scoped<NoScopeRequired>` -- the
+/// always-allowed opt-out. A session whose only resource grant is unrelated
+/// still reaches it.
+#[tokio::test]
+async fn no_scope_required_declaration_permits_a_narrowly_scoped_session() {
+    let (_dir, client) = get_oauth_client().await;
+    common::create_account(&client).await;
+    activate_test_account(&client).await;
+
+    let (access_token, key) = granular_access_token(&client, "atproto blob:image/*").await;
+    let (status, body) = dispatch_scoped_get(
+        &client,
+        "/xrpc/com.atproto.server.getSession",
+        &access_token,
+        &key,
+    )
+    .await;
+    assert_eq!(status, Status::Ok, "body was {body}");
+    assert!(body["did"].as_str().is_some(), "body was {body}");
+}
+
+/// `com.atproto.server.listAppPasswords` declares `Scoped<OAuthForbidden, ...>`.
+/// The declaration must not disturb the legacy sessions that are the only
+/// callers it admits.
+#[tokio::test]
+async fn oauth_forbidden_declaration_still_accepts_a_legacy_session() {
+    let (_dir, client) = get_oauth_client().await;
+    let (identifier, password) = common::create_account(&client).await;
+    let response = client
+        .post("/xrpc/com.atproto.server.createSession")
+        .header(ContentType::JSON)
+        .body(json!({ "identifier": identifier, "password": password }).to_string())
+        .dispatch()
+        .await;
+    assert_eq!(response.status(), Status::Ok);
+    let session: Value = response.into_json().await.expect("session json");
+    let access_jwt = session["accessJwt"]
+        .as_str()
+        .expect("accessJwt")
+        .to_string();
+
+    let response = client
+        .get("/xrpc/com.atproto.server.listAppPasswords")
+        .header(Header::new("Authorization", format!("Bearer {access_jwt}")))
         .dispatch()
         .await;
     let status = response.status();

--- a/rsky-pds/tests/oauth_tests.rs
+++ b/rsky-pds/tests/oauth_tests.rs
@@ -802,12 +802,13 @@ async fn oauth_endpoint_edge_cases() {
 // accept an OAuth session mapped to `AppPass`/`AppPassPrivileged` -- exactly
 // what a granular-scope grant maps to (see
 // `auth_verifier::oauth_scopes_to_auth_scope`) -- so `BlobUpload`,
-// `IdentityHandle`, `RepoWrite` and `AccountRepo` on `AccessStandard` are
-// reachable here. `AccessFull` requires `AuthScope::Access`, a scope only the
-// legacy plain-JWT `createSession` token type carries, and that token type
-// always sets `granted_scopes: None`. No OAuth grant can ever produce
-// `AuthScope::Access`, so `AccountEmail`, `AccountStatus`, `OAuthForbidden`
-// and the `AccessFull` pairing of `AccountRepo` are presently unreachable
+// `IdentityHandle`, `RepoWrite`, `RpcProxy`, and the `AccessStandard*`
+// pairings of `IdentityFull` and `AccountEmail` are reachable here.
+// `AccessFull` requires `AuthScope::Access`, a scope only the legacy plain-JWT
+// `createSession` token type carries, and that token type always sets
+// `granted_scopes: None`. No OAuth grant can ever produce `AuthScope::Access`,
+// so `AccountStatus`, `AccountRepo`, `OAuthForbidden` and the `AccessFull`
+// pairings of `AccountEmail` and `IdentityFull` are presently unreachable
 // through any live OAuth request; their coverage is the declaration-level
 // unit tests in `auth_verifier::scope::tests`, plus the legacy-session
 // regression checks at the end of this file.
@@ -1062,17 +1063,16 @@ async fn an_unresolvable_proxy_audience_denies_the_proxied_call() {
 }
 
 #[tokio::test]
-async fn account_repo_declaration_covers_submit_plc_operation() {
+async fn identity_full_declaration_covers_submit_plc_operation() {
     let (_dir, client) = get_oauth_client().await;
     common::create_account(&client).await;
     activate_test_account(&client).await;
 
-    // `account:repo?action=manage` clears `Scoped<AccountRepo, AccessStandard>`
-    // and reaches the handler's own request-body validation, which rejects
-    // this empty operation -- proving the guard let the request through
-    // rather than stopping it at the scope check.
-    let (access_token, key) =
-        granular_access_token(&client, "atproto account:repo?action=manage").await;
+    // `identity:*` clears `Scoped<IdentityFull, AccessStandard>` and reaches
+    // the handler's own request-body validation, which rejects this empty
+    // operation -- proving the guard let the request through rather than
+    // stopping it at the scope check.
+    let (access_token, key) = granular_access_token(&client, "atproto identity:*").await;
     let (status, body) = dispatch_scoped_post(
         &client,
         "/xrpc/com.atproto.identity.submitPlcOperation",
@@ -1085,9 +1085,27 @@ async fn account_repo_declaration_covers_submit_plc_operation() {
     assert_ne!(body["error"], "InsufficientScope", "body was {body}");
     assert_eq!(status, Status::BadRequest, "body was {body}");
 
-    // `account:repo` alone defaults to `action=read`, which does not satisfy
-    // the `Manage` check `submitPlcOperation` requires.
-    let (access_token, key) = granular_access_token(&client, "atproto account:repo").await;
+    // A PLC operation rewrites the DID document, so the migration scope must
+    // not reach it: `account:repo?action=manage` is what `importRepo` needs,
+    // and a client granted migration capability would otherwise be able to
+    // rotate the signing key and take the account.
+    let (access_token, key) =
+        granular_access_token(&client, "atproto account:repo?action=manage").await;
+    let (status, body) = dispatch_scoped_post(
+        &client,
+        "/xrpc/com.atproto.identity.submitPlcOperation",
+        &access_token,
+        &key,
+        ContentType::JSON,
+        json!({ "operation": {} }).to_string().into_bytes(),
+    )
+    .await;
+    assert_eq!(status, Status::Forbidden, "body was {body}");
+    assert_eq!(body["error"], "InsufficientScope", "body was {body}");
+
+    // Nor does the narrower identity grant: `identity:handle` permits a handle
+    // change, not full control of the document.
+    let (access_token, key) = granular_access_token(&client, "atproto identity:handle").await;
     let (status, body) = dispatch_scoped_post(
         &client,
         "/xrpc/com.atproto.identity.submitPlcOperation",
@@ -1101,10 +1119,10 @@ async fn account_repo_declaration_covers_submit_plc_operation() {
     assert_eq!(body["error"], "InsufficientScope", "body was {body}");
 }
 
-/// `AccountEmail`, `AccountStatus` and the `AccessFull` pairing of
-/// `AccountRepo` sit on `AccessFull`, which requires `AuthScope::Access` -- a
-/// scope only a legacy plain-JWT `createSession` token carries (see the module
-/// doc above). This is a regression check on the only path currently able to
+/// `AccountStatus`, `AccountRepo` and the `AccessFull` pairings of
+/// `AccountEmail` and `IdentityFull` require `AuthScope::Access` -- a scope
+/// only a legacy plain-JWT `createSession` token carries (see the module doc
+/// above). This is a regression check on the only path currently able to
 /// reach them: a legacy session still clears `AccountEmail` exactly as it
 /// cleared the plain `AccessFull` guard before the seam.
 #[tokio::test]


### PR DESCRIPTION
Stacked on #251 — base that PR, not `main`, so this shows only its own diff. Merge #251 first.

Scope enforcement is opt-in. A route can take a plain access guard, read the requester's DID off the credentials, and perform a write with no scope check, and nothing detects the omission. That is the shape of defect that left `blob`, `rpc`, `identity` and `account` unenforced to begin with — and the same shape appears in other implementations, so it is a property of the design rather than an oversight.

`Scoped<D, Base>` makes the declaration structural: `D` names what the route must be permitted to do, and the requester's DID is reachable only from `Scoped`, only through an accessor that has already run `D`'s check. A route cannot learn whose repo it is writing without first saying what it needs.

Routes that require nothing say so explicitly, mirroring the reference implementation's two `authorize` opt-outs:

- `NoScopeRequired` — any session the route's tier admits may call it (`authorize: () => {}`)
- `OAuthForbidden` — OAuth cannot reach this route; app passwords and legacy tokens only (`authorize: () => { throw new ForbiddenError(...) }`)

Both are one grep away, so every unenforced route can be enumerated:

    rg "Scoped<(NoScopeRequired|OAuthForbidden)" rsky-pds/src/apis/

## Where to spend review attention

Most of the diff is mechanical. The substance is in two places:

- `rsky-pds/src/auth_verifier/scope.rs` — the `ScopeDecl` trait, `Scoped`, and the declarations
- the two `compile_fail` doctests on `Scoped`, which pin the actual property: a route holding a plain access guard cannot read the DID, and a deferred declaration cannot skip the value its check needs

Everything else is migrating ~35 call sites off manual `credentials.did` unwrapping onto `auth.did().await?`. The five hand-written scoped guards from #251 collapse into instances of the generic, which is why `auth_verifier.rs` gets substantially shorter.

## Not covered

Enforcement is now unforgettable for every route that goes through `Scoped`. Routes still on the older access guards are unchanged in behaviour and remain to be migrated; they are visible as the guards they still take. This PR does not attempt all 199 registrations.

## Test plan

- [x] `cargo fmt` clean (the two pre-existing violations on main in `password.rs` and `get_service_auth.rs` are untouched)
- [x] `cargo clippy -p rsky-pds --all-targets --no-deps -- -D warnings` clean
- [x] `cargo test -p rsky-pds` — 398 passed, 0 failed, 1 pre-existing ignored, plus 2 doctests
- [x] `cargo build --release -p rsky-pds`
- [x] `compile_fail` doctests confirm the property holds at compile time — verified by hand that they fail for the right reasons (`E0616` private field; `E0599` unsatisfied trait bounds), by temporarily running them as ordinary doctests
- [ ] Consider a `trybuild` harness. Each block names its expected error, but rustdoc on stable checks only *that* compilation fails, not the code — swapping in a deliberately wrong code still passes. So a snippet that starts failing for an unrelated reason (a renamed import, a moved module) would go quietly hollow. `trybuild` compares full stderr and would hold the distinction, at the cost of one dev-dependency
- [ ] Confirm the `OAuthForbidden` routes are the right set — that list is a policy decision, not a mechanical one
- [ ] Decide whether the remaining unmigrated routes land here or as a follow-up
