### PR TITLE
fix(relay): reject malleable high-S signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8439,7 +8439,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-relay"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes",
  "chrono",

--- a/rsky-relay/Cargo.toml
+++ b/rsky-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-relay"
-version = "0.1.2"
+version = "0.1.3"
 default-run = "rsky-relay"
 edition = "2024"
 

--- a/rsky-relay/src/publisher/types.rs
+++ b/rsky-relay/src/publisher/types.rs
@@ -225,13 +225,14 @@ mod maybe_tls_stream {
         fn plain_tcp_shutdown_succeeds() {
             let listener = TcpListener::bind("127.0.0.1:0").unwrap();
             let port = listener.local_addr().unwrap().port();
-            let server_thread = std::thread::spawn(move || {
-                drop(listener.accept());
-            });
+            let server_thread = std::thread::spawn(move || listener.accept().map(|(s, _)| s));
             let client = TcpStream::connect(("127.0.0.1", port)).unwrap();
+            // Hold the accepted end open: a peer that closes first resets the connection and
+            // makes shutdown fail with ENOTCONN.
+            let accepted = server_thread.join().unwrap().unwrap();
             let mut s = MaybeTlsStream::Plain(client);
             s.shutdown().unwrap();
-            server_thread.join().unwrap();
+            drop(accepted);
         }
     }
 }

