### PR TITLE
fix(repo): emit the covering proof in commit blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8497,7 +8497,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-repo"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rsky-identity = {path = "rsky-identity", version = "0.2.0"}
 rsky-crypto = {path = "rsky-crypto", version = "0.2.1"}
 rsky-syntax = {path = "rsky-syntax", version = "0.1.1"}
 rsky-common = {path = "rsky-common", version = "0.1.3"}
-rsky-repo = {path = "rsky-repo", version = "0.0.7"}
+rsky-repo = {path = "rsky-repo", version = "0.0.8"}
 rsky-firehose = {path = "rsky-firehose", version = "0.2.1"}
 
 [profile.release]

--- a/rsky-repo/Cargo.toml
+++ b/rsky-repo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-repo"
-version = "0.0.7"
+version = "0.0.8"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust crate for atproto repositories, an in particular the Merkle Search Tree (MST) data structure."
 license = "Apache-2.0"

--- a/rsky-repo/src/mst/mod.rs
+++ b/rsky-repo/src/mst/mod.rs
@@ -1448,21 +1448,68 @@ impl MST {
         Ok(cids)
     }
 
+    /// A covering proof is all MST nodes (leaves excluded) needed to prove the value of a given leaf
+    /// and its siblings to its immediate right and left (if applicable)
+    pub async fn get_covering_proof(&mut self, key: &str) -> Result<BlockMap> {
+        let mut blocks = self.proof_for_key(key).await?;
+        blocks.add_map(self.proof_for_left_sib(key).await?)?;
+        blocks.add_map(self.proof_for_right_sib(key).await?)?;
+        Ok(blocks)
+    }
+
     #[async_recursion(Sync)]
