### PR TITLE
docs: add security policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ there is a fit!
 
 ## Code of Conduct
 This project and everyone participating in it is governed by the [Code of Conduct](https://github.com/blacksky-algorithms/rsky/blob/main/.github/CODE_OF_CONDUCT.md). 
-By participating, you are expected to uphold this code. Please report any unacceptable behavior to rudy@blacksky.app.
+By participating, you are expected to uphold this code. Please report any unacceptable behavior to support@blacksky.app.
 
 ## Important Links
 * [License Information](https://github.com/blacksky-algorithms/rsky/blob/main/LICENSE)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ In the report, we ask that you include the following information:
 - The Rust Compiler Version (type `rustc --version` to get the version)
 - If you are able to reliably reproduce this issue, how.
 
-If your bug report is concerning a security vulnerability, we encourage you to email us at rudy@blacksky.app.
+If your bug report is concerning a security vulnerability, please follow the process in [SECURITY.md](SECURITY.md) instead of filing a public issue.
 
 ### Submitting a Feature Request
 Similar to the [Bug Report](#submitting-a-bug-report) section, confirm that you are using the latest version, and that

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ The preferred way to report a vulnerability is through GitHub's private reportin
 This opens a private conversation with maintainers and keeps the report out of public
 view until it's resolved.
 
-If you'd rather not use GitHub, you can instead email **rudy@blacksky.app**.
+If you'd rather not use GitHub, you can instead email **support@blacksky.app**.
 
 In either case, please include:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Supported Versions
+
+rsky does not yet publish tagged releases; `main` is the actively maintained line. If you
+believe a vulnerability affects a specific crate, service, or deployment, please note the
+commit, crate version, or image tag in your report.
+
+## Reporting a Vulnerability
+
+Please do **not** open a public GitHub issue for a suspected security vulnerability.
+
+The preferred way to report a vulnerability is through GitHub's private reporting flow:
+
+1. Go to the [Security tab](https://github.com/blacksky-algorithms/rsky/security) of this repository.
+2. Click **Report a vulnerability**.
+3. Fill in the advisory form with as much detail as you can.
+
+This opens a private conversation with maintainers and keeps the report out of public
+view until it's resolved.
+
+If you'd rather not use GitHub, you can instead email **rudy@blacksky.app**.
+
+In either case, please include:
+
+- A description of the vulnerability and its impact.
+- The affected crate, service, or component (e.g. `rsky-pds`, `rsky-relay`).
+- Steps to reproduce, including any proof-of-concept code.
+- Any special configuration required to reproduce the issue.
+
+## What to Expect
+
+- We'll acknowledge new reports as soon as a maintainer is available.
+- We'll work with you to confirm the issue, assess impact, and develop a fix.
+- We'll credit reporters in the advisory when a fix is published, unless you'd prefer to
+  stay anonymous.
+
+## Scope
+
+In-scope: rsky crates and services in this repository, including authentication,
+authorization, data handling, federation, and moderation/labeling behavior.
+
+Out of scope: denial-of-service testing, social engineering, and any testing against
+production infrastructure or accounts you don't own. If you need to test against a live
+deployment, ask first in your report.


### PR DESCRIPTION
## Summary
- Adds a root `SECURITY.md` so GitHub surfaces the private vulnerability reporting flow (now enabled on this repo) directly from the Security tab.
- Keeps the existing `rudy@blacksky.app` contact from `CONTRIBUTING.md` as a fallback for reporters who'd rather not use GitHub.

## Test plan
- [ ] Confirm GitHub's "Report a vulnerability" entry point links here correctly
- [ ] Confirm rendered Markdown looks correct on GitHub

Relates to #183