--- a/rsky-relay/src/publisher/worker.rs
+++ b/rsky-relay/src/publisher/worker.rs
@@ -203,6 +203,14 @@ mod tests {
 
     type WsClient = WebSocket<StdTcpStream>;
 
+    static SHUTDOWN_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// `SHUTDOWN` is process-global: tests that flip it must not overlap with tests that
+    /// depend on it being clear.
+    fn shutdown_guard() -> std::sync::MutexGuard<'static, ()> {
+        SHUTDOWN_GUARD.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
     fn build_worker() -> (Worker, rtrb::Producer<Command>, tempfile::TempDir, Keyspace) {
         let (tx, rx) = rtrb::RingBuffer::<Command>::new(64);
         let tmp = tempfile::tempdir().unwrap();
@@ -263,6 +271,7 @@ mod tests {
 
     #[test]
     fn run_processes_commands_then_exits_on_shutdown() {
+        let _guard = shutdown_guard();
         // Drive run(): start a thread that flips SHUTDOWN after a short delay so run returns.
         let (w, mut tx, _tmp, _ks) = build_worker();
         let (server_stream, peer_addr, client_handle) = ws_pair_for_worker();
@@ -320,6 +329,7 @@ mod tests {
 
     #[test]
     fn update_returns_false_when_shutdown_set() {
+        let _guard = shutdown_guard();
         let (mut w, _tx, _tmp, _ks) = build_worker();
         let mut seq = Cursor::from(0);
         SHUTDOWN.store(true, Ordering::SeqCst);
@@ -330,6 +340,7 @@ mod tests {
 
     #[test]
     fn update_broadcasts_new_events_to_caught_up_subscriber() {
+        let _guard = shutdown_guard();
         let (mut w, _tx, _tmp, ks) = build_worker();
         let (server_stream, peer_addr, client_handle) = ws_pair_for_worker();
         w.handle_command(
@@ -351,6 +362,7 @@ mod tests {
 
     #[test]
     fn update_lag_routes_to_poll_for_subscriber_starting_at_zero() {
+        let _guard = shutdown_guard();
         // The bug-fix scenario. cursor=0 subscriber + live events should still be delivered.
         let (mut w, _tx, _tmp, ks) = build_worker();
         let firehose = ks.open_partition("firehose", PartitionCreateOptions::default()).unwrap();
@@ -375,6 +387,7 @@ mod tests {
 
     #[test]
     fn run_exits_immediately_when_shutdown_already_set() {
+        let _guard = shutdown_guard();
         let (w, _tx, _tmp, _ks) = build_worker();
         SHUTDOWN.store(true, Ordering::SeqCst);
         let result = w.run();

--- a/rsky-relay/src/validator/utils.rs
+++ b/rsky-relay/src/validator/utils.rs
@@ -23,6 +23,33 @@ pub enum VerificationError {
     Key(#[from] p256::ecdsa::Error),
 }
 
+fn verify_sig(msg: &[u8], sig: &[u8], key: &[u8; 35]) -> Result<bool, VerificationError> {
+    match &key[0..2] {
+        P256_DID_PREFIX => {
+            let key = p256::ecdsa::VerifyingKey::from_sec1_bytes(&key[2..])?;
+            let sig = p256::ecdsa::Signature::from_slice(sig)?;
+            // atproto requires low-S: `normalize_s` returns `Some` only for a malleable high-S sig
+            if sig.normalize_s().is_some() {
+                tracing::debug!("rejected high-S signature");
+                return Ok(false);
+            }
+            Ok(key.verify(msg, &sig).is_ok())
+        }
+        K256_DID_PREFIX => {
+            let key = k256::ecdsa::VerifyingKey::from_sec1_bytes(&key[2..])?;
+            let sig = k256::ecdsa::Signature::from_slice(sig)?;
+            if sig.normalize_s().is_some() {
+                tracing::debug!("rejected high-S signature");
+                return Ok(false);
+            }
+            Ok(key.verify(msg, &sig).is_ok())
+        }
+        _ => {
+            unreachable!()
+        }
+    }
+}
+
 #[cfg(feature = "labeler")]
 pub fn verify_commit_sig(
     labels: &[SubscribeLabel], key: &[u8; 35],
@@ -33,21 +60,7 @@ pub fn verify_commit_sig(
             let mut label = label.clone();
             label.sig = None;
             let encoded = serde_ipld_dagcbor::to_vec(&label)?;
-            match &key[0..2] {
-                P256_DID_PREFIX => {
-                    let key = p256::ecdsa::VerifyingKey::from_sec1_bytes(&key[2..])?;
-                    let sig = p256::ecdsa::Signature::from_slice(sig)?;
-                    ret &= key.verify(&encoded, &sig).is_ok();
-                }
-                K256_DID_PREFIX => {
-                    let key = k256::ecdsa::VerifyingKey::from_sec1_bytes(&key[2..])?;
-                    let sig = k256::ecdsa::Signature::from_slice(sig)?;
-                    ret &= key.verify(&encoded, &sig).is_ok();
-                }
-                _ => {
-                    unreachable!()
-                }
-            }
+            ret &= verify_sig(&encoded, sig, key)?;
         }
     }
     Ok(ret)
@@ -56,21 +69,7 @@ pub fn verify_commit_sig(
 #[cfg(not(feature = "labeler"))]
 pub fn verify_commit_sig(commit: &Commit, key: &[u8; 35]) -> Result<bool, VerificationError> {
     let encoded = serde_ipld_dagcbor::to_vec(commit)?;
-    match &key[0..2] {
-        P256_DID_PREFIX => {
-            let key = p256::ecdsa::VerifyingKey::from_sec1_bytes(&key[2..])?;
-            let sig = p256::ecdsa::Signature::from_slice(&commit.sig)?;
-            Ok(key.verify(&encoded, &sig).is_ok())
-        }
-        K256_DID_PREFIX => {
-            let key = k256::ecdsa::VerifyingKey::from_sec1_bytes(&key[2..])?;
-            let sig = k256::ecdsa::Signature::from_slice(&commit.sig)?;
-            Ok(key.verify(&encoded, &sig).is_ok())
-        }
-        _ => {
-            unreachable!()
-        }
-    }
+    verify_sig(&encoded, &commit.sig, key)
 }
 
 #[cfg(not(feature = "labeler"))]
@@ -170,5 +169,220 @@ mod tests {
             unreachable!()
         };
         assert!(verify_commit_sig(&labels.labels, KEY).unwrap_or(false));
+    }
+
+    use serde::Deserialize;
+
+    use super::{K256_DID_PREFIX, P256_DID_PREFIX, verify_commit_sig, verify_sig};
+
+    const FIXTURES: &str = include_str!("../../tests/interop/signature-fixtures.json");
+
+    fn p256_keypair() -> (p256::ecdsa::SigningKey, [u8; 35]) {
+        let signing = p256::ecdsa::SigningKey::from_slice(&[0x11; 32]).unwrap();
+        let point = signing.verifying_key().to_encoded_point(true);
+        let mut key = [0u8; 35];
+        key[0..2].copy_from_slice(P256_DID_PREFIX);
+        key[2..].copy_from_slice(point.as_bytes());
+        (signing, key)
+    }
+
+    fn k256_keypair() -> (k256::ecdsa::SigningKey, [u8; 35]) {
+        let signing = k256::ecdsa::SigningKey::from_slice(&[0x22; 32]).unwrap();
+        let point = signing.verifying_key().to_encoded_point(true);
+        let mut key = [0u8; 35];
+        key[0..2].copy_from_slice(K256_DID_PREFIX);
+        key[2..].copy_from_slice(point.as_bytes());
+        (signing, key)
+    }
+
+    /// Deterministic (RFC 6979) low-S signature plus its high-S counterpart (`s` negated).
+    fn p256_sigs(signing: &p256::ecdsa::SigningKey, msg: &[u8]) -> (Vec<u8>, Vec<u8>) {
+        use p256::ecdsa::signature::Signer as _;
+        let sig: p256::ecdsa::Signature = signing.sign(msg);
+        let low = sig.normalize_s().unwrap_or(sig);
+        let high =
+            p256::ecdsa::Signature::from_scalars(*low.r().as_ref(), -*low.s().as_ref()).unwrap();
+        (low.to_vec(), high.to_vec())
+    }
+
+    fn k256_sigs(signing: &k256::ecdsa::SigningKey, msg: &[u8]) -> (Vec<u8>, Vec<u8>) {
+        use k256::ecdsa::signature::Signer as _;
+        let sig: k256::ecdsa::Signature = signing.sign(msg);
+        let low = sig.normalize_s().unwrap_or(sig);
+        let high =
+            k256::ecdsa::Signature::from_scalars(*low.r().as_ref(), -*low.s().as_ref()).unwrap();
+        (low.to_vec(), high.to_vec())
+    }
+
+    #[test]
+    fn verify_sig_rejects_high_s_p256() {
+        let (signing, key) = p256_keypair();
+        let (low, high) = p256_sigs(&signing, b"msg");
+        assert!(matches!(verify_sig(b"msg", &low, &key), Ok(true)));
+        assert!(matches!(verify_sig(b"msg", &high, &key), Ok(false)));
+    }
+
+    #[test]
+    fn verify_sig_rejects_high_s_k256() {
+        let (signing, key) = k256_keypair();
+        let (low, high) = k256_sigs(&signing, b"msg");
+        assert!(matches!(verify_sig(b"msg", &low, &key), Ok(true)));
+        assert!(matches!(verify_sig(b"msg", &high, &key), Ok(false)));
+    }
+
+    #[test]
+    fn verify_sig_rejects_der_encoded() {
+        let (signing, key) = p256_keypair();
+        let (low, _) = p256_sigs(&signing, b"msg");
+        let der = p256::ecdsa::Signature::from_slice(&low).unwrap().to_der();
+        assert!(verify_sig(b"msg", der.as_bytes(), &key).is_err());
+    }
+
+    #[test]
+    fn verify_sig_rejects_wrong_message() {
+        let (signing, key) = p256_keypair();
+        let (low, _) = p256_sigs(&signing, b"msg");
+        assert!(matches!(verify_sig(b"other", &low, &key), Ok(false)));
+    }
+
+    #[test]
+    fn verify_sig_rejects_malformed_key() {
+        let (signing, mut key) = p256_keypair();
+        let (low, _) = p256_sigs(&signing, b"msg");
+        key[2] = 0xff;
+        assert!(verify_sig(b"msg", &low, &key).is_err());
+        let (signing, mut key) = k256_keypair();
+        let (low, _) = k256_sigs(&signing, b"msg");
+        key[2] = 0xff;
+        assert!(verify_sig(b"msg", &low, &key).is_err());
+    }
+
+    #[cfg(not(feature = "labeler"))]
+    fn make_commit(sig: Vec<u8>) -> crate::validator::event::Commit {
+        use rsky_common::tid::TID;
+
+        crate::validator::event::Commit {
+            did: "did:plc:test".to_owned(),
+            rev: TID::new("3kqcb45gzpk2c".to_owned()).unwrap(),
+            data: cid::Cid::try_from("bafyreigbtj4x7ip5legnfznufuopl4sg4knzc2cof6duas4b3q2fy6swua")
+                .unwrap(),
+            prev: None,
+            version: 3,
+            sig,
+        }
+    }
+
+    #[cfg(not(feature = "labeler"))]
+    #[test]
+    fn verify_commit_sig_rejects_high_s_p256() {
+        let (signing, key) = p256_keypair();
+        let encoded = serde_ipld_dagcbor::to_vec(&make_commit(Vec::new())).unwrap();
+        let (low, high) = p256_sigs(&signing, &encoded);
+        assert!(matches!(verify_commit_sig(&make_commit(low), &key), Ok(true)));
+        assert!(matches!(verify_commit_sig(&make_commit(high), &key), Ok(false)));
+    }
+
+    #[cfg(not(feature = "labeler"))]
+    #[test]
+    fn verify_commit_sig_rejects_high_s_k256() {
+        let (signing, key) = k256_keypair();
+        let encoded = serde_ipld_dagcbor::to_vec(&make_commit(Vec::new())).unwrap();
+        let (low, high) = k256_sigs(&signing, &encoded);
+        assert!(matches!(verify_commit_sig(&make_commit(low), &key), Ok(true)));
+        assert!(matches!(verify_commit_sig(&make_commit(high), &key), Ok(false)));
+    }
+
+    #[cfg(feature = "labeler")]
+    fn make_label(sig: Option<Vec<u8>>) -> crate::validator::event::SubscribeLabel {
+        crate::validator::event::SubscribeLabel {
+            ver: Some(1),
+            src: "did:plc:test".to_owned(),
+            uri: "at://did:plc:test/app.bsky.feed.post/3lr4pmliavk2l".to_owned(),
+            cid: None,
+            val: "spam".to_owned(),
+            neg: None,
+            cts: "2026-01-12T19:45:23.307Z".to_owned(),
+            cts_dt: chrono::DateTime::parse_from_rfc3339("2026-01-12T19:45:23.307Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            exp: None,
+            sig,
+        }
+    }
+
+    #[cfg(feature = "labeler")]
+    #[test]
+    fn verify_commit_sig_rejects_high_s_p256() {
+        let (signing, key) = p256_keypair();
+        let encoded = serde_ipld_dagcbor::to_vec(&make_label(None)).unwrap();
+        let (low, high) = p256_sigs(&signing, &encoded);
+        assert!(matches!(verify_commit_sig(&[make_label(Some(low))], &key), Ok(true)));
+        assert!(matches!(verify_commit_sig(&[make_label(Some(high))], &key), Ok(false)));
+    }
+
+    #[cfg(feature = "labeler")]
+    #[test]
+    fn verify_commit_sig_rejects_high_s_k256() {
+        let (signing, key) = k256_keypair();
+        let encoded = serde_ipld_dagcbor::to_vec(&make_label(None)).unwrap();
+        let (low, high) = k256_sigs(&signing, &encoded);
+        assert!(matches!(verify_commit_sig(&[make_label(Some(low))], &key), Ok(true)));
+        assert!(matches!(verify_commit_sig(&[make_label(Some(high))], &key), Ok(false)));
+    }
+
+    #[cfg(feature = "labeler")]
+    #[test]
+    fn verify_commit_sig_ignores_unsigned_labels() {
+        let (_, key) = p256_keypair();
+        assert!(matches!(verify_commit_sig(&[make_label(None)], &key), Ok(true)));
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Fixture {
+        comment: String,
+        message_base64: String,
+        public_key_did: String,
+        signature_base64: String,
+        valid_signature: bool,
+        tags: Vec<String>,
+    }
+
+    /// Fixtures mix the base64 and base64url alphabets; multibase `m` is unpadded base64.
+    fn b64(input: &str) -> Vec<u8> {
+        let normalized = format!("m{}", input.replace('-', "+").replace('_', "/"));
+        multibase::decode(normalized).unwrap().1
+    }
+
+    fn did_key(did: &str) -> [u8; 35] {
+        multibase::decode(did.trim_start_matches("did:key:")).unwrap().1.try_into().unwrap()
+    }
+
+    #[test]
+    fn atproto_interop_signature_fixtures() {
+        let fixtures: Vec<Fixture> = serde_json::from_str(FIXTURES).unwrap();
+        assert_eq!(fixtures.len(), 6);
+
+        let mut valid = 0;
+        let mut high_s = 0;
+        let mut der = 0;
+        for fixture in &fixtures {
+            let msg = b64(&fixture.message_base64);
+            let sig = b64(&fixture.signature_base64);
+            let key = did_key(&fixture.public_key_did);
+            let got = verify_sig(&msg, &sig, &key);
+            assert_eq!(matches!(got, Ok(true)), fixture.valid_signature, "{}", fixture.comment);
+            if fixture.tags.iter().any(|tag| tag == "high-s") {
+                high_s += 1;
+                assert!(matches!(got, Ok(false)), "{}", fixture.comment);
+            } else if fixture.tags.iter().any(|tag| tag == "der-encoded") {
+                der += 1;
+                assert!(got.is_err(), "{}", fixture.comment);
+            } else {
+                valid += 1;
+                assert!(fixture.valid_signature, "{}", fixture.comment);
+            }
+        }
+        assert_eq!((valid, high_s, der), (2, 2, 2));
     }
 }

--- a/rsky-relay/tests/interop/signature-fixtures.json
+++ b/rsky-relay/tests/interop/signature-fixtures.json
@@ -1,0 +1,68 @@
+[
+  {
+    "comment": "valid P-256 key and signature, with low-S signature",
+    "messageBase64": "oWVoZWxsb2V3b3JsZA",
+    "algorithm": "ES256",
+    "didDocSuite": "EcdsaSecp256r1VerificationKey2019",
+    "publicKeyDid": "did:key:zDnaembgSGUhZULN2Caob4HLJPaxBh92N7rtH21TErzqf8HQo",
+    "publicKeyMultibase": "zxdM8dSstjrpZaRUwBmDvjGXweKuEMVN95A9oJBFjkWMh",
+    "signatureBase64": "2vZNsG3UKvvO/CDlrdvyZRISOFylinBh0Jupc6KcWoJWExHptCfduPleDbG3rko3YZnn9Lw0IjpixVmexJDegg",
+    "validSignature": true,
+    "tags": []
+  },
+  {
+    "comment": "valid K-256 key and signature, with low-S signature",
+    "messageBase64": "oWVoZWxsb2V3b3JsZA",
+    "algorithm": "ES256K",
+    "didDocSuite": "EcdsaSecp256k1VerificationKey2019",
+    "publicKeyDid": "did:key:zQ3shqwJEJyMBsBXCWyCBpUBMqxcon9oHB7mCvx4sSpMdLJwc",
+    "publicKeyMultibase": "z25z9DTpsiYYJKGsWmSPJK2NFN8PcJtZig12K59UgW7q5t",
+    "signatureBase64": "5WpdIuEUUfVUYaozsi8G0B3cWO09cgZbIIwg1t2YKdUn/FEznOndsz/qgiYb89zwxYCbB71f7yQK5Lr7NasfoA",
+    "validSignature": true,
+    "tags": []
+  },
+  {
+    "comment": "P-256 key and signature, with non-low-S signature which is invalid in atproto",
+    "messageBase64": "oWVoZWxsb2V3b3JsZA",
+    "algorithm": "ES256",
+    "didDocSuite": "EcdsaSecp256r1VerificationKey2019",
+    "publicKeyDid": "did:key:zDnaembgSGUhZULN2Caob4HLJPaxBh92N7rtH21TErzqf8HQo",
+    "publicKeyMultibase": "zxdM8dSstjrpZaRUwBmDvjGXweKuEMVN95A9oJBFjkWMh",
+    "signatureBase64": "2vZNsG3UKvvO/CDlrdvyZRISOFylinBh0Jupc6KcWoKp7O4VS9giSAah8k5IUbXIW00SuOrjfEqQ9HEkN9JGzw",
+    "validSignature": false,
+    "tags": ["high-s"]
+  },
+  {
+    "comment": "K-256 key and signature, with non-low-S signature which is invalid in atproto",
+    "messageBase64": "oWVoZWxsb2V3b3JsZA",
+    "algorithm": "ES256K",
+    "didDocSuite": "EcdsaSecp256k1VerificationKey2019",
+    "publicKeyDid": "did:key:zQ3shqwJEJyMBsBXCWyCBpUBMqxcon9oHB7mCvx4sSpMdLJwc",
+    "publicKeyMultibase": "z25z9DTpsiYYJKGsWmSPJK2NFN8PcJtZig12K59UgW7q5t",
+    "signatureBase64": "5WpdIuEUUfVUYaozsi8G0B3cWO09cgZbIIwg1t2YKdXYA67MYxYiTMAVfdnkDCMN9S5B3vHosRe07aORmoshoQ",
+    "validSignature": false,
+    "tags": ["high-s"]
+  },
+  {
+    "comment": "P-256 key and signature, with DER-encoded signature which is invalid in atproto",
+    "messageBase64": "oWVoZWxsb2V3b3JsZA",
+    "algorithm": "ES256",
+    "didDocSuite": "EcdsaSecp256r1VerificationKey2019",
+    "publicKeyDid": "did:key:zDnaeT6hL2RnTdUhAPLij1QBkhYZnmuKyM7puQLW1tkF4Zkt8",
+    "publicKeyMultibase": "ze8N2PPxnu19hmBQ58t5P3E9Yj6CqakJmTVCaKvf9Byq2",
+    "signatureBase64": "MEQCIFxYelWJ9lNcAVt+jK0y/T+DC/X4ohFZ+m8f9SEItkY1AiACX7eXz5sgtaRrz/SdPR8kprnbHMQVde0T2R8yOTBweA",
+    "validSignature": false,
+    "tags": ["der-encoded"]
+  },
+  {
+    "comment": "K-256 key and signature, with DER-encoded signature which is invalid in atproto",
+    "messageBase64": "oWVoZWxsb2V3b3JsZA",
+    "algorithm": "ES256K",
+    "didDocSuite": "EcdsaSecp256k1VerificationKey2019",
+    "publicKeyDid": "did:key:zQ3shnriYMXc8wvkbJqfNWh5GXn2bVAeqTC92YuNbek4npqGF",
+    "publicKeyMultibase": "z22uZXWP8fdHXi4jyx8cCDiBf9qQTsAe6VcycoMQPfcMQX",
+    "signatureBase64": "MEUCIQCWumUqJqOCqInXF7AzhIRg2MhwRz2rWZcOEsOjPmNItgIgXJH7RnqfYY6M0eg33wU0sFYDlprwdOcpRn78Sz5ePgk",
+    "validSignature": false,
+    "tags": ["der-encoded"]
+  }
+]


### PR DESCRIPTION
## Summary

The relay validator verified commit and label signatures without a low-S check, so a malleable high-S signature over the same message was accepted. atproto requires low-S. Both curve paths are folded into one helper that rejects when `normalize_s` reports the signature was not already low-S.

Also vendors the atproto interop signature vectors and runs them against the validator, and serializes three tests that flip the process-global `SHUTDOWN` flag while others depend on it being clear.

## Test plan

- [ ] `cargo test -p rsky-relay` passes, repeatedly and under parallel load
- [ ] The interop vectors all match their expected verdict
- [ ] `cargo build --release -p rsky-relay` succeeds