### PR TITLE
fix(repo): verify commit signatures against the digest for both curves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8143,9 +8143,12 @@ name = "rsky-crypto"
 version = "0.2.1"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "multibase",
  "p256 0.13.2",
  "secp256k1",
+ "serde",
+ "serde_json",
  "sha2 0.10.9",
  "unsigned-varint 0.8.0",
 ]
@@ -8494,7 +8497,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-repo"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -8508,6 +8511,7 @@ dependencies = [
  "ipld-core",
  "iroh-car",
  "lazy_static",
+ "p256 0.13.2",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rsky-identity = {path = "rsky-identity", version = "0.2.0"}
 rsky-crypto = {path = "rsky-crypto", version = "0.2.1"}
 rsky-syntax = {path = "rsky-syntax", version = "0.1.0"}
 rsky-common = {path = "rsky-common", version = "0.1.3"}
-rsky-repo = {path = "rsky-repo", version = "0.0.6"}
+rsky-repo = {path = "rsky-repo", version = "0.0.7"}
 rsky-firehose = {path = "rsky-firehose", version = "0.2.1"}
 
 [profile.release]

--- a/rsky-crypto/Cargo.toml
+++ b/rsky-crypto/Cargo.toml
@@ -19,3 +19,6 @@ unsigned-varint = "0.8.0"
 
 [dev-dependencies]
 sha2 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+base64 = "0.22"