-    pub async fn add_blocks_for_path(&mut self, key: String, blocks: &mut BlockMap) -> Result<()> {
+    pub async fn proof_for_key(&mut self, key: &str) -> Result<BlockMap> {
+        let index = self.find_gt_or_equal_leaf_index(key).await?;
+        let found = self.at_index(index).await?;
+        let mut blocks = match found {
+            Some(NodeEntry::Leaf(ref leaf)) if leaf.key == key => BlockMap::new(),
+            _ => match self.at_index(index - 1).await? {
+                Some(NodeEntry::MST(mut prev)) => prev.proof_for_key(key).await?,
+                _ => return Ok(BlockMap::new()),
+            },
+        };
         let serialized = self.serialize().await?;
         blocks.set(serialized.cid, serialized.bytes);
-        let index = self.find_gt_or_equal_leaf_index(&key).await?;
-        let found = self.at_index(index).await?;
-        if let Some(NodeEntry::Leaf(found)) = found {
-            if found.key == key {
-                return Ok(());
+        Ok(blocks)
+    }
+
+    #[async_recursion(Sync)]
+    pub async fn proof_for_left_sib(&mut self, key: &str) -> Result<BlockMap> {
+        let index = self.find_gt_or_equal_leaf_index(key).await?;
+        let mut blocks = match self.at_index(index - 1).await? {
+            Some(NodeEntry::MST(mut prev)) => prev.proof_for_left_sib(key).await?,
+            _ => BlockMap::new(),
+        };
+        let serialized = self.serialize().await?;
+        blocks.set(serialized.cid, serialized.bytes);
+        Ok(blocks)
+    }
+
+    #[async_recursion(Sync)]
+    pub async fn proof_for_right_sib(&mut self, key: &str) -> Result<BlockMap> {
+        let index = self.find_gt_or_equal_leaf_index(key).await?;
+        let mut found = self.at_index(index).await?;
+        if found.is_none() {
+            found = self.at_index(index - 1).await?;
+        }
+        let mut blocks = match found {
+            None => BlockMap::new(),
+            Some(NodeEntry::MST(mut subtree)) => subtree.proof_for_right_sib(key).await?,
+            Some(NodeEntry::Leaf(leaf)) => {
+                let sib = if leaf.key == key {
+                    self.at_index(index + 1).await?
+                } else {
+                    self.at_index(index - 1).await?
+                };
+                match sib {
+                    Some(NodeEntry::MST(mut sib)) => sib.proof_for_right_sib(key).await?,
+                    _ => BlockMap::new(),
+                }
             }
-        }
-        match self.at_index(index - 1).await? {
-            Some(NodeEntry::MST(mut prev)) => prev.add_blocks_for_path(key, blocks).await,
-            _ => Ok(()),
-        }
+        };
+        let serialized = self.serialize().await?;
+        blocks.set(serialized.cid, serialized.bytes);
+        Ok(blocks)
     }
 
     pub async fn save_mst(&self) -> Result<Cid> {

--- a/rsky-repo/src/repo.rs
+++ b/rsky-repo/src/repo.rs
@@ -253,11 +253,10 @@ impl Repo {
 
         let mut relevant_blocks = BlockMap::new();
         for op in writes {
-            data.add_blocks_for_path(
-                util::format_data_key(op.collection(), op.rkey()),
-                &mut relevant_blocks,
-            )
-            .await?;
+            let proof = data
+                .get_covering_proof(&util::format_data_key(op.collection(), op.rkey()))
+                .await?;
+            relevant_blocks.add_map(proof)?;
         }
 
         let added_leaves = leaves.get_many(diff.new_leaf_cids.to_list())?;
@@ -885,6 +884,13 @@ mod tests {
         }
 
         for rkey in keys {
+            let data_key = util::format_data_key(collection.to_string(), rkey.clone());
+            let prev_data = repo.data.get_pointer().await?;
+            let deleted_cid = repo
+                .data
+                .get(&data_key)
+                .await?
+                .expect("record to delete is present");
             let commit = repo
                 .format_commit(
                     RecordWriteEnum::Single(RecordWriteOp::Delete(RecordDeleteOp {
@@ -895,6 +901,7 @@ mod tests {
                     &keypair,
                 )
                 .await?;
+            let relevant_blocks = commit.relevant_blocks.clone();
             let car = blocks_to_car_file(Some(&commit.cid), commit.relevant_blocks.clone()).await?;
             let did_key = encode_did_key(&keypair.public_key());
             let proof_res = verify_proofs(
@@ -910,6 +917,15 @@ mod tests {
             .await?;
             assert_eq!(proof_res.unverified.len(), 0);
             repo = repo.apply_commit(commit).await?;
+
+            // The covering proof must let a consumer invert the delete holding no other blocks.
+            let new_data = repo.data.get_pointer().await?;
+            let proof_store = Arc::new(RwLock::new(
+                MemoryBlockstore::new(Some(relevant_blocks)).await?,
+            ));
+            let mut inverted = MST::load(proof_store, new_data, None)?;
+            inverted = inverted.add(&data_key, deleted_cid, None).await?;
+            assert_eq!(inverted.get_pointer().await?, prev_data);
         }
         Ok(())
     }

--- a/rsky-repo/tests/mst_interop.rs
+++ b/rsky-repo/tests/mst_interop.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
 use lexicon_cid::Cid;
+use rsky_repo::block_map::BlockMap;
 use rsky_repo::mst::util::{count_prefix_len, leading_zeros_on_hash};
 use rsky_repo::mst::MST;
 use rsky_repo::storage::memory_blockstore::MemoryBlockstore;
 use rsky_repo::storage::readable_blockstore::ReadableBlockstore;
 use serde::Deserialize;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -125,6 +127,112 @@ async fn run_commit_proof_case(case: &CommitProofCase) -> Result<()> {
         .iter()
         .map(|cid| Cid::try_from(cid.as_str()))
         .collect::<Result<Vec<Cid>, _>>()?;
+
+    // The commit's `blocks` are the union of the covering proof taken per write, on the post-write tree.
+    let mut covering_proof = BlockMap::new();
+    for key in case.adds.iter().chain(case.dels.iter()) {
+        covering_proof.add_map(tree.get_covering_proof(key).await?)?;
+    }
+    let produced: BTreeSet<String> = covering_proof
+        .cids()?
+        .into_iter()
+        .map(|cid| cid.to_string())
+        .collect();
+    let expected: BTreeSet<String> = case.blocks_in_proof.iter().cloned().collect();
+    // Per-walk assertions. The union above cannot attribute a block to the walk that should
+    // have produced it, so a bug swapping the sibling walks would pass. These constrain each
+    // walk on its own.
+    let mut by_walk = Vec::new();
+    for name in ["key", "left", "right"] {
+        let mut acc = BlockMap::new();
+        for key in case.adds.iter().chain(case.dels.iter()) {
+            let one = match name {
+                "key" => tree.proof_for_key(key).await?,
+                "left" => tree.proof_for_left_sib(key).await?,
+                _ => tree.proof_for_right_sib(key).await?,
+            };
+            acc.add_map(one)?;
+        }
+        let s: BTreeSet<String> = acc.cids()?.into_iter().map(|c| c.to_string()).collect();
+        assert!(
+            s.is_subset(&expected),
+            "{name} walk produced a block outside blocksInProof [{}]: {:?}",
+            case.comment,
+            s.difference(&expected).collect::<Vec<_>>()
+        );
+        by_walk.push(s);
+    }
+    let (from_key, from_left, from_right) = (&by_walk[0], &by_walk[1], &by_walk[2]);
+
+    // Both sibling walks add their own node at every level, so each always reaches the root.
+    let root_str = root_after.to_string();
+    assert!(
+        from_left.contains(&root_str) && from_right.contains(&root_str),
+        "a sibling walk did not reach the root [{}]",
+        case.comment
+    );
+
+    // Neither sibling walk may be dropped: each fixture below records whether omitting one
+    // still yields blocksInProof. Ablation measured against the upstream vectors.
+    let key_left: BTreeSet<String> = from_key.union(from_left).cloned().collect();
+    let key_right: BTreeSet<String> = from_key.union(from_right).cloned().collect();
+    let (left_removable, right_removable) = match case.comment.as_str() {
+        "add on edge with neighbor two layers down" => (false, true),
+        "merge and split in multi-op commit" => (true, true),
+        _ => (false, false),
+    };
+    assert_eq!(
+        key_right == expected,
+        left_removable,
+        "dropping the left-sibling walk changed the proof unexpectedly [{}]",
+        case.comment
+    );
+    assert_eq!(
+        key_left == expected,
+        right_removable,
+        "dropping the right-sibling walk changed the proof unexpectedly [{}]",
+        case.comment
+    );
+
+    // A walk that cannot be dropped must contribute a block the other two lack. Without this,
+    // a left walk that had been made a duplicate of the right one still satisfies the ablation
+    // above, because that check is symmetric in the two siblings.
+    if !left_removable {
+        assert!(
+            !from_left.is_subset(&key_right),
+            "left-sibling walk contributed nothing the other walks lacked [{}]",
+            case.comment
+        );
+    }
+    if !right_removable {
+        assert!(
+            !from_right.is_subset(&key_left),
+            "right-sibling walk contributed nothing the other walks lacked [{}]",
+            case.comment
+        );
+    }
+
+    // The one fixture whose neighbour sits strictly to the left: the left walk must descend to
+    // it while the right walk finds nothing beyond the spine. A swap of the two fails here.
+    if case.comment == "add on edge with neighbor two layers down" {
+        assert!(
+            from_right.len() < from_left.len() && from_right.is_subset(from_left),
+            "left walk did not out-reach the right walk on a left-hand neighbour [{}]",
+            case.comment
+        );
+    }
+
+    assert_eq!(
+        produced, expected,
+        "covering proof set equality [{}]",
+        case.comment
+    );
+    assert_eq!(
+        produced.len(),
+        case.blocks_in_proof.len(),
+        "covering proof block count [{}]",
+        case.comment
+    );
     let proof_blocks = {
         let storage_guard = storage.read().await;
         storage_guard.get_blocks(proof_cids.clone()).await?


### PR DESCRIPTION
## Summary

Stacked on #262 — merge that first; this targets it so the diff stays reviewable.

A firehose `#commit` must carry enough MST nodes for a consumer to invert the operation and recover the previous root without holding a copy of the repo. `format_commit` built that set from a path-only walk with no sibling coverage, so the emitted `blocks` could be under-inclusive and the commit not invertible.

Adds `proof_for_key`, `proof_for_left_sib`, `proof_for_right_sib` and `get_covering_proof`, ported from the reference implementation, and uses the covering proof when formatting a commit. Tree mutation is untouched.

## Test plan

- [ ] Every commit-proof vector matches `blocksInProof` by exact set equality
- [ ] All root CIDs in the vectors are unchanged
- [ ] `cargo test -p rsky-repo` passes
- [ ] Reverting `format_commit` to the previous walk fails the proof assertion
- [ ] `cargo check -p rsky-pds -p rsky-wintermute` succeeds