### PR TITLE
ci: skip path-shaped workspace members by glob; drop stale backpressure step

### DIFF
--- a/.github/scripts/determine-workspace-members.sh
+++ b/.github/scripts/determine-workspace-members.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu pipefail
+set -euo pipefail
 
 # Get GitHub event variables from environment
 EVENT_NAME="${GITHUB_EVENT_NAME}"
@@ -7,17 +7,57 @@ PR_BASE_SHA="${PR_BASE_SHA:-}"
 PR_HEAD_SHA="${PR_HEAD_SHA:-}"
 GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/stdout}"
 
+# Workspace members that must never become a `cargo <cmd> -p <entry>` matrix
+# job. Entries are bash glob patterns matched against the member path exactly
+# as it appears in Cargo.toml (or as discovered on disk), so `dir/*` skips
+# everything under that directory.
+#
+# Vendored crates live under `vendor/`. Their member path is a directory, not a
+# package name, so `cargo check -p vendor/<crate>` fails with "package ID
+# specification looks like a file path". The `vendor/*` pattern covers any
+# future vendored crate without editing this list; `vendor/hubble-sync` is the
+# entry that motivated it.
+SKIP_PACKAGES=("cypher/frontend" "cypher/backend" "rsky-pdsadmin" "vendor/hubble-sync" "vendor/*")
+
+# Returns 0 when the member matches any SKIP_PACKAGES pattern.
+is_skipped() {
+  local pkg="$1"
+  local pattern
+  for pattern in "${SKIP_PACKAGES[@]}"; do
+    # Unquoted right-hand side so the entry is treated as a glob pattern.
+    if [[ "$pkg" == $pattern ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Appends a member to WORKSPACE_MEMBERS unless it is empty or skipped. Every
+# code path that discovers members must go through this so the skip list is
+# applied uniformly.
+add_member() {
+  local pkg="$1"
+  if [[ -z "$pkg" ]]; then
+    return 0
+  fi
+  if is_skipped "$pkg"; then
+    echo "Skipping workspace member: $pkg"
+    return 0
+  fi
+  WORKSPACE_MEMBERS+=("$pkg")
+}
+
 # Function to convert array to JSON without jq dependency
 array_to_json() {
   local array=("$@")
   local json="["
   local separator=""
-  
-  for item in "${array[@]}"; do
+
+  for item in ${array[@]+"${array[@]}"}; do
     json="${json}${separator}\"${item}\""
     separator=","
   done
-  
+
   json="${json}]"
   echo "$json"
 }
@@ -31,12 +71,16 @@ if grep -q '\[workspace\]' Cargo.toml; then
   # Extract the members section: print from the members key to the closing
   # bracket, regardless of how many lines the array spans
   MEMBERS_SECTION=$(awk '/^[[:space:]]*members[[:space:]]*=/ { in_members=1 } in_members { print; if (index($0, "]")) exit }' Cargo.toml)
-  
+
   # Extract member paths - handle both array and table formats
   if echo "$MEMBERS_SECTION" | grep -q 'members.*=.*\['; then
     # Array format: members = ["pkg1", "pkg2"]
-    MEMBERS_LIST=$(echo "$MEMBERS_SECTION" | grep -o '"[^"]*"' | tr -d '"')
-    readarray -t WORKSPACE_MEMBERS <<< "$MEMBERS_LIST"
+    # `|| true` keeps an empty array from tripping pipefail.
+    MEMBERS_LIST=$(echo "$MEMBERS_SECTION" | grep -o '"[^"]*"' | tr -d '"' || true)
+    # A plain read loop instead of readarray, which bash 3 does not have.
+    while IFS= read -r member; do
+      add_member "$member"
+    done <<< "$MEMBERS_LIST"
   else
     # Fallback: Try to find any directory that contains a Cargo.toml file
     echo "Falling back to finding all directories with Cargo.toml..."
@@ -46,7 +90,7 @@ if grep -q '\[workspace\]' Cargo.toml; then
         pkg_dir=$(dirname "$dir")
         # Remove the leading ./ if present
         pkg_dir=${pkg_dir#./}
-        WORKSPACE_MEMBERS+=("$pkg_dir")
+        add_member "$pkg_dir"
       fi
     done < <(find . -name "Cargo.toml" -type f | sort)
   fi
@@ -58,14 +102,11 @@ if [ ${#WORKSPACE_MEMBERS[@]} -eq 0 ]; then
   for dir in $(find . -maxdepth 1 -type d -name "rsky*"); do
     # Remove the leading ./
     dir=${dir#./}
-    WORKSPACE_MEMBERS+=("$dir")
+    add_member "$dir"
   done
 fi
 
-echo "Found workspace members: ${WORKSPACE_MEMBERS[*]}"
-
-# Define packages to skip
-SKIP_PACKAGES=("cypher/frontend" "cypher/backend" "rsky-pdsadmin")
+echo "Found workspace members: ${WORKSPACE_MEMBERS[*]+"${WORKSPACE_MEMBERS[*]}"}"
 
 # Check if .github directory has changes
 GITHUB_CHANGES=false
@@ -89,7 +130,7 @@ CHANGED_MEMBERS=()
 if [[ "$GITHUB_CHANGES" == "true" ]]; then
     # If .github has changes, include all packages (except skipped ones)
     echo "Changes detected in .github directory, including all packages"
-    for pkg in "${WORKSPACE_MEMBERS[@]}"; do
+    for pkg in ${WORKSPACE_MEMBERS[@]+"${WORKSPACE_MEMBERS[@]}"}; do
         CHANGED_MEMBERS+=("$pkg")
     done
 else
@@ -106,7 +147,7 @@ else
     echo "Changed files:"
     echo "$DIFF_FILES"
 
-    for pkg in "${WORKSPACE_MEMBERS[@]}"; do
+    for pkg in ${WORKSPACE_MEMBERS[@]+"${WORKSPACE_MEMBERS[@]}"}; do
         if echo "$DIFF_FILES" | grep -q "^$pkg/"; then
             CHANGED_MEMBERS+=("$pkg")
             echo "Package with changes: $pkg"
@@ -114,20 +155,9 @@ else
     done
 fi
 
-# Filter out packages to skip
-FILTERED_MEMBERS=()
-for pkg in "${CHANGED_MEMBERS[@]}"; do
-    skip=false
-    for skip_pkg in "${SKIP_PACKAGES[@]}"; do
-        if [[ "$pkg" == "$skip_pkg" ]]; then
-            skip=true
-            break
-        fi
-    done
-    if [[ "$skip" == "false" ]]; then
-        FILTERED_MEMBERS+=("$pkg")
-    fi
-done
+# WORKSPACE_MEMBERS was already filtered through the skip list by add_member,
+# so CHANGED_MEMBERS cannot contain a skipped package.
+FILTERED_MEMBERS=(${CHANGED_MEMBERS[@]+"${CHANGED_MEMBERS[@]}"})
 
 # Always include at least one default package if array is empty
 if [ ${#FILTERED_MEMBERS[@]} -eq 0 ]; then
@@ -137,20 +167,20 @@ if [ ${#FILTERED_MEMBERS[@]} -eq 0 ]; then
         FILTERED_MEMBERS+=("rsky-common")
     else
         # Find the first available Rust package
-        for dir in "${WORKSPACE_MEMBERS[@]}"; do
+        for dir in ${WORKSPACE_MEMBERS[@]+"${WORKSPACE_MEMBERS[@]}"}; do
             if [[ -d "$dir" && -f "$dir/Cargo.toml" ]]; then
                 FILTERED_MEMBERS+=("$dir")
                 break
             fi
         done
     fi
-    
+
     # If still empty, use a hardcoded fallback
     if [ ${#FILTERED_MEMBERS[@]} -eq 0 ]; then
         echo "No valid workspace members found, using default package"
         # Use the first 'rsky-' directory as fallback
         for dir in rsky-*; do
-            if [[ -d "$dir" && -f "$dir/Cargo.toml" ]]; then
+            if [[ -d "$dir" && -f "$dir/Cargo.toml" ]] && ! is_skipped "$dir"; then
                 FILTERED_MEMBERS+=("$dir")
                 break
             fi
@@ -159,6 +189,6 @@ if [ ${#FILTERED_MEMBERS[@]} -eq 0 ]; then
 fi
 
 # Convert to JSON array for matrix - without jq dependency
-JSON_MEMBERS=$(array_to_json "${FILTERED_MEMBERS[@]}")
+JSON_MEMBERS=$(array_to_json ${FILTERED_MEMBERS[@]+"${FILTERED_MEMBERS[@]}"})
 echo "workspace_members=$JSON_MEMBERS" >> "$GITHUB_OUTPUT"
 echo "Found workspace members to process: $JSON_MEMBERS"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -168,13 +168,6 @@ jobs:
       # require ffmpeg on every dev machine; CI installs it and runs them
       # explicitly, otherwise the video normalization fix has zero coverage
       # in the green build.
-      # Ignored by default because its runtime scales with the production high
-      # water mark. A small mark exercises the same assertion in seconds.
-      - name: Run rsky-wintermute backpressure test
-        if: matrix.package == 'rsky-wintermute'
-        env:
-          BACKFILLER_OUTPUT_HIGH_WATER_MARK: "100"
-        run: cargo test --release -p rsky-wintermute -- --ignored backpressure
       - name: Install ffmpeg for rsky-video e2e tests
         if: matrix.package == 'rsky-video'
         run: sudo apt-get update && sudo apt-get install -y ffmpeg


### PR DESCRIPTION
Two CI fixes, both ahead of the wintermute hubble-backfill PR (branch `feat/wintermute-hubble-backfill`) so that branch can go green.

## 1. `determine-workspace-members.sh`: skip path-shaped members by glob

`rust.yml` turns each entry of the root `Cargo.toml` `[workspace] members` array into `cargo check|build|test -p <entry>`. That only works when the member path is also the package name. The backfill branch adds a vendored member `vendor/hubble-sync`, which makes cargo fail with:

```
error: package ID specification `vendor/hubble-sync` looks like a file path
```

Changes:

- `SKIP_PACKAGES` entries are now bash glob patterns. Added `vendor/hubble-sync` (the entry that motivated this) and `vendor/*`, so any future vendored crate is skipped without editing the list.
- The skip list is applied in one place, `add_member`, that every member-discovery path goes through: the `members = [...]` array parse, the find-based fallback, and the `rsky*` fallback. The final hardcoded `rsky-*` fallback checks `is_skipped` too. Previously the filter ran once, late, with exact string match only.
- `set -eu pipefail` never enabled pipefail (it set `$1` to `pipefail`); it is now `set -euo pipefail`. The members `grep -o` is guarded with `|| true` so an empty array does not trip it.
- `readarray` (bash 4+) replaced with a `read` loop, and possibly-empty arrays use the `${arr[@]+"${arr[@]}"}` idiom, so the script runs under `set -u` on bash 3.2 as well as GitHub's ubuntu-latest bash 5. The script on `main` exits 127 with `readarray: command not found` under macOS `/bin/bash`.

Verified locally under bash 3.2.57: push path, PR path (`PR_BASE_SHA`/`PR_HEAD_SHA` set to two `main` commits), and both the `.github`-changed "all packages" branch and the changed-files-only branch. With `vendor/hubble-sync`, `vendor/other-crate`, and `cypher/frontend` temporarily added to the members array, all three are logged as `Skipping workspace member:` and none reach `workspace_members=`. The find-based fallback (members not in array form) skips a fake `vendor/fake-crate/Cargo.toml` and `rsky-pdsadmin`; the `rsky*` fallback (no `[workspace]` section) skips `rsky-pdsadmin`. The temporary `Cargo.toml` edits were reverted and are not part of this PR.

## 2. `rust.yml`: remove the "Run rsky-wintermute backpressure test" step

The step ran `cargo test --release -p rsky-wintermute -- --ignored backpressure` with `BACKFILLER_OUTPUT_HIGH_WATER_MARK=100`. The backfill PR deletes the old backfiller and with it `test_backpressure_metric_tracking`, which would leave this step running zero tests.

To be plain about the ordering: that test **still exists on `main`** (`rsky-wintermute/src/backfiller/tests.rs`, `#[ignore]`d), and this step was its only runner in CI. Between this PR merging and the backfill PR merging, that one test is not run in CI. The test itself is not touched here; only the workflow step and its two-line comment are removed. If the gap is unacceptable, merge this PR together with or after the backfill PR.

`rust.yml` still parses (`ruby -ryaml` and `yq`); the remaining `build-and-test` steps are unchanged.

## Notes

- Commits are unsigned (`-c commit.gpgsign=false`; no GPG pinentry in the authoring environment). The author may re-sign before merge.
- No Rust code changes; `.github/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