--- a/rsky-crypto/tests/interop/signature-fixtures.json
+++ b/rsky-crypto/tests/interop/signature-fixtures.json
@@ -1,0 +1,68 @@
+[
+  {
+    "comment": "valid P-256 key and signature, with low-S signature",
+    "messageBase64": "oWVoZWxsb2V3b3JsZA",
+    "algorithm": "ES256",
+    "didDocSuite": "EcdsaSecp256r1VerificationKey2019",
+    "publicKeyDid": "did:key:zDnaembgSGUhZULN2Caob4HLJPaxBh92N7rtH21TErzqf8HQo",
+    "publicKeyMultibase": "zxdM8dSstjrpZaRUwBmDvjGXweKuEMVN95A9oJBFjkWMh",
+    "signatureBase64": "2vZNsG3UKvvO/CDlrdvyZRISOFylinBh0Jupc6KcWoJWExHptCfduPleDbG3rko3YZnn9Lw0IjpixVmexJDegg",
+    "validSignature": true,
+    "tags": []
+  },
+  {
+    "comment": "valid K-256 key and signature, with low-S signature",
+    "messageBase64": "oWVoZWxsb2V3b3JsZA",
+    "algorithm": "ES256K",
+    "didDocSuite": "EcdsaSecp256k1VerificationKey2019",
+    "publicKeyDid": "did:key:zQ3shqwJEJyMBsBXCWyCBpUBMqxcon9oHB7mCvx4sSpMdLJwc",
+    "publicKeyMultibase": "z25z9DTpsiYYJKGsWmSPJK2NFN8PcJtZig12K59UgW7q5t",
+    "signatureBase64": "5WpdIuEUUfVUYaozsi8G0B3cWO09cgZbIIwg1t2YKdUn/FEznOndsz/qgiYb89zwxYCbB71f7yQK5Lr7NasfoA",
+    "validSignature": true,
+    "tags": []
+  },
+  {
+    "comment": "P-256 key and signature, with non-low-S signature which is invalid in atproto",
+    "messageBase64": "oWVoZWxsb2V3b3JsZA",
+    "algorithm": "ES256",
+    "didDocSuite": "EcdsaSecp256r1VerificationKey2019",
+    "publicKeyDid": "did:key:zDnaembgSGUhZULN2Caob4HLJPaxBh92N7rtH21TErzqf8HQo",
+    "publicKeyMultibase": "zxdM8dSstjrpZaRUwBmDvjGXweKuEMVN95A9oJBFjkWMh",
+    "signatureBase64": "2vZNsG3UKvvO/CDlrdvyZRISOFylinBh0Jupc6KcWoKp7O4VS9giSAah8k5IUbXIW00SuOrjfEqQ9HEkN9JGzw",
+    "validSignature": false,
+    "tags": ["high-s"]
+  },
+  {
+    "comment": "K-256 key and signature, with non-low-S signature which is invalid in atproto",
+    "messageBase64": "oWVoZWxsb2V3b3JsZA",
+    "algorithm": "ES256K",
+    "didDocSuite": "EcdsaSecp256k1VerificationKey2019",
+    "publicKeyDid": "did:key:zQ3shqwJEJyMBsBXCWyCBpUBMqxcon9oHB7mCvx4sSpMdLJwc",
+    "publicKeyMultibase": "z25z9DTpsiYYJKGsWmSPJK2NFN8PcJtZig12K59UgW7q5t",
+    "signatureBase64": "5WpdIuEUUfVUYaozsi8G0B3cWO09cgZbIIwg1t2YKdXYA67MYxYiTMAVfdnkDCMN9S5B3vHosRe07aORmoshoQ",
+    "validSignature": false,
+    "tags": ["high-s"]
+  },
+  {
+    "comment": "P-256 key and signature, with DER-encoded signature which is invalid in atproto",
+    "messageBase64": "oWVoZWxsb2V3b3JsZA",
+    "algorithm": "ES256",
+    "didDocSuite": "EcdsaSecp256r1VerificationKey2019",
+    "publicKeyDid": "did:key:zDnaeT6hL2RnTdUhAPLij1QBkhYZnmuKyM7puQLW1tkF4Zkt8",
+    "publicKeyMultibase": "ze8N2PPxnu19hmBQ58t5P3E9Yj6CqakJmTVCaKvf9Byq2",
+    "signatureBase64": "MEQCIFxYelWJ9lNcAVt+jK0y/T+DC/X4ohFZ+m8f9SEItkY1AiACX7eXz5sgtaRrz/SdPR8kprnbHMQVde0T2R8yOTBweA",
+    "validSignature": false,
+    "tags": ["der-encoded"]
+  },
+  {
+    "comment": "K-256 key and signature, with DER-encoded signature which is invalid in atproto",
+    "messageBase64": "oWVoZWxsb2V3b3JsZA",
+    "algorithm": "ES256K",
+    "didDocSuite": "EcdsaSecp256k1VerificationKey2019",
+    "publicKeyDid": "did:key:zQ3shnriYMXc8wvkbJqfNWh5GXn2bVAeqTC92YuNbek4npqGF",
+    "publicKeyMultibase": "z22uZXWP8fdHXi4jyx8cCDiBf9qQTsAe6VcycoMQPfcMQX",
+    "signatureBase64": "MEUCIQCWumUqJqOCqInXF7AzhIRg2MhwRz2rWZcOEsOjPmNItgIgXJH7RnqfYY6M0eg33wU0sFYDlprwdOcpRn78Sz5ePgk",
+    "validSignature": false,
+    "tags": ["der-encoded"]
+  }
+]

