### PR TITLE
fix(lexicon): decode subscribeRepos#commit blobs as cid-links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8320,7 +8320,7 @@ dependencies = [
 
 [[package]]
 name = "rsky-lexicon"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rand_core = "0.6.4"
 secp256k1 = { version = "0.28.2", features = ["global-context", "serde", "rand", "hashes","rand-std"] }
 serde_json = { version = "1.0.96",features = ["preserve_order"] }
 rusqlite = { version = "0.36", features = ["bundled"] }
-rsky-lexicon = {path = "rsky-lexicon", version = "0.10.0"}
+rsky-lexicon = {path = "rsky-lexicon", version = "0.11.0"}
 rsky-identity = {path = "rsky-identity", version = "0.2.0"}
 rsky-crypto = {path = "rsky-crypto", version = "0.2.1"}
 rsky-syntax = {path = "rsky-syntax", version = "0.1.1"}

--- a/rsky-lexicon/Cargo.toml
+++ b/rsky-lexicon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsky-lexicon"
-version = "0.10.3"
+version = "0.11.0"
 edition = "2021"
 publish = true
 description = "Bluesky API library"

--- a/rsky-lexicon/src/com/atproto/sync.rs
+++ b/rsky-lexicon/src/com/atproto/sync.rs
@@ -43,7 +43,11 @@ pub struct SubscribeReposCommit {
     #[serde(with = "serde_bytes")]
     pub blocks: Vec<u8>,
     pub ops: Vec<SubscribeReposCommitOperation>,
-    pub blobs: Vec<String>,
+    /// CIDs of blobs referenced by records in this commit. The lexicon defines this as an
+    /// array of `cid-link`, so it serializes as DAG-CBOR tag-42 links. Decoding is lenient
+    /// and also accepts text-string CIDs, which older rsky-pds instances emitted.
+    #[serde(default, deserialize_with = "deserialize_cid_vec_v1")]
+    pub blobs: Vec<Cid>,
     /// The root CID of the MST tree for the previous commit from this repo.
     /// Effectively required for the inductive version of the firehose.
     #[serde(rename = "prevData", default, skip_serializing_if = "Option::is_none")]
@@ -272,6 +276,94 @@ where
     }
 }
 
+/// Deserializes an array of CIDs (e.g. `#commit.blobs`) leniently.
+///
+/// The lexicon declares the elements as `cid-link`, which DAG-CBOR encodes as tag 42
+/// wrapping the binary CID; that is what the reference PDS and `tranquil` emit and what
+/// this struct serializes. Older rsky-pds instances emitted text-string CIDs instead, and
+/// those frames still exist in the wild, so string elements (and raw untagged CID bytes)
+/// are accepted too. Like `deserialize_cid_v1`, this drives the deserializer through
+/// `deserialize_any` so a tag-42 link arrives via `visit_newtype_struct`.
+pub fn deserialize_cid_vec_v1<'de, D>(deserializer: D) -> Result<Vec<Cid>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct LenientCid(Cid);
+
+    fn cid_from_bytes<E: serde::de::Error>(mut bz: Vec<u8>) -> Result<LenientCid, E> {
+        if bz.first() == Some(&MULTIBASE_IDENTITY) {
+            bz.remove(0);
+        }
+        Cid::try_from(bz)
+            .map(LenientCid)
+            .map_err(|e| E::custom(format!("Failed to deserialize Cid: {}", e)))
+    }
+
+    struct LenientCidVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for LenientCidVisitor {
+        type Value = LenientCid;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("a CID link (CBOR tag 42) or a CID string")
+        }
+
+        fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<LenientCid, E> {
+            Cid::try_from(v)
+                .map(LenientCid)
+                .map_err(|e| E::custom(format!("Failed to deserialize Cid: {}", e)))
+        }
+
+        fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<LenientCid, E> {
+            cid_from_bytes(v.to_vec())
+        }
+
+        fn visit_byte_buf<E: serde::de::Error>(self, v: Vec<u8>) -> Result<LenientCid, E> {
+            cid_from_bytes(v)
+        }
+
+        // serde_ipld_dagcbor (and serde_cbor) surface a tagged value as a newtype struct
+        // wrapping the tag's content; for tag 42 that content is the binary CID.
+        fn visit_newtype_struct<D2>(self, deserializer: D2) -> Result<LenientCid, D2::Error>
+        where
+            D2: Deserializer<'de>,
+        {
+            let buf = serde_bytes::ByteBuf::deserialize(deserializer)?;
+            cid_from_bytes(buf.into_vec())
+        }
+
+        // JSON form: {"$link": "cid_string"}
+        fn visit_map<A>(self, map: A) -> Result<LenientCid, A::Error>
+        where
+            A: serde::de::MapAccess<'de>,
+        {
+            let map = serde_json::Map::<String, Value>::deserialize(
+                serde::de::value::MapAccessDeserializer::new(map),
+            )?;
+            match map.get("$link") {
+                Some(Value::String(link)) => Cid::try_from(link.as_str())
+                    .map(LenientCid)
+                    .map_err(serde::de::Error::custom),
+                _ => Err(serde::de::Error::custom(
+                    "expected \"$link\" field with CID string",
+                )),
+            }
+        }
+    }
+
+    impl<'de> Deserialize<'de> for LenientCid {
+        fn deserialize<D2>(deserializer: D2) -> Result<Self, D2::Error>
+        where
+            D2: Deserializer<'de>,
+        {
+            deserializer.deserialize_any(LenientCidVisitor)
+        }
+    }
+
+    let cids = Vec::<LenientCid>::deserialize(deserializer)?;
+    Ok(cids.into_iter().map(|c| c.0).collect())
+}
+
 pub fn default_resource() -> Option<Cid> {
     None
 }
