### PR TITLE
fix(relay): make rsky-relay clippy-clean under Rust 1.98

### DIFF
--- a/rsky-relay/Cargo.toml
+++ b/rsky-relay/Cargo.toml
@@ -3,6 +3,10 @@ name = "rsky-relay"
 version = "0.1.3"
 default-run = "rsky-relay"
 edition = "2024"
+# Keep in sync with the toolchain pin in `rust-toolchain`. Clippy reads this as
+# its MSRV so it does not suggest syntax/APIs (let chains, `Duration::from_mins`)
+# that the pinned toolchain cannot compile.
+rust-version = "1.86"
 
 [dependencies]
 # external

--- a/rsky-relay/src/crawler/client.rs
+++ b/rsky-relay/src/crawler/client.rs
@@ -8,7 +8,7 @@ use socket2::{Domain, Protocol, Socket, Type};
 use tungstenite::Connector;
 use tungstenite::client::{IntoClientRequest, uri_mode};
 use tungstenite::client_tls_with_config;
-use tungstenite::error::{Error, Result, UrlError};
+use tungstenite::error::{Error, UrlError};
 use tungstenite::handshake::client::Request;
 use tungstenite::protocol::WebSocketConfig;
 use tungstenite::stream::{Mode, NoDelay};
@@ -32,7 +32,7 @@ pub fn connect<Req: IntoClientRequest>(request: Req) -> HandshakeResult {
 }
 
 // Ref: https://github.com/snapview/tungstenite-rs/blob/master/src/client.rs
-#[expect(clippy::expect_used, clippy::ignored_unit_patterns, clippy::redundant_clone)]
+#[expect(clippy::expect_used, clippy::ignored_unit_patterns)]
 pub fn connect_with_config<Req: IntoClientRequest>(
     request: Req, config: Option<WebSocketConfig>, max_redirects: u8,
 ) -> HandshakeResult {
@@ -47,7 +47,7 @@ pub fn connect_with_config<Req: IntoClientRequest>(
             Mode::Tls => 443,
         });
         let mut stream = connect_to_some((host, port), request.uri())?;
-        NoDelay::set_nodelay(&mut stream, true)?;
+        NoDelay::set_nodelay(&mut stream, true).map_err(Error::from)?;
 
         // Build an explicit rustls connector to avoid the tungstenite "Bug: TLS
         // handshake not blocked" panic that occurs when passing None for the
@@ -71,27 +71,39 @@ pub fn connect_with_config<Req: IntoClientRequest>(
     }
 
     let (parts, _) = request.into_client_request()?.into_parts();