--- a/rsky-crypto/tests/interop_signatures.rs
+++ b/rsky-crypto/tests/interop_signatures.rs
@@ -1,0 +1,100 @@
+//! Table-driven check against the upstream atproto interop crypto fixtures,
+//! vendored verbatim from `interop-test-files/crypto/signature-fixtures.json`.
+
+use base64::engine::general_purpose::STANDARD_NO_PAD;
+use base64::Engine;
+use rsky_crypto::verify::{verify_signature, verify_signature_digest};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Fixture {
+    comment: String,
+    message_base64: String,
+    algorithm: String,
+    public_key_did: String,
+    signature_base64: String,
+    valid_signature: bool,
+    tags: Vec<String>,
+}
+
+/// The fixtures are unpadded but use the standard alphabet, not the url-safe
+/// one, so fold `-_` onto `+/` before decoding.
+fn decode(value: &str) -> Vec<u8> {
+    let normalized: String = value
+        .chars()
+        .map(|c| match c {
+            '-' => '+',
+            '_' => '/',
+            other => other,
+        })
+        .collect();
+    STANDARD_NO_PAD.decode(normalized).unwrap()
+}
+
+fn fixtures() -> Vec<Fixture> {
+    serde_json::from_str(include_str!("interop/signature-fixtures.json")).unwrap()
+}
+
+#[test]
+fn interop_fixtures_match_expected_validity() {
+    let fixtures = fixtures();
+    assert_eq!(fixtures.len(), 6);
+    assert_eq!(
+        fixtures.iter().filter(|f| f.valid_signature).count(),
+        2,
+        "fixture set should carry exactly two valid signatures"
+    );
+    assert_eq!(
+        fixtures
+            .iter()
+            .filter(|f| f.tags.iter().any(|t| t == "high-s"))
+            .count(),
+        2
+    );
+    assert_eq!(
+        fixtures
+            .iter()
+            .filter(|f| f.tags.iter().any(|t| t == "der-encoded"))
+            .count(),
+        2
+    );
+
+    for fixture in &fixtures {
+        let message = decode(&fixture.message_base64);
+        let sig = decode(&fixture.signature_base64);
+        let digest = Sha256::digest(&message);
+        let actual =
+            verify_signature_digest(&fixture.public_key_did, &digest, &sig, None).unwrap_or(false);
+        assert_eq!(
+            actual, fixture.valid_signature,
+            "{} ({})",
+            fixture.comment, fixture.algorithm
+        );
+    }
+}
+
+/// Pins the documented asymmetry of the raw-message entrypoint: p256 hashes
+/// `data` internally while secp256k1 requires `data` to already be the digest.
+#[test]
+fn raw_message_entrypoint_semantics_are_asymmetric() {
+    for fixture in fixtures().iter().filter(|f| f.valid_signature) {
+        let message = decode(&fixture.message_base64);
+        let sig = decode(&fixture.signature_base64);
+        let digest = Sha256::digest(&message);
+        let did = &fixture.public_key_did;
+
+        match fixture.algorithm.as_str() {
+            "ES256" => {
+                assert!(verify_signature(did, &message, &sig, None).unwrap());
+                assert!(!verify_signature(did, &digest, &sig, None).unwrap());
+            }
+            "ES256K" => {
+                assert!(verify_signature(did, &digest, &sig, None).unwrap());
+                assert!(verify_signature(did, &message, &sig, None).is_err());
+            }
+            other => panic!("unexpected algorithm {other}"),
+        }
+    }
+}

--- a/rsky-repo/Cargo.toml
+++ b/rsky-repo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-repo"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust crate for atproto repositories, an in particular the Merkle Search Tree (MST) data structure."
 license = "Apache-2.0"
@@ -43,3 +43,4 @@ lazy_static = "1.4.0"
 [dev-dependencies]
 glob = "0.3"
 indexmap = "2"
+p256 = { version = "0.13.2", features = ["ecdsa", "arithmetic", "alloc"] }

--- a/rsky-repo/src/util.rs
+++ b/rsky-repo/src/util.rs
@@ -41,7 +41,7 @@ pub fn verify_commit_sig(commit: Commit, did_key: &String) -> Result<bool> {
     };
     let encoded = serde_ipld_dagcbor::to_vec(&rest)?;
     let hash = Sha256::digest(&*encoded);
-    rsky_crypto::verify::verify_signature(did_key, hash.as_ref(), sig.as_slice(), None)
+    rsky_crypto::verify::verify_signature_digest(did_key, hash.as_ref(), sig.as_slice(), None)
 }
 
 pub fn format_data_key<T: FromStr + Display>(collection: T, rkey: T) -> String {
@@ -401,5 +401,94 @@ mod tests {
             }
             other => panic!("avatar should parse as Lex::Blob, got {other:?}"),
         }