@@ -423,6 +515,134 @@ mod tests {
         assert_eq!(decoded.prev, None);
         assert_eq!(decoded.prev_data, commit.prev_data);
         assert_eq!(decoded.ops[0].prev, None);
+        assert_eq!(decoded.blocks, commit.blocks);
+    }
+
+    const BLOB_CID_A: &str = "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku";
+    const BLOB_CID_B: &str = "bafkreie5cvv4h45feadgeuwhbcutmh6t2ceseocckahdoe6uat64zmz454";
+
+    /// Hand-build a DAG-CBOR `#commit` frame body whose `blobs` array holds the given
+    /// elements, so the test controls the exact wire encoding of each element.
+    fn commit_body_with_blobs(blobs: Vec<ipld_core::ipld::Ipld>) -> Vec<u8> {
+        use ipld_core::ipld::Ipld;
+        use std::collections::BTreeMap;
+
+        let mut op = BTreeMap::new();
+        op.insert(
+            "path".to_string(),
+            Ipld::String("app.bsky.feed.post/3jzfcijpj2z2a".to_string()),
+        );
+        op.insert("action".to_string(), Ipld::String("create".to_string()));
+        op.insert(
+            "cid".to_string(),
+            Ipld::Link(Cid::from_str(TEST_CID).unwrap()),
+        );
+
+        let mut body = BTreeMap::new();
+        body.insert("seq".to_string(), Ipld::Integer(42));
+        body.insert(
+            "time".to_string(),
+            Ipld::String("2026-01-12T19:45:23.307Z".to_string()),
+        );
+        body.insert("rebase".to_string(), Ipld::Bool(false));
+        body.insert("tooBig".to_string(), Ipld::Bool(false));
+        body.insert("repo".to_string(), Ipld::String("did:plc:test".to_string()));
+        body.insert(
+            "commit".to_string(),
+            Ipld::Link(Cid::from_str(TEST_CID).unwrap()),
+        );
+        body.insert("rev".to_string(), Ipld::String("3jzfcijpj2z2a".to_string()));
+        body.insert("since".to_string(), Ipld::Null);
+        body.insert("blocks".to_string(), Ipld::Bytes(vec![1, 2, 3]));
+        body.insert("ops".to_string(), Ipld::List(vec![Ipld::Map(op)]));
+        body.insert("blobs".to_string(), Ipld::List(blobs));
+        serde_ipld_dagcbor::to_vec(&Ipld::Map(body)).unwrap()
+    }
+
+    /// The lexicon defines `blobs` as `array` of `cid-link`, which DAG-CBOR encodes as
+    /// tag 42 (0xD8 0x2A) wrapping the binary CID. The `tranquil` PDS populates this
+    /// field; decoding it as text used to fail with `Mismatch { expect_major: 3, byte: 216 }`.
+    #[test]
+    fn commit_decodes_blobs_encoded_as_cid_links() {
+        use ipld_core::ipld::Ipld;
+
+        let a = Cid::from_str(BLOB_CID_A).unwrap();
+        let b = Cid::from_str(BLOB_CID_B).unwrap();
+        let body = commit_body_with_blobs(vec![Ipld::Link(a), Ipld::Link(b)]);
+        let decoded: SubscribeReposCommit =
+            serde_ipld_dagcbor::from_slice(&body).expect("commit with tag-42 blobs must decode");
+        assert_eq!(decoded.seq, 42);
+        assert_eq!(decoded.blobs.len(), 2);
+        assert_eq!(decoded.blobs[0].to_string(), BLOB_CID_A);
+        assert_eq!(decoded.blobs[1].to_string(), BLOB_CID_B);
+    }
+
+    /// rsky-pds (non-conformantly) emitted `blobs` as text-string CIDs; those frames exist
+    /// in the wild and must keep decoding.
+    #[test]
+    fn commit_decodes_blobs_encoded_as_text_strings() {
+        use ipld_core::ipld::Ipld;
+
+        let body = commit_body_with_blobs(vec![
+            Ipld::String(BLOB_CID_A.to_string()),
+            Ipld::String(BLOB_CID_B.to_string()),
+        ]);
+        let decoded: SubscribeReposCommit = serde_ipld_dagcbor::from_slice(&body)
+            .expect("commit with text-string blobs must decode");
+        assert_eq!(decoded.blobs.len(), 2);
+        assert_eq!(decoded.blobs[0].to_string(), BLOB_CID_A);
+        assert_eq!(decoded.blobs[1].to_string(), BLOB_CID_B);
+    }
+
+    #[test]
+    fn commit_decodes_missing_blobs_as_empty() {
+        use ipld_core::ipld::Ipld;
+
+        let mut body = commit_body_with_blobs(vec![]);
+        // Re-encode without the `blobs` key at all.
+        let Ipld::Map(mut map) = serde_ipld_dagcbor::from_slice::<Ipld>(&body).unwrap() else {
+            panic!("expected map");
+        };
+        map.remove("blobs");
+        body = serde_ipld_dagcbor::to_vec(&Ipld::Map(map)).unwrap();
+        let decoded: SubscribeReposCommit = serde_ipld_dagcbor::from_slice(&body).unwrap();
+        assert!(decoded.blobs.is_empty());
+    }
+
+    #[test]
+    fn commit_round_trips_blobs_as_cid_links() {
+        use ipld_core::ipld::Ipld;
+
+        let a = Cid::from_str(BLOB_CID_A).unwrap();
+        let b = Cid::from_str(BLOB_CID_B).unwrap();
+        let mut commit = test_commit();
+        commit.blobs = vec![a, b];
+        let bytes = serde_ipld_dagcbor::to_vec(&commit).unwrap();
+
+        // Each blob must be on the wire as a CID link (tag 42 wrapping 0x00 || cid bytes).
+        for cid in [&a, &b] {
+            let mut link = vec![0xD8, 0x2A];
+            let mut cid_bytes = vec![MULTIBASE_IDENTITY];
+            cid_bytes.extend(cid.to_bytes());
+            link.push(0x58); // bytes, 1-byte length follows
+            link.push(cid_bytes.len() as u8);
+            link.extend(cid_bytes);
+            assert!(
+                bytes.windows(link.len()).any(|w| w == link.as_slice()),
+                "serialized commit must contain tag-42 link for {cid}"
+            );
+        }
+        let Ipld::Map(map) = serde_ipld_dagcbor::from_slice::<Ipld>(&bytes).unwrap() else {
+            panic!("expected map");
+        };
+        assert_eq!(
+            map.get("blobs"),
+            Some(&Ipld::List(vec![Ipld::Link(a), Ipld::Link(b)]))
+        );
+
+        let decoded: SubscribeReposCommit = serde_ipld_dagcbor::from_slice(&bytes).unwrap();
+        assert_eq!(decoded.blobs, commit.blobs);
+        assert_eq!(decoded.commit, commit.commit);
         assert_eq!(decoded.blocks, commit.blocks);
     }
 }

