### PR TITLE
perf(repo): stop cloning MST entries and encoding node data twice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,7 +1163,7 @@ dependencies = [
  "bitflags 2.9.2",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -1395,6 +1401,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbor4ii"
@@ -1974,6 +1986,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -5067,6 +5117,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -6449,6 +6508,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl"
 version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7033,6 +7098,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7318,7 +7411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -7593,7 +7686,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.12.1",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -8497,26 +8590,26 @@ dependencies = [
 
 [[package]]
 name = "rsky-repo"
-version = "0.0.8"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-recursion",
  "async-stream",
  "async-trait",
  "cid",
+ "criterion",
  "futures",
  "integer-encoding",
  "ipld-core",
  "iroh-car",
- "lazy_static",
  "p256 0.13.2",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "regex",
  "rsky-common",
  "rsky-crypto",
  "rsky-lexicon",
  "rsky-syntax",
+ "rusqlite",
  "secp256k1",
  "serde",
  "serde_bytes",
@@ -8525,6 +8618,7 @@ dependencies = [
  "serde_ipld_dagcbor",
  "serde_json",
  "sha2 0.10.9",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -10073,6 +10167,16 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rsky-identity = {path = "rsky-identity", version = "0.2.0"}
 rsky-crypto = {path = "rsky-crypto", version = "0.2.1"}
 rsky-syntax = {path = "rsky-syntax", version = "0.1.1"}
 rsky-common = {path = "rsky-common", version = "0.1.3"}
-rsky-repo = {path = "rsky-repo", version = "0.0.8"}
+rsky-repo = {path = "rsky-repo", version = "0.1.0"}
 rsky-firehose = {path = "rsky-firehose", version = "0.2.1"}
 
 [profile.release]

--- a/rsky-pds/Dockerfile
+++ b/rsky-pds/Dockerfile
@@ -34,6 +34,9 @@ COPY rsky-identity/src rsky-identity/src
 COPY rsky-lexicon/src rsky-lexicon/src
 COPY rsky-oauth/src rsky-oauth/src
 COPY rsky-repo/src rsky-repo/src
+# rsky-repo declares a [[bench]] target; cargo refuses to parse the manifest
+# unless the bench source is present, even though this build never builds it.
+COPY rsky-repo/benches rsky-repo/benches
 COPY rsky-syntax/src rsky-syntax/src
 
 # Stub out binary workspace members so cargo can resolve the workspace

--- a/rsky-repo/Cargo.toml
+++ b/rsky-repo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-repo"
-version = "0.0.8"
+version = "0.1.0"
 authors = ["Rudy Fraser <him@rudyfraser.com>"]
 description = "Rust crate for atproto repositories, an in particular the Merkle Search Tree (MST) data structure."
 license = "Apache-2.0"
@@ -37,8 +37,13 @@ secp256k1 = {workspace = true}
 ipld-core = {workspace = true}
 iroh-car = "0.5.1"
 
-regex = "1.10.3"
-lazy_static = "1.4.0"
-
 [dev-dependencies]
 p256 = { version = "0.13.2", features = ["ecdsa", "arithmetic", "alloc"] }
+criterion = { version = "0.5", features = ["async_tokio"] }
+rusqlite = { workspace = true }
+tempfile = "3.10"
+
+[[bench]]
+name = "mst_perf"
+harness = false
+test = false

--- a/rsky-repo/benches/mst_perf.rs
+++ b/rsky-repo/benches/mst_perf.rs
@@ -1,0 +1,520 @@
+//! MST performance benchmarks over both an in-memory blockstore and a real
+//! on-disk SQLite blockstore modelled on `rsky_pds::actor_store::repo::SqlRepoReader`.
+//!
+//! Run with: `cargo bench -p rsky-repo`
+//! Restrict with: `cargo bench -p rsky-repo -- covering_proof`
+
+use anyhow::Result;
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use lexicon_cid::Cid;
+use rsky_common::ipld::cid_for_cbor;
+use rsky_repo::block_map::{BlockMap, BlocksAndMissing};
+use rsky_repo::cid_set::CidSet;
+use rsky_repo::mst::MST;
+use rsky_repo::storage::memory_blockstore::MemoryBlockstore;
+use rsky_repo::storage::readable_blockstore::ReadableBlockstore;
+use rsky_repo::storage::types::RepoStorage;
+use rsky_repo::types::CommitData;
+use rusqlite::{Connection, OptionalExtension};
+use serde_json::json;
+use std::future::Future;
+use std::pin::Pin;
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+use tokio::runtime::Runtime;
+use tokio::sync::RwLock;
+
+const SIZES: [usize; 3] = [1_000, 10_000, 50_000];
+const BATCH_OPS: usize = 200;
+
+// ---------------------------------------------------------------------------
+// SQLite blockstore
+// ---------------------------------------------------------------------------
+
+/// Minimal `RepoStorage` over a real SQLite file. Schema, pragmas, per-instance
+/// block cache and chunked `IN (...)` reads mirror the PDS `SqlRepoReader` so the
+/// numbers are representative of a live actor store.
+#[derive(Clone, Debug)]
+pub struct SqliteBlockstore {
+    cache: Arc<RwLock<BlockMap>>,
+    conn: Arc<Mutex<Connection>>,
+    root: Arc<RwLock<Option<Cid>>>,
+}
+
+fn placeholders(len: usize) -> String {
+    vec!["?"; len].join(",")
+}
+
+impl SqliteBlockstore {
+    pub fn open(path: &std::path::Path) -> Result<Self> {
+        let conn = Connection::open(path)?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS repo_block (\
+                cid TEXT PRIMARY KEY, \
+                \"repoRev\" TEXT NOT NULL, \
+                size INTEGER NOT NULL, \
+                content BLOB NOT NULL\
+            );\
+            CREATE INDEX IF NOT EXISTS repo_block_repo_rev_idx ON repo_block (\"repoRev\", cid);",
+        )?;
+        Ok(Self {
+            cache: Arc::new(RwLock::new(BlockMap::new())),
+            conn: Arc::new(Mutex::new(conn)),
+            root: Arc::new(RwLock::new(None)),
+        })
+    }
+
+    /// A handle onto the same file with an empty block cache, i.e. what a PDS
+    /// builds per request.
+    pub fn fresh(&self) -> Self {
+        Self {
+            cache: Arc::new(RwLock::new(BlockMap::new())),
+            conn: self.conn.clone(),
+            root: self.root.clone(),
+        }
+    }
+
+    async fn run<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&Connection) -> Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.lock().expect("sqlite mutex poisoned");
+            f(&conn)
+        })
+        .await?
+    }
+}
+
+impl ReadableBlockstore for SqliteBlockstore {
+    fn get_bytes<'a>(
+        &'a self,
+        cid: &'a Cid,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<Vec<u8>>>> + Send + Sync + 'a>> {
+        let cid = *cid;
+        Box::pin(async move {
+            let cached = {
+                let guard = self.cache.read().await;
+                guard.get(cid).cloned()
+            };
+            if let Some(hit) = cached {
+                return Ok(Some(hit));
+            }
+            let found: Option<Vec<u8>> = self
+                .run(move |conn| {
+                    Ok(conn
+                        .query_row(
+                            "SELECT content FROM repo_block WHERE cid = ?1",
+                            [cid.to_string()],
+                            |row| row.get(0),
+                        )
+                        .optional()?)
+                })
+                .await?;
+            if let Some(ref bytes) = found {
+                let mut guard = self.cache.write().await;
+                guard.set(cid, bytes.clone());
+            }
+            Ok(found)
+        })
+    }
+
+    fn has<'a>(
+        &'a self,
+        cid: Cid,
+    ) -> Pin<Box<dyn Future<Output = Result<bool>> + Send + Sync + 'a>> {
+        Box::pin(async move { Ok(self.get_bytes(&cid).await?.is_some()) })
+    }
+
+    fn get_blocks<'a>(
+        &'a self,
+        cids: Vec<Cid>,
+    ) -> Pin<Box<dyn Future<Output = Result<BlocksAndMissing>> + Send + Sync + 'a>> {
+        Box::pin(async move {
+            let cached = {
+                let mut guard = self.cache.write().await;
+                guard.get_many(cids)?
+            };
+            if cached.missing.is_empty() {
+                return Ok(cached);
+            }
+            let missing_strings: Vec<String> =
+                cached.missing.iter().map(|c| c.to_string()).collect();
+            let mut missing = CidSet::new(Some(cached.missing));
+            let rows: Vec<(String, Vec<u8>)> = self
+                .run(move |conn| {
+                    let mut rows = Vec::new();
+                    for batch in missing_strings.chunks(500) {
+                        let sql = format!(
+                            "SELECT cid, content FROM repo_block WHERE cid IN ({})",
+                            placeholders(batch.len())
+                        );
+                        let mut stmt = conn.prepare(&sql)?;
+                        let batch_rows = stmt
+                            .query_map(rusqlite::params_from_iter(batch.iter()), |row| {
+                                Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?))
+                            })?
+                            .collect::<Result<Vec<_>, rusqlite::Error>>()?;
+                        rows.extend(batch_rows);
+                    }
+                    Ok(rows)
+                })
+                .await?;
+            let mut blocks = BlockMap::new();
+            for (cid_str, content) in rows {
+                let cid = Cid::from_str(&cid_str)?;
+                blocks.set(cid, content);
+                missing.delete(cid);
+            }
+            {
+                let mut guard = self.cache.write().await;
+                guard.add_map(blocks.clone())?;
+            }
+            blocks.add_map(cached.blocks)?;
+            Ok(BlocksAndMissing {
+                blocks,
+                missing: missing.to_list(),
+            })
+        })
+    }
+}
+
+impl RepoStorage for SqliteBlockstore {
+    fn get_root<'a>(&'a self) -> Pin<Box<dyn Future<Output = Option<Cid>> + Send + Sync + 'a>> {
+        Box::pin(async move { *self.root.read().await })
+    }
+
+    fn put_block<'a>(
+        &'a self,
+        cid: Cid,
+        bytes: Vec<u8>,
+        rev: String,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + Sync + 'a>> {
+        Box::pin(async move {
+            let mut map = BlockMap::new();
+            map.set(cid, bytes);
+            self.put_many(map, rev).await
+        })
+    }
+
+    fn put_many<'a>(
+        &'a self,
+        to_put: BlockMap,
+        rev: String,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + Sync + 'a>> {
+        Box::pin(async move {
+            let entries: Vec<(String, usize, Vec<u8>)> = to_put
+                .entries()?
+                .into_iter()
+                .map(|e| (e.cid.to_string(), e.bytes.len(), e.bytes))
+                .collect();
+            self.run(move |conn| {
+                conn.execute_batch("BEGIN IMMEDIATE")?;
+                {
+                    let mut stmt = conn.prepare(
+                        "INSERT OR IGNORE INTO repo_block (cid, \"repoRev\", size, content) \
+                         VALUES (?1, ?2, ?3, ?4)",
+                    )?;
+                    for (cid, size, content) in entries {
+                        stmt.execute(rusqlite::params![cid, rev, size as i64, content])?;
+                    }
+                }
+                conn.execute_batch("COMMIT")?;
+                Ok(())
+            })
+            .await
+        })
+    }
+
+    fn update_root<'a>(
+        &'a self,
+        cid: Cid,
+        _rev: String,
+        _is_create: Option<bool>,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + Sync + 'a>> {
+        Box::pin(async move {
+            *self.root.write().await = Some(cid);
+            Ok(())
+        })
+    }
+
+    fn apply_commit<'a>(
+        &'a self,
+        commit: CommitData,
+        _is_create: Option<bool>,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + Sync + 'a>> {
+        Box::pin(async move {
+            let rev = commit.rev.clone();
+            self.put_many(commit.new_blocks, rev).await?;
+            *self.root.write().await = Some(commit.cid);
+            Ok(())
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Backend {
+    Memory,
+    Sqlite,
+}
+
+impl Backend {
+    fn name(self) -> &'static str {
+        match self {
+            Backend::Memory => "memory",
+            Backend::Sqlite => "sqlite",
+        }
+    }
+}
+
+fn record_key(i: usize) -> String {
+    format!("app.bsky.feed.post/{:0>13}", i)
+}
+
+fn record_value(i: usize) -> Cid {
+    cid_for_cbor(&json!({"$type": "app.bsky.feed.post", "text": format!("post {i}")})).unwrap()
+}
+
+struct Fixture {
+    backend: Backend,
+    size: usize,
+    memory: Option<MemoryBlockstore>,
+    sqlite: Option<SqliteBlockstore>,
+    _dir: Option<tempfile::TempDir>,
+    root: Cid,
+}
+
+impl Fixture {
+    /// A storage handle with a cold per-request cache, as a PDS builds per write.
+    fn storage(&self) -> Arc<RwLock<dyn RepoStorage>> {
+        match self.backend {
+            Backend::Memory => Arc::new(RwLock::new(self.memory.clone().unwrap())),
+            Backend::Sqlite => Arc::new(RwLock::new(self.sqlite.as_ref().unwrap().fresh())),
+        }
+    }
+
+    /// A virtual (unhydrated) tree rooted at the fixture root.
+    fn cold_tree(&self) -> MST {
+        MST::load(self.storage(), self.root, None).unwrap()
+    }
+
+    async fn warm_tree(&self) -> MST {
+        let mut mst = self.cold_tree();
+        // Touch every node once so entries are cached, isolating in-memory cost.
+        let _ = mst.get_covering_proof(&record_key(self.size / 2)).await;
+        let _ = mst.get_covering_proof(&record_key(0)).await;
+        let _ = mst.get_covering_proof(&record_key(self.size - 1)).await;
+        mst
+    }
+
+    fn probe_key(&self) -> String {
+        record_key(self.size / 2)
+    }
+
+    fn new_key(&self, n: usize) -> String {
+        record_key(self.size + 1 + n)
+    }
+}
+
+async fn build_fixture(backend: Backend, size: usize) -> Result<Fixture> {
+    let (memory, sqlite, dir) = match backend {
+        Backend::Memory => (Some(MemoryBlockstore::default()), None, None),
+        Backend::Sqlite => {
+            let dir = tempfile::tempdir()?;
+            let store = SqliteBlockstore::open(&dir.path().join("actor.sqlite"))?;
+            (None, Some(store), Some(dir))
+        }
+    };
+
+    let storage: Arc<RwLock<dyn RepoStorage>> = match backend {
+        Backend::Memory => Arc::new(RwLock::new(memory.clone().unwrap())),
+        Backend::Sqlite => Arc::new(RwLock::new(sqlite.clone().unwrap())),
+    };
+
+    // Persist the record blocks in one batch.
+    let mut leaves = BlockMap::new();
+    let mut pairs: Vec<(String, Cid)> = Vec::with_capacity(size);
+    for i in 0..size + BATCH_OPS + 8 {
+        let rec = json!({"$type": "app.bsky.feed.post", "text": format!("post {i}")});
+        let cid = cid_for_cbor(&rec)?;
+        leaves.set(cid, rsky_common::struct_to_cbor(&rec)?);
+        if i < size {
+            pairs.push((record_key(i), cid));
+        }
+    }
+    {
+        let guard = storage.read().await;
+        guard.put_many(leaves, "bench".to_string()).await?;
+    }
+
+    let mut mst = MST::create(storage.clone(), None, None).await?;
+    for (key, value) in &pairs {
+        mst = mst.add(key, *value, None).await?;
+    }
+    let root = mst.save_mst().await?;
+
+    Ok(Fixture {
+        backend,
+        size,
+        memory,
+        sqlite,
+        _dir: dir,
+        root,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+fn fixtures(rt: &Runtime) -> Vec<Fixture> {
+    let mut out = Vec::new();
+    for backend in [Backend::Memory, Backend::Sqlite] {
+        for size in SIZES {
+            out.push(rt.block_on(build_fixture(backend, size)).unwrap());
+        }
+    }
+    out
+}
+
+fn bench_all(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let fixtures = fixtures(&rt);
+
+    // get_covering_proof against a hydrated tree: pure in-process cost.
+    {
+        let mut group = c.benchmark_group("covering_proof_warm");
+        for f in &fixtures {
+            let tree = rt.block_on(f.warm_tree());
+            let key = f.probe_key();
+            group.bench_with_input(
+                BenchmarkId::new(f.backend.name(), f.size),
+                &f.size,
+                |b, _| {
+                    b.iter(|| {
+                        rt.block_on(async {
+                            let mut tree = tree.clone();
+                            tree.get_covering_proof(&key).await.unwrap()
+                        })
+                    })
+                },
+            );
+        }
+        group.finish();
+    }
+
+    // get_covering_proof from a cold repo load: what a single PDS write pays.
+    {
+        let mut group = c.benchmark_group("covering_proof_cold");
+        group.sample_size(40);
+        for f in &fixtures {
+            let key = f.probe_key();
+            group.bench_with_input(
+                BenchmarkId::new(f.backend.name(), f.size),
+                &f.size,
+                |b, _| {
+                    b.iter_batched(
+                        || f.cold_tree(),
+                        |mut tree| {
+                            rt.block_on(async { tree.get_covering_proof(&key).await.unwrap() })
+                        },
+                        BatchSize::SmallInput,
+                    )
+                },
+            );
+        }
+        group.finish();
+    }
+
+    {
+        let mut group = c.benchmark_group("add");
+        for f in &fixtures {
+            let tree = rt.block_on(f.warm_tree());
+            let key = f.new_key(0);
+            let value = record_value(f.size + 1);
+            group.bench_with_input(
+                BenchmarkId::new(f.backend.name(), f.size),
+                &f.size,
+                |b, _| {
+                    b.iter(|| {
+                        rt.block_on(async {
+                            let mut tree = tree.clone();
+                            tree.add(&key, value, None).await.unwrap()
+                        })
+                    })
+                },
+            );
+        }
+        group.finish();
+    }
+
+    {
+        let mut group = c.benchmark_group("delete");
+        for f in &fixtures {
+            let tree = rt.block_on(f.warm_tree());
+            let key = f.probe_key();
+            group.bench_with_input(
+                BenchmarkId::new(f.backend.name(), f.size),
+                &f.size,
+                |b, _| {
+                    b.iter(|| {
+                        rt.block_on(async {
+                            let mut tree = tree.clone();
+                            tree.delete(&key).await.unwrap()
+                        })
+                    })
+                },
+            );
+        }
+        group.finish();
+    }
+
+    // applyWrites shape: N creates applied to the tree, then one covering proof
+    // per write against the final tree (see Repo::format_commit).
+    {
+        let mut group = c.benchmark_group("apply_writes_200");
+        group.sample_size(10);
+        for f in &fixtures {
+            let keys: Vec<String> = (0..BATCH_OPS).map(|n| f.new_key(n)).collect();
+            let values: Vec<Cid> = (0..BATCH_OPS)
+                .map(|n| record_value(f.size + 1 + n))
+                .collect();
+            group.bench_with_input(
+                BenchmarkId::new(f.backend.name(), f.size),
+                &f.size,
+                |b, _| {
+                    b.iter_batched(
+                        || f.cold_tree(),
+                        |mut tree| {
+                            rt.block_on(async {
+                                for (key, value) in keys.iter().zip(values.iter()) {
+                                    tree = tree.add(key, *value, None).await.unwrap();
+                                }
+                                let mut proof = BlockMap::new();
+                                for key in keys.iter() {
+                                    proof
+                                        .add_map(tree.get_covering_proof(key).await.unwrap())
+                                        .unwrap();
+                                }
+                                proof
+                            })
+                        },
+                        BatchSize::SmallInput,
+                    )
+                },
+            );
+        }
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_all);
+criterion_main!(benches);

--- a/rsky-repo/src/mst/mod.rs
+++ b/rsky-repo/src/mst/mod.rs
@@ -91,7 +91,11 @@ impl NodeIter {
                 let entries = match &mut mst_entry {
                     NodeEntry::MST(subtree) => {
                         // Asynchronously fetch child entries
-                        subtree.get_entries().await.unwrap_or_default()
+                        subtree
+                            .get_entries()
+                            .await
+                            .map(|e| e.to_vec())
+                            .unwrap_or_default()
                     }
                     _ => vec![],
                 };
@@ -435,7 +439,7 @@ pub struct UnstoredBlocks {
 /// MerkleSearchTree values are immutable. Methods return copies with changes.
 #[derive(Clone)]
 pub struct MST {
-    pub entries: Arc<RwLock<Option<Vec<NodeEntry>>>>,
+    pub entries: Arc<RwLock<Option<Arc<Vec<NodeEntry>>>>>,
     pub layer: Option<u32>,
     pub pointer: Arc<RwLock<Cid>>,
     pub outdated_pointer: Arc<RwLock<bool>>,
@@ -522,7 +526,7 @@ impl MST {
     ) -> Self {
         Self {
             storage,
-            entries: Arc::new(RwLock::new(entries)),
+            entries: Arc::new(RwLock::new(entries.map(Arc::new))),
             layer,
             pointer: Arc::new(RwLock::new(pointer)),
             outdated_pointer: Arc::new(RwLock::new(false)),
@@ -577,7 +581,10 @@ impl MST {
     // === "Getters (lazy load)" ===
 
     /// "We don't want to load entries of every subtree, just the ones we need"
-    pub async fn get_entries(&self) -> Result<Vec<NodeEntry>> {
+    ///
+    /// The cached vector is handed back behind an `Arc` so repeated reads are a
+    /// refcount bump rather than a deep copy of every leaf key and CID.
+    pub async fn get_entries(&self) -> Result<Arc<Vec<NodeEntry>>> {
         // If `self.entries` is not populated, hydrate it first\
         {
             let mut entries = self.entries.write().await;
@@ -603,11 +610,11 @@ impl MST {
                 };
 
                 // Deserialize into self.entries
-                *entries = Some(util::deserialize_node_data(
+                *entries = Some(Arc::new(util::deserialize_node_data(
                     self.storage.clone(),
                     &data,
                     layer,
-                )?);
+                )?));
             }
         }
 
@@ -638,7 +645,7 @@ impl MST {
     pub async fn serialize(&self) -> Result<CidAndBytes> {
         let mut entries = self.get_entries().await?;
         let mut outdated: Vec<Self> = Vec::new();
-        for entry in &entries {
+        for entry in entries.iter() {
             if let NodeEntry::MST(ref mst) = entry {
                 let is_outdated = *mst.outdated_pointer.read().await;
                 if is_outdated {
@@ -654,9 +661,10 @@ impl MST {
             entries = self.get_entries().await?
         }
         let data = util::serialize_node_data(entries.as_slice()).await?;
+        let bytes = rsky_common::struct_to_cbor(&data)?;
         Ok(CidAndBytes {
-            cid: ipld::cid_for_cbor(&data)?,
-            bytes: rsky_common::struct_to_cbor(&data)?,
+            cid: util::cid_for_dag_cbor_bytes(&bytes)?,
+            bytes,
         })
     }
 
@@ -677,12 +685,12 @@ impl MST {
         if self.layer.is_some() {
             return Ok(self.layer);
         };
-        let mut entries = self.get_entries().await?;
+        let entries = self.get_entries().await?;
         let mut layer = util::layer_for_entries(entries.as_slice())?;
         if layer.is_none() {
-            for entry in entries.iter_mut() {
-                if let NodeEntry::MST(ref mut tree) = entry {
-                    let child_layer = tree.attempt_get_layer().await?;
+            for entry in entries.iter() {
+                if let NodeEntry::MST(tree) = entry {
+                    let child_layer = tree.clone().attempt_get_layer().await?;
                     if let Some(c) = child_layer {
                         layer = Some(c + 1);
                         break;
@@ -966,7 +974,7 @@ impl MST {
     pub async fn at_index(&mut self, index: isize) -> Result<Option<NodeEntry>> {
         let entries = self.get_entries().await?;
         if index >= 0 {
-            Ok(entries.into_iter().nth(index as usize))
+            Ok(entries.get(index as usize).cloned())
         } else {
             Ok(None)
         }
@@ -1030,7 +1038,7 @@ impl MST {
                 };
                 Ok(entries[..end].to_vec())
             }
-            (None, None) => Ok(entries),
+            (None, None) => Ok(entries.to_vec()),
         }
     }
 
@@ -1075,7 +1083,7 @@ impl MST {
     pub async fn trim_top(self) -> Result<Self> {
         let entries = self.get_entries().await?;
         return if entries.len() == 1 {
-            match entries.into_iter().nth(0) {
+            match entries.first() {
                 Some(NodeEntry::MST(n)) => Ok(n.clone().trim_top().await?),
                 _ => Ok(self),
             }
@@ -1964,12 +1972,7 @@ mod tests {
         // Helper macro to handle assertions
         macro_rules! assert_prefix_len {
             ($a:expr, $b:expr, $expected:expr) => {
-                assert_eq!(
-                    count_prefix_len($a.to_string(), $b.to_string())?,
-                    $expected,
-                    "{}",
-                    msg
-                );
+                assert_eq!(count_prefix_len($a, $b)?, $expected, "{}", msg);
             };
         }
 
@@ -2002,12 +2005,7 @@ mod tests {
         // Helper macro to handle assertions for count_prefix_len
         macro_rules! assert_prefix_len {
             ($a:expr, $b:expr, $expected:expr) => {
-                assert_eq!(
-                    count_prefix_len($a.to_string(), $b.to_string())?,
-                    $expected,
-                    "{}",
-                    msg
-                );
+                assert_eq!(count_prefix_len($a, $b)?, $expected, "{}", msg);
             };
         }
 
@@ -2090,6 +2088,28 @@ mod tests {
             assert!(result.is_ok(), "Key '{}' should be valid", key);
         }
 
+        Ok(())
+    }
+
+    /// `serialize` derives the CID from the bytes it already encoded; pin that
+    /// against the encode-twice form it replaced.
+    #[tokio::test]
+    async fn serialize_cid_matches_cbor_of_node_data() -> Result<()> {
+        let cid1 = Cid::try_from("bafyreie5cvv4h45feadgeuwhbcutmh6t2ceseocckahdoe6uat64zmz454")?;
+        let storage = MemoryBlockstore::default();
+        let mut mst = MST::create(Arc::new(RwLock::new(storage)), None, None).await?;
+        for i in 0..64 {
+            mst = mst
+                .add(&format!("com.example.record/{:0>13}", i), cid1, None)
+                .await?;
+        }
+
+        let serialized = mst.serialize().await?;
+        let entries = mst.get_entries().await?;
+        let data = serialize_node_data(entries.as_slice()).await?;
+
+        assert_eq!(serialized.cid, ipld::cid_for_cbor(&data)?);
+        assert_eq!(serialized.bytes, rsky_common::struct_to_cbor(&data)?);
         Ok(())
     }
 

--- a/rsky-repo/src/mst/util.rs
+++ b/rsky-repo/src/mst/util.rs
@@ -1,10 +1,9 @@
 use super::{Leaf, NodeData, NodeEntry, TreeEntry, MST};
 use crate::storage::types::RepoStorage;
 use anyhow::{anyhow, Result};
-use lazy_static::lazy_static;
+use lexicon_cid::multihash::Multihash;
 use lexicon_cid::Cid;
 use rand::{thread_rng, Rng};
-use regex::Regex;
 use rsky_common;
 use rsky_common::ipld::cid_for_cbor;
 use rsky_common::tid::Ticker;
@@ -15,11 +14,23 @@ use std::str;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+const DAG_CBOR_CODEC: u64 = 0x71;
+const SHA2_256_CODE: u64 = 0x12;
+
 fn is_valid_chars(input: &str) -> bool {
-    lazy_static! {
-        static ref RE: Regex = Regex::new(r"^[a-zA-Z0-9_\-:.]*$").unwrap();
-    }
-    RE.is_match(input)
+    input
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b':' | b'.'))
+}
+
+/// CID for an already-encoded DAG-CBOR block, so callers that need both the
+/// bytes and the CID encode once instead of twice.
+pub fn cid_for_dag_cbor_bytes(bytes: &[u8]) -> Result<Cid> {
+    let hash = Sha256::digest(bytes);
+    Ok(Cid::new_v1(
+        DAG_CBOR_CODEC,
+        Multihash::<64>::wrap(SHA2_256_CODE, hash.as_ref())?,
+    ))
 }
 
 // * Restricted to a subset of ASCII characters — the allowed characters are
@@ -27,19 +38,16 @@ fn is_valid_chars(input: &str) -> bool {
 // * Must have at least 1 and at most 512 characters
 // * The specific record key values . and .. are not allowed
 pub fn is_valid_repo_mst_path(key: &str) -> Result<bool> {
-    let split: Vec<&str> = key.split("/").collect();
+    let Some((collection, rkey)) = key.split_once('/') else {
+        return Ok(false);
+    };
 
-    if key.len() <= 256
-        && split.len() == 2
-        && !split[0].is_empty()
-        && !split[1].is_empty()
-        && is_valid_chars(split[0])
-        && is_valid_chars(split[1])
-    {
-        Ok(true)
-    } else {
-        Ok(false)
-    }
+    // `is_valid_chars` rejects '/', so a third segment fails here too.
+    Ok(key.len() <= 256
+        && !collection.is_empty()
+        && !rkey.is_empty()
+        && is_valid_chars(collection)
+        && is_valid_chars(rkey))
 }
 
 pub fn ensure_valid_mst_key(key: &str) -> Result<()> {
@@ -55,15 +63,8 @@ pub async fn cid_for_entries(entries: &[NodeEntry]) -> Result<Cid> {
     cid_for_cbor(&data)
 }
 
-pub fn count_prefix_len(a: String, b: String) -> Result<usize> {
-    let mut x = 0;
-    for i in 0..a.len() {
-        match (a.chars().nth(i), b.chars().nth(i)) {
-            (Some(a), Some(b)) if a == b => x += 1,
-            _ => break,
-        }
-    }
-    Ok(x)
+pub fn count_prefix_len(a: &str, b: &str) -> Result<usize> {
+    Ok(a.chars().zip(b.chars()).take_while(|(a, b)| a == b).count())
 }
 
 pub async fn serialize_node_data(entries: &[NodeEntry]) -> Result<NodeData> {
@@ -90,7 +91,7 @@ pub async fn serialize_node_data(entries: &[NodeEntry]) -> Result<NodeData> {
                 i += 1;
             };
             ensure_valid_mst_key(&l.key)?;
-            let prefix_len = count_prefix_len(last_key.to_owned(), l.key.to_owned())?;
+            let prefix_len = count_prefix_len(last_key, &l.key)?;
             data.e.push(TreeEntry {
                 p: u8::try_from(prefix_len)?,
                 k: l.key[prefix_len..].to_owned().into_bytes(),

--- a/rsky-repo/src/mst/walker.rs
+++ b/rsky-repo/src/mst/walker.rs
@@ -66,7 +66,7 @@ impl MstWalker {
                 if let Some(ref mut mst) = p.walking {
                     let entries = mst.get_entries().await?;
                     p.index += 1;
-                    let next = entries.into_iter().nth(p.index);
+                    let next = entries.get(p.index).cloned();
                     if let Some(next) = next {
                         p.curr = next.clone();
                     } else {

--- a/rsky-repo/tests/mst_interop.rs
+++ b/rsky-repo/tests/mst_interop.rs
@@ -47,7 +47,7 @@ fn mst_common_prefix_vectors() -> Result<()> {
 
     for case in &cases {
         assert_eq!(
-            count_prefix_len(case.left.clone(), case.right.clone())?,
+            count_prefix_len(&case.left, &case.right)?,
             case.len,
             "left={:?} right={:?}",
             case.left,


### PR DESCRIPTION
## Summary

Profiling the firehose commit-proof path found three avoidable costs in the MST, all on the write path:

- `serialize` encoded each node to DAG-CBOR **twice** — once inside `cid_for_cbor` to derive the CID, then again for the bytes.
- `count_prefix_len` was **quadratic**: it indexed with `chars().nth(i)` inside a loop over the key length, restarting the iterator each time, and took its arguments by value so every call site allocated two `String`s.
- `is_valid_repo_mst_path` allocated a `Vec` and ran a regex per key, per serialize.

Separately, `get_entries` returned an owned `Vec<NodeEntry>` — cloning every cached leaf key and CID on each call, including for single-element reads via `at_index`. The cache now holds an `Arc<Vec<NodeEntry>>` and hands out a refcount bump.

A covering proof serializes ~24 nodes (three walks over a tree of depth ~8), so these compound. `Repo::format_commit` calls `get_covering_proof` once per write op, so this is on the path of every post.

Encoding once is also what every other implementation already does — the reference TS (`packages/repo/src/mst/mst.ts`), indigo's Go MST, jacquard, and star-lite all hash the bytes they just encoded. `rsky-repo` was the outlier.

## Results

Medians, criterion, release build, 50k-record tree.

| | before | after |
|---|---|---|
| covering proof (warm) | 172 µs | 87 µs |
| covering proof (cold in-process cache) | 336 µs | 248 µs |
| `add` | 8.5 µs | 5.0 µs |
| `delete` | 10.5 µs | 5.5 µs |
| 200 adds + 200 covering proofs | 39.1 ms | 19.4 ms |

Reading the numbers honestly:

- **"Cold" means a cold in-process block cache, not a cold database.** `SqliteBlockstore::fresh()` resets the `BlockMap` but reuses the connection, so SQLite's page cache and the OS's stay warm. It models a busy actor store, not a first read after boot.
- **The last row is not a full `applyWrites`.** It covers the adds and the per-op covering proofs. It excludes `data.get_pointer()`, `DataDiff::of` (a full two-tree diff walk, plausibly the largest single cost at 200 ops), leaf CBOR encoding, `sign_commit`, and all persistence. The improvement is real for the MST portion; it is not a 50% cut to end-to-end `applyWrites`.
- **The `memory` vs `sqlite` split is only meaningful in the `cold` group.** `MST::clone()` is `Arc`-shallow, so the per-iteration clone in the warm, `add`, and `delete` groups shares hydration with the fixture and never touches storage. Those two columns run identical code; any spread is noise.
- Allocation counts from a local dhat run are not included here — that harness isn't committed, so the figure isn't reproducible from this tree. Structurally, `get_entries` goes from one `Vec` allocation plus a `String` clone per leaf, per call, to zero.

The benchmark harness is committed as `rsky-repo/benches/mst_perf.rs` and includes a SQLite-backed `RepoStorage` modelled on the PDS `SqlRepoReader` (same single connection behind a `Mutex` via `spawn_blocking`, same DDL, same 500-row chunked `IN (...)` reads).

## Notes

`get_entries` and `count_prefix_len` change signature and `MST::entries` changes type, so this is a breaking release for `rsky-repo`. Nothing outside `rsky-repo` references either symbol — `rsky-pds` and `rsky-wintermute` are the only dependents, neither imports the `mst` module, and both take `rsky-repo` via `{ workspace = true }`, so the root `Cargo.toml` bump covers them.

**On the version number:** under cargo, `^0.0.8` resolves as `>=0.0.8, <0.0.9`, so `0.0.9` and `0.1.0` are equally breaking to any consumer — the choice is signalling, not resolution. Prior `rsky-repo` bumps have stayed on patch even when breaking; going to `0.1.0` here is a deliberate departure to mark a public-API reshape. It does mean the next break goes to `0.2.0`.

`rsky-pds/Dockerfile` needed a one-line fix in its own commit: the builder stage copies `rsky-repo/Cargo.toml` and `rsky-repo/src` but not `benches/`, and a `[[bench]]` target makes cargo refuse to parse the manifest when the bench source is missing — so `cargo build --package rsky-pds` failed inside the image even though it never compiles the bench. `rsky-pds` is the only Dockerfile that copies `rsky-repo`.

## Test plan

- [x] `cargo test -p rsky-repo` passes, including the MST interop vectors
- [x] Commit-proof vectors still match `blocksInProof` by exact set equality, and all root CIDs are unchanged
- [x] A large tree built from identical input yields a byte-identical root CID before and after — verified on a 20k-key tree: root CIDs after add/update/delete, the covering-proof block sets for 39 probe keys (present, absent, first, last, past-the-end), and the root node's serialized bytes are all byte-identical to `main`
- [x] `cargo check -p rsky-pds -p rsky-wintermute` passes
- [x] `cargo bench -p rsky-repo` reproduces the figures above on both backends
- [x] The `rsky-pds` builder stage parses the workspace manifest — verified by replicating its `COPY` set and stub-crate `RUN` block in a scratch tree; removing `rsky-repo/benches` from that tree reproduces the CI error exactly. The image build itself is left to CI.

## Follow-ups, not in this PR

- `BlockMap::add` (`block_map.rs:36`) and the commit encode in `repo.rs:281-282` are the same encode-twice pattern on the same write path. `cid_for_dag_cbor_bytes` arguably belongs in `rsky_common::ipld` next to `cid_for_cbor`, with `cid_for_cbor` delegating to it.
- `is_valid_chars` rejects `~`, which the spec allows and which `rsky_syntax::record_key` already accepts — so a valid rkey passes our own validator and is then rejected by the MST. The 256-byte key cap is also below the reference implementation's 1024 (and below `NSID + "/" + rkey`). Both predate this PR; both deserve an interop test rather than riding along in a perf change.
- The bench is never compiled by CI (`test = false`, and there's no bench job), so it can rot while CI stays green.