+    }
+
+    fn unsigned_commit() -> UnsignedCommit {
+        UnsignedCommit {
+            did: "did:plc:aaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+            rev: "3lbqxyzabcd2z".to_string(),
+            data: "bafkreiey6e2xp4ncufvsyfmubucbsz5xujbc7lguospuziohtgfdik3pr4"
+                .parse()
+                .unwrap(),
+            prev: None,
+            version: 3,
+        }
+    }
+
+    fn commit_digest(unsigned: &UnsignedCommit) -> Vec<u8> {
+        Sha256::digest(&*serde_ipld_dagcbor::to_vec(unsigned).unwrap()).to_vec()
+    }
+
+    fn to_commit(unsigned: UnsignedCommit, sig: Vec<u8>) -> Commit {
+        Commit {
+            did: unsigned.did,
+            rev: unsigned.rev,
+            data: unsigned.data,
+            prev: unsigned.prev,
+            version: unsigned.version,
+            sig,
+        }
+    }
+
+    /// A P-256 signing key signs the commit digest; verification must hash the
+    /// commit exactly once, or every P-256-keyed repo fails to verify.
+    #[test]
+    fn verifies_p256_signed_commit() {
+        use p256::ecdsa::signature::hazmat::PrehashSigner;
+        use p256::ecdsa::{Signature, SigningKey};
+
+        let signing_key = SigningKey::from_slice(&[0x2au8; 32]).unwrap();
+        let did_key = rsky_crypto::did::format_did_key(
+            rsky_crypto::constants::P256_JWT_ALG.to_string(),
+            signing_key
+                .verifying_key()
+                .to_encoded_point(true)
+                .as_bytes()
+                .to_vec(),
+        )
+        .unwrap();
+
+        let unsigned = unsigned_commit();
+        let digest = commit_digest(&unsigned);
+        let sig: Signature = signing_key.sign_prehash(&digest).unwrap();
+        let sig = sig.normalize_s().unwrap_or(sig);
+        let commit = to_commit(unsigned, sig.to_vec());
+
+        assert!(verify_commit_sig(commit.clone(), &did_key).unwrap());
+
+        let mut tampered = commit;
+        tampered.rev = "3lbqxyzabce2z".to_string();
+        assert!(!verify_commit_sig(tampered, &did_key).unwrap());
+    }
+
+    #[test]
+    fn verifies_secp256k1_signed_commit() {
+        use rsky_crypto::utils::encode_did_key;
+        use secp256k1::{PublicKey, Secp256k1, SecretKey};
+
+        let secret = SecretKey::from_slice(&[0x2au8; 32]).unwrap();
+        let did_key = encode_did_key(&PublicKey::from_secret_key(&Secp256k1::new(), &secret));
+
+        let unsigned = unsigned_commit();
+        let sig = sign_without_indexmap(&unsigned, &secret).unwrap();
+        let commit = to_commit(unsigned, sig.to_vec());
+
+        assert!(verify_commit_sig(commit.clone(), &did_key).unwrap());
+
+        let mut tampered = commit;
+        tampered.rev = "3lbqxyzabce2z".to_string();
+        assert!(!verify_commit_sig(tampered, &did_key).unwrap());
+    }
+
+    #[test]
+    fn sign_commit_round_trips() {
+        use rsky_crypto::utils::encode_did_key;
+        use secp256k1::{Keypair, Secp256k1};
+
+        let secp = Secp256k1::new();
+        let keypair = Keypair::from_seckey_slice(&secp, &[0x2au8; 32]).unwrap();
+        let did_key = encode_did_key(&keypair.public_key());
+        let commit = sign_commit(unsigned_commit(), &keypair).unwrap();
+        assert!(verify_commit_sig(commit, &did_key).unwrap());
     }
 }


### PR DESCRIPTION
## Summary

`verify_commit_sig` hashed the DAG-CBOR commit and then called `verify_signature`, whose per-curve plugins disagree on what `data` means: secp256k1 treats it as a digest, P-256 hashes it internally. P-256-keyed repos were therefore hashed twice and their commit signatures never verified. `verify_signature_digest` gives both curves digest semantics and is used instead.

Also vendors the atproto interop signature vectors (valid, high-S, and DER-encoded cases) and runs them against the verifier.

## Test plan

- [ ] `cargo test -p rsky-repo -p rsky-crypto` passes
- [ ] The interop vectors all match their expected verdict
- [ ] Reverting the one-line change fails the P-256 regression test and not the secp256k1 one
- [ ] `cargo build --release -p rsky-repo -p rsky-crypto` succeeds