### PR TITLE
fix(pds): withhold the account email from sessions not granted it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8225,7 +8225,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-lexicon"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/rsky-lexicon/Cargo.toml
+++ b/rsky-lexicon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-lexicon"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 publish = true
 description = "Bluesky API library"

--- a/rsky-lexicon/src/com/atproto/server.rs
+++ b/rsky-lexicon/src/com/atproto/server.rs
@@ -171,6 +171,7 @@ pub struct CreateSessionOutput {
 pub struct GetSessionOutput {
     pub handle: String,
     pub did: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
     #[serde(rename = "emailConfirmed", skip_serializing_if = "Option::is_none")]
     pub email_confirmed: Option<bool>,

--- a/rsky-pds/src/apis/com/atproto/server/get_session.rs
+++ b/rsky-pds/src/apis/com/atproto/server/get_session.rs
@@ -1,5 +1,5 @@
 use crate::account_manager::AccountManager;
-use crate::apis::ApiError;
+use crate::apis::{allows_email_read, ApiError};
 use crate::auth_verifier::scope::{NoScopeRequired, Scoped};
 use rocket::serde::json::Json;
 use rsky_lexicon::com::atproto::server::GetSessionOutput;
@@ -11,14 +11,15 @@ pub async fn get_session(
     auth: Scoped<NoScopeRequired>,
     account_manager: AccountManager,
 ) -> Result<Json<GetSessionOutput>, ApiError> {
+    let email_visible = allows_email_read(auth.credentials().await?);
     let did = auth.did().await?;
     match account_manager.get_account(&did, None).await {
         Ok(Some(user)) => Ok(Json(GetSessionOutput {
             handle: user.handle.unwrap_or(INVALID_HANDLE.to_string()),
             did: user.did,
-            email: user.email,
+            email: email_visible.then_some(user.email).flatten(),
             did_doc: None,
-            email_confirmed: Some(user.email_confirmed_at.is_some()),
+            email_confirmed: email_visible.then_some(user.email_confirmed_at.is_some()),
         })),
         _ => Err(ApiError::AccountNotFound),
     }

--- a/rsky-pds/src/apis/mod.rs
+++ b/rsky-pds/src/apis/mod.rs
@@ -159,6 +159,28 @@ pub fn assert_rpc_target(
     )
 }
 
+/// Whether a session may see the account's email address on
+/// `com.atproto.server.getSession`.
+///
+/// Unlike the `assert_*` helpers this degrades the response rather than
+/// refusing the request: the endpoint answers for any session and only the
+/// address is withheld. The OAuth spec confers it through `transition:email`
+/// ("gets included in response to com.atproto.server.getSession") or an
+/// explicit `account:email` grant. `transition:generic` is not one of them.
+#[must_use]
+pub fn allows_email_read(credentials: &Option<Credentials>) -> bool {
+    match scoped_session(
+        credentials.as_ref().and_then(|c| c.granted_scopes.as_ref()),
+        false,
+    ) {
+        None => true,
+        Some(scopes) => {
+            scopes.has_transition("email")
+                || scopes.allows_account("email", crate::oauth_scope::AccountAction::Read)
+        }
+    }
+}
+
 /// Enforce an OAuth session's `account:` scope on an account-level mutation
 /// (email, deactivation/activation, PLC rotation).
 ///
@@ -891,6 +913,43 @@ mod tests {
         // Legacy sessions are unaffected, as everywhere else.
         assert!(assert_rpc_target(&creds(&["atproto", "transition:generic"]), lxm, aud).is_ok());
         assert!(assert_rpc_target(&None, lxm, aud).is_ok());
+    }
+
+    /// The OAuth spec confers the address through `transition:email` or an
+    /// explicit `account:email` grant, and through nothing else.
+    #[test]
+    fn email_is_visible_only_to_a_session_granted_it() {
+        // No granted scopes at all: app password / legacy token, unaffected.
+        assert!(allows_email_read(&None));
+
+        // The two grants the spec names.
+        assert!(allows_email_read(&creds(&["atproto", "transition:email"])));
+        assert!(allows_email_read(&creds(&["atproto", "account:email"])));
+        assert!(allows_email_read(&creds(&[
+            "atproto",
+            "account:email?action=read"
+        ])));
+        // `manage` subsumes `read`.
+        assert!(allows_email_read(&creds(&[
+            "atproto",
+            "account:email?action=manage"
+        ])));
+
+        // Everything else is withheld, transition:generic included.
+        assert!(!allows_email_read(&creds(&["atproto"])));
+        assert!(!allows_email_read(&creds(&[
+            "atproto",
+            "transition:generic"
+        ])));
+        assert!(!allows_email_read(&creds(&[
+            "atproto",
+            "repo:app.bsky.feed.post"
+        ])));
+        assert!(!allows_email_read(&creds(&["atproto", "account:status"])));
+        assert!(!allows_email_read(&creds(&[
+            "atproto",
+            "include:app.example.set"
+        ])));
     }
 
     /// App passwords and legacy access tokens carry no `granted_scopes`;


### PR DESCRIPTION
Stacked on #251 for the `account:` scope variants it adds — base that PR, not `main`. Sibling to #255; the two are independent.

`com.atproto.server.getSession` returned the email address and its confirmation state to every session, consulting no scope at all. Any OAuth token reached them, including one granted nothing but repo writes.

The [OAuth spec](https://atproto.com/specs/oauth#transitional-scopes) confers the address through `transition:email` — whose entire definition is that it *"gets included in response to `com.atproto.server.getSession`"* — or through an explicit `account:email` grant. If email were unconditional, that scope would grant nothing and have no reason to exist.

| session | email |
|---|---|
| app password / legacy `createSession` (no granted scopes) | returned |
| `transition:email` | returned |
| `account:email`, `?action=read`, `?action=manage` | returned |
| `transition:generic` | **withheld** |
| `repo:`-only, or any other granular grant | **withheld** |

This degrades the response rather than refusing the request — the endpoint still answers, minus the address. That is the `allows_*` half of the scope API rather than the `assert_*` half.

## Two details

`email` had no `skip_serializing_if`, so withholding it would have emitted `"email": null` where the lexicon types the field as a string. The lexicon marks only `handle` and `did` as required, so omission is the schema-valid way to withhold it; `emailConfirmed` already had the attribute. Hence the `rsky-lexicon` patch bump.

The handler also did `credentials.unwrap().did.unwrap()`. Those now return `AccountNotFound` instead of panicking.

## How other implementations handle this

Read directly rather than assumed:

- **TypeScript reference** — redacts unless `account:email?action=read`, stripping `email`, `emailConfirmed` and `emailAuthFactor`. Its route declares `authorize: () => {}` with the comment *"Always allowed. `email` access is checked in the handler."*
- **tranquil-pds** — redacts on `allows_email_read()`, which is `transition:email` OR an `account:email`/`account:*` grant. It computes the predicate without first asking whether a scope check applies, so legacy password sessions appear unable to see their own email; this PR avoids that by routing through the same no-granted-scopes exemption the other checks use.
- **cocoon** — returns the email unconditionally. The identical gap, in the same endpoint, worth reporting upstream.

rsky has no `emailAuthFactor` field in `GetSessionOutput`, so there are two fields to withhold here rather than upstream's three.

## Behavior change

A granular OAuth session that never requested `transition:email` or `account:email` stops seeing the address. Sessions with no granted scopes — the ordinary app-password path — are unaffected. Lands in the same deploy as #251's transition-scope changes and would be noticed alongside them.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy -p rsky-pds --all-targets --no-deps -- -D warnings` clean (4 pre-existing `rsky-lexicon` lints are identical on the base)
- [x] `cargo test -p rsky-pds` — 387 passed, 0 failed, 1 pre-existing ignored
- [x] `cargo build --release -p rsky-pds`
- [x] New unit test pinning the full visibility matrix above
- [ ] Confirm against a real OAuth client that losing the address is acceptable, or that the client can request `account:email`
- [ ] Consider whether `getSession` should advertise the requirement in its lexicon description