--- a/rsky-pds/src/apis/com/atproto/sync/subscribe_repos.rs
+++ b/rsky-pds/src/apis/com/atproto/sync/subscribe_repos.rs
@@ -201,7 +201,7 @@ pub async fn subscribe_repos<'a>(
                                     prev: op.prev,
                                     action: op.action.to_string()
                                 }).collect::<Vec<SubscribeReposCommitOperation>>(),
-                                blobs: blobs.into_iter().map(|blob| blob.to_string()).collect::<Vec<String>>(),
+                                blobs,
                                 prev_data,
                             };
                             let message_frame = MessageFrame::new(subscribe_commit_evt, Some(MessageFrameOpts { r#type: Some(format!("#{0}",r#type)) }));

--- a/rsky-pds/tests/firehose_tests.rs
+++ b/rsky-pds/tests/firehose_tests.rs
@@ -295,7 +295,7 @@ fn encode_frame(evt: &SeqEvt) -> Vec<u8> {
                             action: op.action.to_string(),
                         })
                         .collect(),
-                    blobs: e.blobs.iter().map(|blob| blob.to_string()).collect(),
+                    blobs: e.blobs.clone(),
                     prev_data: e.prev_data,
                 },
                 opts(&evt.r#type),


### PR DESCRIPTION
## Production symptom

On production wintermute, every `#commit` frame from a `tranquil` PDS (e.g. `airlock.ltd`) that carries a blob fails to decode with

```
Mismatch { expect_major: 3, byte: 216 }
```

and the whole event is dropped — hundreds per hour. `expect_major: 3` is CBOR text-string; byte `216` is `0xD8`, the start of a CBOR tag.

## Cause

`rsky-lexicon`'s `SubscribeReposCommit` declared `blobs: Vec<String>`. The lexicon `com.atproto.sync.subscribeRepos#commit` defines `blobs` as:

```json
"blobs": { "type": "array", "items": { "type": "cid-link" } }
```

In DAG-CBOR a `cid-link` is tag 42 (`0xD8 0x2A`) wrapping the binary CID, not a text string. The reference PDS always sends an empty `blobs` array, so the mismatch was invisible until a PDS that populates the field appeared on the firehose.

## Change

- `blobs` is now `Vec<Cid>` (the same `Cid` type used for `commit`, `prev`, `prevData`), with `#[serde(default)]` so a missing field decodes as empty.
- New `deserialize_cid_vec_v1` decodes each element leniently: tag-42 CID links (what the lexicon requires and what the reference PDS / tranquil emit), **and** text-string CIDs, because rsky-pds itself has been emitting `blobs` as strings (`blob.to_string()` in `subscribe_repos.rs`) and those frames exist in the wild — relays and consumers must keep parsing them. Raw untagged CID bytes are accepted too, mirroring `deserialize_cid_v1`. It drives the deserializer through `deserialize_any` exactly like the existing `Tagged<ByteBuf>` helpers, so a tag-42 link arrives via `visit_newtype_struct` under both `serde_ipld_dagcbor` and `serde_cbor`.
- Serialization now emits proper tag-42 CID links. `rsky-pds`'s firehose passes its `Vec<Cid>` straight through instead of stringifying, so rsky-pds now emits a conformant `blobs` field.
- `rsky-lexicon` bumped `0.10.3 -> 0.11.0` (public field type change); root `Cargo.toml` constraint and `Cargo.lock` updated.

## Tests (rsky-lexicon)

- `commit_decodes_blobs_encoded_as_cid_links` — hand-built DAG-CBOR body with two tag-42 links. **Fails on `main`** with the exact production error `Mismatch { expect_major: 3, byte: 216 }`; passes here.
- `commit_decodes_blobs_encoded_as_text_strings` — the rsky-pds legacy encoding still decodes.
- `commit_decodes_missing_blobs_as_empty` — `#[serde(default)]` (also failed on `main`: `missing field 'blobs'`).
- `commit_round_trips_blobs_as_cid_links` — serializes two blobs, asserts the `D8 2A 58 <len> 00 <cid>` byte sequence is present for each and that the value re-reads as `Ipld::Link`, then round-trips equal.

## Verification

- `cargo test -p rsky-lexicon` — 57 passed
- `cargo check --all-targets -p rsky-pds -p rsky-relay -p rsky-firehose -p rsky-wintermute -p rsky-jetstream-subscriber -p rsky-labeler` — clean
- `cargo clippy -p rsky-lexicon --all-targets` — only the 4 pre-existing `large_enum_variant` warnings, none in changed code
- `cargo fmt --all -- --check` — clean

Note: `rsky-relay` has its own `validator::event::SubscribeReposCommit` with `blobs: Vec<String>` (marked deprecated); it is not touched here and likely has the same latent decode failure — worth a follow-up.

Commits are unsigned (GPG pinentry unavailable in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