+    // False positive on clippy <= 1.86 (fixed upstream): `uri` is reassigned on
+    // each redirect while `parts` stays borrowed by `create_request`.
+    #[allow(clippy::redundant_clone)]
     let mut uri = parts.uri.clone();
 
     for attempt in 0..=max_redirects {
         let request = create_request(&parts, &uri);
 
-        match try_client_handshake(request, config) {
-            Err(Error::Http(res)) if res.status().is_redirection() && attempt < max_redirects => {
-                if let Some(location) = res.headers().get("Location") {
-                    uri = location.to_str()?.parse::<Uri>()?;
-                } else {
-                    return Err(Error::Http(res));
+        let err = match try_client_handshake(request, config) {
+            Ok(res) => return Ok(res),
+            Err(err) => err,
+        };
+        match &*err {
+            Error::Http(res) if res.status().is_redirection() && attempt < max_redirects => {
+                match res.headers().get("Location") {
+                    Some(location) => {
+                        uri = location
+                            .to_str()
+                            .map_err(Error::from)?
+                            .parse::<Uri>()
+                            .map_err(Error::from)?;
+                    }
+                    None => return Err(err),
                 }
             }
-            other => return other,
+            _ => return Err(err),
         }
     }
 
     unreachable!("Bug in a redirect handling logic")
 }
 
-fn connect_to_some(addrs: impl ToSocketAddrs, uri: &Uri) -> Result<TcpStream> {
+fn connect_to_some(addrs: impl ToSocketAddrs, uri: &Uri) -> Result<TcpStream, Box<Error>> {
     fn is_blocking_error(error: &io::Error) -> bool {
         matches!(
             error.kind(),
@@ -99,16 +111,23 @@ fn connect_to_some(addrs: impl ToSocketAddrs, uri: &Uri) -> Result<TcpStream> {
         ) || matches!(error.raw_os_error(), Some(libc::EINPROGRESS))
     }
 
-    for addr in addrs.to_socket_addrs()? {
-        // debug!("Trying to contact {uri} at {addr}...");
-        let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))?;
-        socket.set_nonblocking(true)?;
-        match socket.connect(&addr.into()) {
-            Ok(()) => {}
-            Err(e) if is_blocking_error(&e) => {}
-            Err(_) => continue,
+    /// `Ok(None)`: every address was tried and none accepted the connection.
+    fn try_addrs(addrs: impl ToSocketAddrs) -> io::Result<Option<TcpStream>> {
+        for addr in addrs.to_socket_addrs()? {
+            // debug!("Trying to contact {uri} at {addr}...");
+            let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))?;
+            socket.set_nonblocking(true)?;
+            match socket.connect(&addr.into()) {
+                Ok(()) => {}
+                Err(e) if is_blocking_error(&e) => {}
+                Err(_) => continue,
+            }
+            return Ok(Some(socket.into()));
         }
-        return Ok(socket.into());
+        Ok(None)
     }
-    Err(Error::Url(UrlError::UnableToConnect(uri.to_string())))
+
+    try_addrs(addrs)
+        .map_err(Error::from)?
+        .ok_or_else(|| Box::new(Error::Url(UrlError::UnableToConnect(uri.to_string()))))
 }

--- a/rsky-relay/src/crawler/connection.rs
+++ b/rsky-relay/src/crawler/connection.rs
@@ -16,9 +16,15 @@ pub enum ConnectionError {
     #[error("io error: {0}")]
     Io(#[from] io::Error),
     #[error("tungstenite error: {0}")]
-    Tungstenite(#[from] tungstenite::Error),
+    Tungstenite(#[from] Box<tungstenite::Error>),
     #[error("thingbuf error: {0}")]
     Thingbuf(#[from] mpsc::errors::Closed),
+}
+
+impl From<tungstenite::Error> for ConnectionError {
+    fn from(value: tungstenite::Error) -> Self {
+        Self::Tungstenite(Box::new(value))
+    }
 }
 
 pub struct Connection {

--- a/rsky-relay/src/crawler/types.rs
+++ b/rsky-relay/src/crawler/types.rs
@@ -15,7 +15,8 @@ pub type MaybeTlsTcpStream = MaybeTlsStream<TcpStream>;
 pub type WebSocketClient = WebSocket<MaybeTlsTcpStream>;
 pub type Handshaking = MidHandshake<ClientHandshake<MaybeTlsTcpStream>>;
 pub type MaybeHandshake = Result<WebSocketClient, Handshaking>;
-pub type HandshakeResult = Result<MaybeHandshake, tungstenite::Error>;
+// Boxed: `tungstenite::Error` is 136 bytes, over clippy's `result_large_err` limit.
+pub type HandshakeResult = Result<MaybeHandshake, Box<tungstenite::Error>>;
 
 pub trait DecomposeError {
     fn decompose(self) -> HandshakeResult;
@@ -28,7 +29,7 @@ impl DecomposeError
         match self {
             Ok((client, _)) => Ok(Ok(client)),
             Err(HandshakeError::Interrupted(handshaking)) => Ok(Err(handshaking)),
-            Err(HandshakeError::Failure(err)) => Err(err),
+            Err(HandshakeError::Failure(err)) => Err(Box::new(err)),
         }
     }
 }
@@ -96,6 +97,6 @@ mod tests {
             HandshakeError<ClientHandshake<MaybeTlsTcpStream>>,
         > = Err(HandshakeError::Failure(tungstenite::Error::ConnectionClosed));
         let out = res.decompose();
-        assert!(matches!(out, Err(tungstenite::Error::ConnectionClosed)));
+        assert!(matches!(out, Err(err) if matches!(*err, tungstenite::Error::ConnectionClosed)));
     }
 }

--- a/rsky-relay/src/lib.rs
+++ b/rsky-relay/src/lib.rs
@@ -23,7 +23,6 @@
     clippy::print_stdout,
     clippy::renamed_function_params,
     clippy::str_to_string,
-    clippy::string_to_string,
     clippy::unused_result_ok,
     clippy::unwrap_used
 )]
@@ -42,7 +41,6 @@
         clippy::redundant_pub_crate,
         clippy::min_ident_chars,
         clippy::str_to_string,
-        clippy::string_to_string,
         clippy::tests_outside_test_module,
         clippy::let_underscore_must_use,
         clippy::print_stdout,

--- a/rsky-relay/src/publisher/connection.rs
+++ b/rsky-relay/src/publisher/connection.rs
@@ -24,11 +24,28 @@ pub enum ConnectionError {
     #[error("io error: {0}")]
     Io(#[from] io::Error),
     #[error("handshake error: {0}")]
-    Handshake(#[from] HandshakeError<ServerHandshake<MaybeTlsStream<TcpStream>, NoCallback>>),
+    Handshake(#[from] Box<ServerHandshakeError>),
     #[error("tungstenite error: {0}")]
-    Tungstenite(#[from] tungstenite::Error),
+    Tungstenite(#[from] Box<tungstenite::Error>),
     #[error("fjall error: {0}")]
     Fjall(#[from] fjall::Error),
+}
+
+/// Carries the mid-handshake stream, so it is ~1.4 KiB; boxed to keep
+/// `ConnectionError` (and every `Result` wrapping it) small.
+pub type ServerHandshakeError =
+    HandshakeError<ServerHandshake<MaybeTlsStream<TcpStream>, NoCallback>>;
+
+impl From<ServerHandshakeError> for ConnectionError {
+    fn from(value: ServerHandshakeError) -> Self {
+        Self::Handshake(Box::new(value))
+    }
+}
+
+impl From<tungstenite::Error> for ConnectionError {
+    fn from(value: tungstenite::Error) -> Self {
+        Self::Tungstenite(Box::new(value))
+    }
 }
 
 pub struct Connection {

--- a/rsky-relay/src/server/server.rs
+++ b/rsky-relay/src/server/server.rs
@@ -519,10 +519,9 @@ impl Server {
     fn host_status(&self, url: &Url) -> Result<GetHostStatus> {
         let mut hostname = None;
         for (key, value) in url.query_pairs() {
-            match key.as_ref() {
-                "hostname" => hostname = Some(value.to_string()),
-                // Ignore unknown query parameters.
-                _ => (),
+            // Ignore unknown query parameters.
+            if key.as_ref() == "hostname" {
+                hostname = Some(value.to_string());
             }
         }
         let hostname = hostname.ok_or_else(|| eyre!("hostname param is required"))?;


### PR DESCRIPTION
## Summary

Makes `rsky-relay` clippy-clean under Rust 1.98 while staying clean under the pinned 1.86 toolchain. Lint-only: no behavior changes, no test semantics changed, `rust-toolchain` untouched.

This prepares for the toolchain bump to 1.98 in `feat/wintermute-hubble-backfill`, where `cargo clippy -p rsky-relay --all-targets` currently fails with 62 errors because the crate uses `#![deny(warnings, clippy::all, clippy::pedantic, clippy::nursery, ...)]`.

## Lint categories and how each was resolved

| Lint | Count | Resolution |
|---|---|---|
| `result_large_err` (fn + closure) | 33 | Real fix: boxed the large payloads. `tungstenite::Error` (136 bytes, over the 128-byte limit) is now `Box<tungstenite::Error>` in `crawler::ConnectionError`, `publisher::ConnectionError`, and the `HandshakeResult` alias. The publisher `Handshake` variant carried the mid-handshake stream (~1440 bytes) and is now `Box<ServerHandshakeError>`. Manual `From` impls keep every `?` site working; `crawler/client.rs` (vendored tungstenite `connect`) gained explicit `map_err(Error::from)` on the few `io::Error`/`ToStrError`/`InvalidUri` conversions. |
| `large_enum_variant` | 4 | Fixed by the same boxing (`ConnectionError`, `WorkerError`, `ManagerError`, `RelayError` all shrink). |
| `collapsible_if` | 20 | Every suggestion required let-chains (Rust 1.88+), which the pinned 1.86 toolchain cannot compile. Declared `rust-version = "1.86"` in `rsky-relay/Cargo.toml`; clippy reads that as MSRV and no longer suggests them. |
| Duration smaller-unit (`Duration::from_mins`/`from_hours`) | 3 | Same MSRV declaration (those constructors are 1.91+). |
| `string_to_string` removed (covered by `implicit_clone`) | 2 | Removed from the `deny` list and the `cfg_attr(test, allow(...))` list. |
| `match` used for equality check | 1 | Rewrote the query-param `match` in `Server::host_status` as `if key.as_ref() == "hostname"`. |
| Unfulfilled `#[expect(clippy::redundant_clone)]` | 1 | Removed from the `expect` on `connect_with_config`. Clippy 1.86 still reports that clone as redundant (false positive fixed upstream; `uri` is reassigned per redirect while `parts` stays borrowed), so the single `let` carries a targeted `#[allow(clippy::redundant_clone)]` with a comment. |
| `missing_const_for_fn` | 1 | Silenced by the MSRV declaration (the suggestion depended on newer const stabilizations). |

## Verification

- `cargo clippy -p rsky-relay --all-targets` (pinned 1.86): 0 errors, 0 warnings from `rsky-relay`
- `RUSTUP_TOOLCHAIN=1.98 cargo clippy -p rsky-relay --all-targets`: 0 errors, 0 warnings from `rsky-relay`
- `cargo test -p rsky-relay` (1.86): 120 passed, 0 failed
- `cargo fmt --all -- --check`: clean

Remaining warnings in the clippy output come from `rsky-common`, `rsky-identity`, and `rsky-crypto`, plus a pre-existing cargo manifest warning about `src/main.rs` being shared by the `rsky-relay` and `rsky-relay-labeler` bin targets; none are introduced here.

Not addressed (pre-existing, out of scope): with `--features labeler`, rustc 1.98's stricter `dead_code` analysis flags five `cfg(not(feature = "labeler"))`-only types in `server/types.rs` and `validator/event.rs`. That build is clean on 1.86 and CI does not exercise the feature.

## Notes

Commits are unsigned (GPG pinentry unavailable in the authoring environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
