### PR TITLE
fix(wintermute): drop stale live replays of commits before enqueue

### DIFF
--- a/rsky-wintermute/README.md
+++ b/rsky-wintermute/README.md
@@ -216,6 +216,7 @@ Prometheus metrics are exposed at `http://localhost:9090/metrics`:
 - `ingester_sync11_commits_total{outcome}` - Live `#commit` frames checked against stored sync state: `applied`, `first_seen`, `stale`, `lax`, `desync`, `no_data`
 - `ingester_sync11_sync_events_total{outcome}` - Live `#sync` frames: `resync` or `unchanged`
 - `ingester_sync11_resyncs_requested_total{reason}` - Repos handed to backfill for a full resync: `prev_mismatch` or `sync_event`
+- `ingester_live_commits_dropped_total{reason}` - Live `#commit` frames dropped whole before enqueue: `stale_replay` (the rev does not advance what the sync 1.1 tracker holds for the repo)
 - `ingester_identity_tasks_in_flight` - Identity/account/sync tasks running (bounded by `IDENTITY_EVENT_CONCURRENCY`)
 - `ingester_identity_task_timeouts_total{kind}` / `ingester_identity_tasks_shed_total{kind}` - Tasks abandoned at the deadline; events dropped because every permit was busy
 - `wintermute_rss_bytes` / `wintermute_rss_peak_bytes` - Resident set size and its high-water mark (Linux; 0 elsewhere)
@@ -269,6 +270,8 @@ A `#sync` frame means the repo's MST was rewritten upstream: unless its commit m
 A resync is a row in `backfill_state.sqlite` set back to `pending` with `indexed_rev` cleared (`last_error` says `resync: prev_mismatch` or `resync: sync_event`); the backfill runner's next tick fetches the whole repo through whichever source owns it. With `BACKFILL_MODE=off` requests are still recorded and are fetched once backfill is enabled; the first such request is logged at `info`.
 
 Cost on the live path: the check runs in a single tracker task behind a bounded channel, with a bounded in-memory cache (two generations of 150k repos) in front of `repo_sync`. Postgres is read only on cache miss, one query per drained batch, and written once a second as one `unnest` upsert per repo touched in that second.
+
+Stale replays are dropped before they reach the queue, not just left unrecorded: with several `RELAY_HOSTS` a relay running hours behind re-delivers commits the others already carried, so the firehose loop checks every `#commit` against the tracker's cache (shared with it as a synchronous read-only view) and, when the rev does not advance what is held, enqueues none of its creates, updates or deletes and counts it in `ingester_live_commits_dropped_total{reason="stale_replay"}`; the indexer's per-row rev gate cannot do this for a record deleted in between, because there is no row left to gate on. The gate is only as warm as the cache: a repo not seen since the process started passes its first commit through (the tracker then loads its `repo_sync` row and catches the next replay), as does a replay arriving within the tracker's channel lag of the original.
 
 ### Handle Resolution
 

--- a/rsky-wintermute/src/bin/label_sync.rs
+++ b/rsky-wintermute/src/bin/label_sync.rs
@@ -179,11 +179,7 @@ async fn sync_labeler(
 
                     if total_events.is_multiple_of(10000) {
                         let elapsed = start.elapsed().as_secs();
-                        let rate = if elapsed > 0 {
-                            total_events / elapsed
-                        } else {
-                            0
-                        };
+                        let rate = total_events.checked_div(elapsed).unwrap_or(0);
                         println!(
                             "[{labeler_host}] seq={last_seq} events={total_events} \
                              negations={total_negations_applied} skipped={total_skipped} \

--- a/rsky-wintermute/src/bin/plc_import.rs
+++ b/rsky-wintermute/src/bin/plc_import.rs
@@ -321,11 +321,7 @@ async fn main() -> Result<()> {
         // Log progress every 100 pages
         if page_count.is_multiple_of(100) {
             let elapsed = start.elapsed().as_secs();
-            let rate = if elapsed > 0 {
-                total_operations / elapsed
-            } else {
-                0
-            };
+            let rate = total_operations.checked_div(elapsed).unwrap_or(0);
             info!(
                 page_count,
                 total_operations,

--- a/rsky-wintermute/src/ingester/mod.rs
+++ b/rsky-wintermute/src/ingester/mod.rs
@@ -39,6 +39,15 @@ pub enum ParseResult {
     FutureCursor,
 }
 
+/// What became of a live `#commit` offered to the fjall queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LiveCommit {
+    /// Its jobs are durable in fjall and the sync 1.1 tracker has been told.
+    Enqueued,
+    /// A stale replay: nothing was enqueued and the tracker was not told.
+    DroppedStale,
+}
+
 pub struct IngesterManager {
     workers: usize,
     relay_hosts: Vec<String>,
@@ -559,31 +568,9 @@ impl IngesterManager {
 
                 // Queue to Fjall so live intake never blocks on indexing speed; the
                 // firehose_live processor loop consumes and indexes from the queue.
-                let sync11_msg = Msg::from_event(&event, &sync11_host);
-                match Self::parse_event_to_jobs(&event).await {
-                    Ok(jobs) => {
-                        for job in jobs {
-                            if let Err(e) = storage.enqueue_firehose_live(&job) {
-                                tracing::error!("failed to enqueue firehose_live job: {e}");
-                                metrics::INGESTER_ERRORS_TOTAL
-                                    .with_label_values(&["enqueue_failed"])
-                                    .inc();
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!("failed to parse event seq={} to jobs: {e}", event.seq);
-                        metrics::INGESTER_ERRORS_TOTAL
-                            .with_label_values(&["parse_failed"])
-                            .inc();
-                    }
-                }
-
-                // Only after the jobs are durable in fjall: the tracker's
-                // stored state must never run ahead of what will be indexed.
-                if let Some(msg) = sync11_msg {
-                    sync11.send(msg).await;
-                }
+                // A commit that replays a rev the tracker already holds is
+                // dropped whole instead.
+                Self::enqueue_live_commit(storage, &event, sync11, &sync11_host).await;
 
                 // Atomically update last_seq (cheap, lock-free operation)
                 // The cursor_saver_task will persist this to postgres on interval
@@ -785,6 +772,74 @@ impl IngesterManager {
         };
 
         Ok(ParseResult::Event(event))
+    }
+
+    /// Queue a live `#commit`'s jobs to fjall, then tell the sync 1.1 tracker.
+    ///
+    /// The stale-replay gate runs first, before the CAR is even parsed: when
+    /// the tracker already holds a rev for this repo that the commit does not
+    /// advance, the frame is a replay (in production, a second relay hours
+    /// behind the first re-delivering commits it already carried) and every
+    /// one of its ops is dropped. It has to happen *before* enqueue because
+    /// the indexer's own rev gate can only protect rows that exist: a record
+    /// deleted since the original commit has no row left, so a late create
+    /// would re-insert it. A dropped commit is not sent to the tracker either;
+    /// it would only be judged `stale` again.
+    ///
+    /// The gate is exactly as warm as the tracker's cache (see
+    /// [`sync11::KnownRevs`]): a repo not seen since the process started
+    /// passes, and the tracker then loads its row so the next replay is
+    /// caught. Non-commit frames never reach this function.
+    pub(crate) async fn enqueue_live_commit(
+        storage: &Storage,
+        event: &FirehoseEvent,
+        sync11: &Sync11Handle,
+        host: &Arc<str>,
+    ) -> LiveCommit {
+        if event.kind == "commit"
+            && let Some(commit) = &event.commit
+            && sync11.is_stale_replay(&event.did, &commit.rev)
+        {
+            crate::metrics::INGESTER_LIVE_COMMITS_DROPPED_TOTAL
+                .with_label_values(&["stale_replay"])
+                .inc();
+            tracing::debug!(
+                did = %event.did,
+                rev = %commit.rev,
+                seq = event.seq,
+                host = %host,
+                ops = commit.ops.len(),
+                "live: dropped stale replay of a commit"
+            );
+            return LiveCommit::DroppedStale;
+        }
+
+        let sync11_msg = Msg::from_event(event, host);
+        match Self::parse_event_to_jobs(event).await {
+            Ok(jobs) => {
+                for job in jobs {
+                    if let Err(e) = storage.enqueue_firehose_live(&job) {
+                        tracing::error!("failed to enqueue firehose_live job: {e}");
+                        crate::metrics::INGESTER_ERRORS_TOTAL
+                            .with_label_values(&["enqueue_failed"])
+                            .inc();
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!("failed to parse event seq={} to jobs: {e}", event.seq);
+                crate::metrics::INGESTER_ERRORS_TOTAL
+                    .with_label_values(&["parse_failed"])
+                    .inc();
+            }
+        }
+
+        // Only after the jobs are durable in fjall: the tracker's stored
+        // state must never run ahead of what will be indexed.
+        if let Some(msg) = sync11_msg {
+            sync11.send(msg).await;
+        }
+        LiveCommit::Enqueued
     }
 
     /// Parse a `FirehoseEvent` into `IndexJob`s for inline processing (skipping Fjall queue)

--- a/rsky-wintermute/src/ingester/sync11.rs
+++ b/rsky-wintermute/src/ingester/sync11.rs
@@ -22,12 +22,18 @@
 //! repo. "Observed" rather than "indexed": the record jobs are already durable
 //! in the fjall queue by the time a frame is recorded here, which is the same
 //! guarantee the firehose cursor gives.
+//!
+//! The tracker's cache doubles as the live path's stale-replay gate: it is
+//! shared with every [`Sync11Handle`] as [`KnownRevs`], so the firehose loop
+//! can ask, synchronously and without a Postgres round-trip, whether a
+//! commit's `rev` is already behind what we hold and drop it before anything
+//! is enqueued. See [`KnownRevs`] for the cold-cache caveat.
 
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::Duration;
 
 use deadpool_postgres::Pool;
@@ -182,6 +188,16 @@ pub fn rev_newer(rev: &str, stored: &str) -> bool {
     }
 }
 
+/// The live path's stale-replay gate, as a pure function.
+///
+/// A commit is a stale replay when we already hold a rev for the repo and
+/// the commit's `rev` is not newer than it. An unknown repo (`known == None`)
+/// always passes; the tracker will judge it with the full [`decide`] step.
+#[must_use]
+pub fn is_stale_replay(known: Option<&str>, rev: &str) -> bool {
+    known.is_some_and(|k| !rev_newer(rev, k))
+}
+
 /// The sync 1.1 inductive step, as a pure function of `(stored, frame)`.
 ///
 /// 1. nothing stored: `FirstSeen` (or `NoData` if there is nothing to store);
@@ -281,13 +297,19 @@ pub struct Sync11Config {
     pub backfill_enabled: bool,
 }
 
-/// Sending side of the tracker channel. Cheap to clone; one per connection.
+/// Sending side of the tracker channel plus a read-only view of the tracker's
+/// cache. Cheap to clone; one per connection.
 #[derive(Clone)]
 pub struct Sync11Handle {
     tx: mpsc::Sender<Msg>,
+    revs: KnownRevs,
 }
 
 impl Sync11Handle {
+    pub(crate) const fn new(tx: mpsc::Sender<Msg>, revs: KnownRevs) -> Self {
+        Self { tx, revs }
+    }
+
     /// Waits when the channel is full: the tracker is far cheaper than the
     /// CAR parse that precedes it, so this is backpressure, not a stall.
     pub async fn send(&self, msg: Msg) {
@@ -296,6 +318,20 @@ impl Sync11Handle {
                 .with_label_values(&["sync11_closed"])
                 .inc();
         }
+    }
+
+    /// Whether a `#commit` at `rev` for `did` is a replay of something we
+    /// already hold. Synchronous, one read lock, no allocation; see
+    /// [`KnownRevs`] for what "hold" covers and the cold-cache caveat.
+    #[must_use]
+    pub fn is_stale_replay(&self, did: &str, rev: &str) -> bool {
+        self.revs.is_stale_replay(did, rev)
+    }
+
+    /// The rev we hold for `did`, if any. For tests and diagnostics.
+    #[must_use]
+    pub fn known_rev(&self, did: &str) -> Option<String> {
+        self.revs.known_rev(did)
     }
 }
 
@@ -425,6 +461,14 @@ impl Cache {
         self.cur.get(did)
     }
 
+    /// Read without promoting, so a shared reader needs no write access.
+    fn peek_rev(&self, did: &str) -> Option<&str> {
+        self.cur
+            .get(did)
+            .or_else(|| self.prev.get(did))
+            .map(|s| s.rev.as_str())
+    }
+
     fn contains(&self, did: &str) -> bool {
         self.cur.contains_key(did) || self.prev.contains_key(did)
     }
@@ -447,6 +491,67 @@ impl Cache {
     }
 }
 
+/// The tracker's cache, shared read-only with the firehose loop so it can
+/// gate stale replays before enqueuing anything.
+///
+/// This *is* the tracker's [`Cache`], not a copy: every path that changes what
+/// the tracker holds (a recorded commit, a `repo_sync` batch load on cache
+/// miss, a forget on `#account` or `#sync`) is visible here the moment it
+/// happens, and the view is bounded by the cache's own two generations of
+/// [`CACHE_GENERATION_ENTRIES`]. The tracker takes the write lock for its own
+/// accesses; readers hold the read lock for one hash lookup and never wait on
+/// Postgres or the tracker task.
+///
+/// Cold-cache caveat: a repo the tracker has not touched since the process
+/// started (or that rotated out of the cache) has no entry here, so its next
+/// commit passes the gate even if it is a replay; the tracker then loads the
+/// persisted row and judges it `stale`, so the entry is present from then on.
+/// The gate therefore never drops anything newer than what we hold, but it
+/// cannot catch the first replay per repo after a restart. The same holds for
+/// a replay that arrives inside the tracker's channel lag behind the original.
+#[derive(Clone)]
+pub struct KnownRevs(Arc<RwLock<Cache>>);
+
+impl KnownRevs {
+    fn new(cap: usize) -> Self {
+        Self(Arc::new(RwLock::new(Cache::new(cap))))
+    }
+
+    /// A poisoned lock only means a panic elsewhere while it was held; the
+    /// map itself is still consistent (every mutation is a single insert or
+    /// remove), so keep serving it rather than take the ingester down.
+    fn read(&self) -> RwLockReadGuard<'_, Cache> {
+        self.0.read().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn write(&self) -> RwLockWriteGuard<'_, Cache> {
+        self.0.write().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// See [`is_stale_replay`]. One read lock, no allocation.
+    #[must_use]
+    pub fn is_stale_replay(&self, did: &str, rev: &str) -> bool {
+        is_stale_replay(self.read().peek_rev(did), rev)
+    }
+
+    /// The rev held for `did`, if any.
+    #[must_use]
+    pub fn known_rev(&self, did: &str) -> Option<String> {
+        self.read().peek_rev(did).map(str::to_owned)
+    }
+
+    /// Entries held.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.read().len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
 // ------------------------------------------------------------------- tracker
 
 enum Pending {
@@ -456,7 +561,7 @@ enum Pending {
 
 /// Per-repo live sync state: cache, pending writes, and the resync hand-off.
 pub struct Tracker {
-    cache: Cache,
+    cache: KnownRevs,
     pending: HashMap<String, Pending>,
     state: RepoStateStore,
     store: Arc<dyn SyncStore>,
@@ -468,13 +573,19 @@ impl Tracker {
     #[must_use]
     pub fn new(store: Arc<dyn SyncStore>, state: RepoStateStore, backfill_enabled: bool) -> Self {
         Self {
-            cache: Cache::new(CACHE_GENERATION_ENTRIES),
+            cache: KnownRevs::new(CACHE_GENERATION_ENTRIES),
             pending: HashMap::new(),
             state,
             store,
             backfill_enabled,
             warned_backfill_off: false,
         }
+    }
+
+    /// The shared read-only view of this tracker's cache, for the handles.
+    #[must_use]
+    pub fn revs(&self) -> KnownRevs {
+        self.cache.clone()
     }
 
     /// Entries held in memory. For tests and the occasional log line.
@@ -490,33 +601,33 @@ impl Tracker {
     }
 
     fn known(&self, did: &str) -> bool {
-        self.pending.contains_key(did) || self.cache.contains(did)
+        self.pending.contains_key(did) || self.cache.read().contains(did)
     }
 
-    fn lookup(&mut self, did: &str) -> Option<SyncState> {
+    fn lookup(&self, did: &str) -> Option<SyncState> {
         match self.pending.get(did) {
             Some(Pending::Upsert(state, _)) => return Some(state.clone()),
             Some(Pending::Delete) => return None,
             None => {}
         }
-        self.cache.get(did).cloned()
+        self.cache.write().get(did).cloned()
     }
 
     fn record(&mut self, did: &str, state: SyncState, host: &Arc<str>) {
-        self.cache.insert(did.to_owned(), state.clone());
+        self.cache.write().insert(did.to_owned(), state.clone());
         self.pending
             .insert(did.to_owned(), Pending::Upsert(state, Arc::clone(host)));
     }
 
     fn forget(&mut self, did: &str) {
-        self.cache.remove(did);
+        self.cache.write().remove(did);
         self.pending.insert(did.to_owned(), Pending::Delete);
     }
 
     /// Warm the cache for every repo in the batch we know nothing about, in
     /// one read. A failed read is logged and the repos are treated as unseen:
     /// the frame is recorded rather than dropped.
-    async fn prefetch(&mut self, msgs: &[Msg]) {
+    async fn prefetch(&self, msgs: &[Msg]) {
         let mut want: Vec<String> = Vec::new();
         let mut seen: HashSet<&str> = HashSet::new();
         for m in msgs {
@@ -533,8 +644,11 @@ impl Tracker {
         }
         match self.store.load(&want).await {
             Ok(rows) => {
+                // One lock for the whole batch; the loaded revs are visible
+                // to the live path's gate as soon as it is released.
+                let mut cache = self.cache.write();
                 for (did, state) in rows {
-                    self.cache.insert(did, state);
+                    cache.insert(did, state);
                 }
             }
             Err(e) => {
@@ -760,8 +874,9 @@ pub fn spawn(
 ) -> (Sync11Handle, JoinHandle<()>) {
     let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
     let tracker = Tracker::new(store, state, backfill_enabled);
+    let handle = Sync11Handle::new(tx, tracker.revs());
     let task = tokio::spawn(run(tracker, rx));
-    (Sync11Handle { tx }, task)
+    (handle, task)
 }
 
 async fn run(mut tracker: Tracker, mut rx: mpsc::Receiver<Msg>) {
@@ -792,11 +907,73 @@ async fn run(mut tracker: Tracker, mut rx: mpsc::Receiver<Msg>) {
     tracing::info!(cached = tracker.cached(), "sync11 tracker stopped");
 }
 
+/// In-memory [`SyncStore`] for tests in this module and in the ingester's.
+#[cfg(test)]
+pub(crate) mod testing {
+    use super::{BoxFut, SyncState, SyncStore, Upsert};
+    use crate::types::WintermuteError;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    pub struct MemStore {
+        pub rows: Mutex<HashMap<String, (SyncState, String)>>,
+        pub fail: Mutex<bool>,
+        pub loads: Mutex<usize>,
+    }
+
+    impl MemStore {
+        pub fn row(&self, did: &str) -> Option<SyncState> {
+            self.rows.lock().unwrap().get(did).map(|(s, _)| s.clone())
+        }
+    }
+
+    impl SyncStore for MemStore {
+        fn load<'a>(
+            &'a self,
+            dids: &'a [String],
+        ) -> BoxFut<'a, Result<Vec<(String, SyncState)>, WintermuteError>> {
+            Box::pin(async move {
+                *self.loads.lock().unwrap() += 1;
+                if *self.fail.lock().unwrap() {
+                    return Err(WintermuteError::Other("down".into()));
+                }
+                let rows = self.rows.lock().unwrap();
+                Ok(dids
+                    .iter()
+                    .filter_map(|d| rows.get(d).map(|(s, _)| (d.clone(), s.clone())))
+                    .collect())
+            })
+        }
+
+        fn flush<'a>(
+            &'a self,
+            upserts: &'a [Upsert],
+            deletes: &'a [String],
+        ) -> BoxFut<'a, Result<(), WintermuteError>> {
+            Box::pin(async move {
+                if *self.fail.lock().unwrap() {
+                    return Err(WintermuteError::Other("down".into()));
+                }
+                let mut rows = self.rows.lock().unwrap();
+                for (did, s, h) in upserts {
+                    rows.insert(did.clone(), (s.clone(), h.to_string()));
+                }
+                for did in deletes {
+                    rows.remove(did);
+                }
+                drop(rows);
+                Ok(())
+            })
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::testing::MemStore;
     use super::*;
     use crate::backfiller::state::HUBBLE_SOURCE;
-    use std::sync::Mutex;
 
     // ------------------------------------------------------------ fixtures
 
@@ -857,59 +1034,6 @@ mod tests {
         let root = rsky_common::ipld::cid_for_cbor(&commit).unwrap();
         let filler = serde_ipld_dagcbor::to_vec(&serde_json::json!({"x": 1})).unwrap();
         (car(Some(root), &[(root, bytes), (cid(200), filler)]), root)
-    }
-
-    #[derive(Default)]
-    struct MemStore {
-        rows: Mutex<HashMap<String, (SyncState, String)>>,
-        fail: Mutex<bool>,
-        loads: Mutex<usize>,
-    }
-
-    impl MemStore {
-        fn row(&self, did: &str) -> Option<SyncState> {
-            self.rows.lock().unwrap().get(did).map(|(s, _)| s.clone())
-        }
-    }
-
-    impl SyncStore for MemStore {
-        fn load<'a>(
-            &'a self,
-            dids: &'a [String],
-        ) -> BoxFut<'a, Result<Vec<(String, SyncState)>, WintermuteError>> {
-            Box::pin(async move {
-                *self.loads.lock().unwrap() += 1;
-                if *self.fail.lock().unwrap() {
-                    return Err(WintermuteError::Other("down".into()));
-                }
-                let rows = self.rows.lock().unwrap();
-                Ok(dids
-                    .iter()
-                    .filter_map(|d| rows.get(d).map(|(s, _)| (d.clone(), s.clone())))
-                    .collect())
-            })
-        }
-
-        fn flush<'a>(
-            &'a self,
-            upserts: &'a [Upsert],
-            deletes: &'a [String],
-        ) -> BoxFut<'a, Result<(), WintermuteError>> {
-            Box::pin(async move {
-                if *self.fail.lock().unwrap() {
-                    return Err(WintermuteError::Other("down".into()));
-                }
-                let mut rows = self.rows.lock().unwrap();
-                for (did, s, h) in upserts {
-                    rows.insert(did.clone(), (s.clone(), h.to_string()));
-                }
-                for did in deletes {
-                    rows.remove(did);
-                }
-                drop(rows);
-                Ok(())
-            })
-        }
     }
 
     fn tracker(store: &Arc<MemStore>, repo_state: &RepoStateStore) -> Tracker {
@@ -981,6 +1105,17 @@ mod tests {
         let s = state(R2, &a);
         assert_eq!(decide(Some(&s), R2, Some(&a), Some(&a)), Outcome::Stale);
         assert_eq!(decide(Some(&s), R1, Some(&z), None), Outcome::Stale);
+    }
+
+    #[test]
+    fn the_replay_gate_drops_equal_and_older_revs_and_passes_newer_or_unknown() {
+        assert!(!is_stale_replay(Some(R1), R2), "newer rev passes");
+        assert!(is_stale_replay(Some(R2), R2), "equal rev is a replay");
+        assert!(is_stale_replay(Some(R2), R1), "older rev is a replay");
+        assert!(!is_stale_replay(None, R1), "unknown repo passes");
+        // malformed revs are only ever judged by equality
+        assert!(is_stale_replay(Some("odd"), "odd"));
+        assert!(!is_stale_replay(Some("odd"), R1));
     }
 
     #[test]
@@ -1062,6 +1197,129 @@ mod tests {
         c.remove("a");
         assert!(!c.contains("a"));
         assert_eq!(c.len(), 1);
+    }
+
+    #[test]
+    fn cache_peek_reads_both_generations_without_promoting() {
+        let mut c = Cache::new(2);
+        c.insert("a".into(), state(R1, "x"));
+        c.insert("b".into(), state(R2, "y")); // rotates: both now in prev
+        assert_eq!(c.peek_rev("a"), Some(R1));
+        assert_eq!(c.peek_rev("b"), Some(R2));
+        assert_eq!(c.cur.len(), 0, "peek did not promote");
+        assert_eq!(c.peek_rev("z"), None);
+    }
+
+    // ----------------------------------------------------------- known revs
+
+    /// A handle wired to a tracker driven directly by the test, so the view
+    /// can be checked deterministically without the actor task.
+    fn handle_for(t: &Tracker) -> (Sync11Handle, mpsc::Receiver<Msg>) {
+        let (tx, rx) = mpsc::channel(8);
+        (Sync11Handle::new(tx, t.revs()), rx)
+    }
+
+    #[tokio::test]
+    async fn the_handle_sees_a_rev_once_the_tracker_records_it() {
+        let store = Arc::new(MemStore::default());
+        let rs = RepoStateStore::open_in_memory().unwrap();
+        let mut t = tracker(&store, &rs);
+        let (h, _rx) = handle_for(&t);
+
+        assert_eq!(h.known_rev("did:a"), None);
+        assert!(!h.is_stale_replay("did:a", R1), "cold: nothing to gate on");
+
+        t.handle(commit("did:a", R1, None, Some(&cid(1)))).await;
+        assert_eq!(h.known_rev("did:a").as_deref(), Some(R1));
+        assert!(h.is_stale_replay("did:a", R1));
+        assert!(!h.is_stale_replay("did:a", R2));
+
+        t.handle(commit("did:a", R2, Some(&cid(1)), Some(&cid(2))))
+            .await;
+        assert_eq!(h.known_rev("did:a").as_deref(), Some(R2));
+        assert!(h.is_stale_replay("did:a", R1));
+        assert!(h.is_stale_replay("did:a", R2));
+        assert!(!h.is_stale_replay("did:a", R3));
+
+        // a stale commit reaching the tracker anyway does not move the view
+        t.handle(commit("did:a", R1, Some(&cid(9)), Some(&cid(1))))
+            .await;
+        assert_eq!(h.known_rev("did:a").as_deref(), Some(R2));
+    }
+
+    #[tokio::test]
+    async fn the_handle_sees_revs_loaded_from_the_store_on_warm_up() {
+        let store = Arc::new(MemStore::default());
+        store.rows.lock().unwrap().insert(
+            "did:a".into(),
+            (state(R2, &cid(2).to_string()), "old".into()),
+        );
+        store.rows.lock().unwrap().insert(
+            "did:b".into(),
+            (state(R1, &cid(1).to_string()), "old".into()),
+        );
+        let rs = RepoStateStore::open_in_memory().unwrap();
+        let mut t = tracker(&store, &rs);
+        let (h, _rx) = handle_for(&t);
+        assert_eq!(h.known_rev("did:a"), None);
+
+        // A batch that only mentions did:a and did:b still warms both, even
+        // though the frame for did:a turns out to be stale.
+        t.handle_batch(vec![
+            commit("did:a", R1, Some(&cid(9)), Some(&cid(1))),
+            commit("did:b", R2, Some(&cid(1)), Some(&cid(2))),
+        ])
+        .await;
+        assert_eq!(
+            h.known_rev("did:a").as_deref(),
+            Some(R2),
+            "loaded, not advanced"
+        );
+        assert_eq!(
+            h.known_rev("did:b").as_deref(),
+            Some(R2),
+            "loaded, then advanced"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_handle_forgets_a_repo_the_tracker_forgets() {
+        let store = Arc::new(MemStore::default());
+        let rs = RepoStateStore::open_in_memory().unwrap();
+        let mut t = tracker(&store, &rs);
+        let (h, _rx) = handle_for(&t);
+        t.handle(commit("did:a", R1, None, Some(&cid(1)))).await;
+        assert!(h.is_stale_replay("did:a", R1));
+        t.handle(Msg::WriteOff {
+            did: "did:a".into(),
+            status: "deleted".into(),
+        })
+        .await;
+        assert_eq!(h.known_rev("did:a"), None);
+        assert!(!h.is_stale_replay("did:a", R1));
+        assert!(h.revs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn the_spawned_handle_shares_the_actor_tracker_view() {
+        let store = Arc::new(MemStore::default());
+        let rs = RepoStateStore::open_in_memory().unwrap();
+        let dyn_store: Arc<dyn SyncStore> = store.clone();
+        let (handle, task) = spawn(dyn_store, rs, false);
+        handle.send(commit("did:a", R2, None, Some(&cid(2)))).await;
+        // the actor is asynchronous: wait for it to have drained the message
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while handle.known_rev("did:a").is_none() {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "tracker never recorded"
+            );
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(handle.is_stale_replay("did:a", R1));
+        assert!(!handle.is_stale_replay("did:a", R3));
+        drop(handle);
+        task.await.unwrap();
     }
 
     // -------------------------------------------------------------- tracker

--- a/rsky-wintermute/src/ingester/tests.rs
+++ b/rsky-wintermute/src/ingester/tests.rs
@@ -1316,4 +1316,107 @@ mod ingester_tests {
             assert_eq!(parse_active_flag(""), None);
         }
     }
+
+    /// The production incident: a second relay, hours behind, re-delivers a
+    /// commit the first already carried. The replay must leave fjall
+    /// untouched (creates and deletes alike), not reach the tracker, and be
+    /// counted; a genuinely newer commit still goes through.
+    #[tokio::test]
+    async fn a_stale_replay_enqueues_nothing_and_is_counted() {
+        use crate::backfiller::state::RepoStateStore;
+        use crate::ingester::LiveCommit;
+        use crate::ingester::sync11::{Msg, Sync11Handle, SyncStore, Tracker, testing::MemStore};
+        use crate::metrics::INGESTER_LIVE_COMMITS_DROPPED_TOTAL;
+        use crate::types::RepoOp;
+
+        const R1: &str = "3lz7gd2xq5c2a";
+        const R2: &str = "3lz7gd2xq5c2b";
+        const R3: &str = "3lz7gd2xq5c2c";
+        const DID: &str = "did:plc:replay";
+        const CID: &str = "bafyreihzwnyumvubacqyflkxpsejegc6sxwkcaxv3iwm3lrn3x45gxkioa";
+
+        let (storage, _dir) = setup_test_storage();
+        let store: Arc<dyn SyncStore> = Arc::new(MemStore::default());
+        let rs = RepoStateStore::open_in_memory().unwrap();
+        // The tracker is driven by hand so the shared view is deterministic.
+        let mut tracker = Tracker::new(store, rs, false);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let handle = Sync11Handle::new(tx, tracker.revs());
+        let host: Arc<str> = Arc::from("relay.test");
+
+        let event = |seq: i64, rev: &str| FirehoseEvent {
+            seq,
+            did: DID.to_owned(),
+            time: "2024-01-01T00:00:00Z".to_owned(),
+            kind: "commit".to_owned(),
+            commit: Some(CommitData {
+                rev: rev.to_owned(),
+                ops: vec![
+                    RepoOp {
+                        action: "create".to_owned(),
+                        path: "app.bsky.feed.post/aaa".to_owned(),
+                        cid: Some(CID.to_owned()),
+                    },
+                    RepoOp {
+                        action: "delete".to_owned(),
+                        path: "app.bsky.feed.post/bbb".to_owned(),
+                        cid: None,
+                    },
+                ],
+                blocks: vec![],
+                since: None,
+                prev_data: None,
+                data: Some(CID.to_owned()),
+                too_big: false,
+            }),
+            identity: None,
+            account: None,
+        };
+        let dropped = || {
+            INGESTER_LIVE_COMMITS_DROPPED_TOTAL
+                .with_label_values(&["stale_replay"])
+                .get()
+        };
+        let before = dropped();
+
+        // Cold: nothing is known, so the commit goes through and the tracker
+        // is told only after its jobs are in fjall.
+        let out =
+            IngesterManager::enqueue_live_commit(&storage, &event(1, R2), &handle, &host).await;
+        assert_eq!(out, LiveCommit::Enqueued);
+        assert_eq!(storage.firehose_live_len().unwrap(), 2);
+        let msg = rx.try_recv().expect("the tracker was told");
+        assert!(matches!(msg, Msg::Commit { .. }));
+        tracker.handle(msg).await;
+        assert_eq!(handle.known_rev(DID).as_deref(), Some(R2));
+
+        // The same commit again, a day late from another relay.
+        let out =
+            IngesterManager::enqueue_live_commit(&storage, &event(2, R2), &handle, &host).await;
+        assert_eq!(out, LiveCommit::DroppedStale);
+        assert_eq!(
+            storage.firehose_live_len().unwrap(),
+            2,
+            "neither the create nor the delete was enqueued"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "the tracker is not told about a drop"
+        );
+
+        // An even older one.
+        let out =
+            IngesterManager::enqueue_live_commit(&storage, &event(3, R1), &handle, &host).await;
+        assert_eq!(out, LiveCommit::DroppedStale);
+        assert_eq!(storage.firehose_live_len().unwrap(), 2);
+        assert_eq!(dropped() - before, 2);
+
+        // A newer commit for the repo is not a replay.
+        let out =
+            IngesterManager::enqueue_live_commit(&storage, &event(4, R3), &handle, &host).await;
+        assert_eq!(out, LiveCommit::Enqueued);
+        assert_eq!(storage.firehose_live_len().unwrap(), 4);
+        assert!(rx.try_recv().is_ok());
+        assert_eq!(dropped() - before, 2);
+    }
 }

--- a/rsky-wintermute/src/metrics.rs
+++ b/rsky-wintermute/src/metrics.rs
@@ -149,6 +149,19 @@ pub static INGESTER_SYNC11_RESYNCS_REQUESTED_TOTAL: LazyLock<IntCounterVec> = La
     .unwrap()
 });
 
+/// Live `#commit` frames dropped whole before any job was enqueued, by reason.
+///
+/// `stale_replay`: the rev does not advance what the sync 1.1 tracker already
+/// holds for the repo; typically a second relay running behind the first.
+pub static INGESTER_LIVE_COMMITS_DROPPED_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "ingester_live_commits_dropped_total",
+        "Live #commit frames dropped before enqueue, by reason",
+        &["reason"]
+    )
+    .unwrap()
+});
+
 pub static INGESTER_ERRORS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     register_int_counter_vec!(
         "ingester_errors_total",


### PR DESCRIPTION
## Incident

Production wintermute subscribes to three relays at once (`RELAY_HOSTS=bsky.network,atproto.africa,blacksky.app`) with no cross-source dedupe, and atproto.africa runs ~37 h behind, so every commit carried by more than one relay was applied again a day or two late. The post upsert is rev-gated so existing rows survived, but a post the user had deleted in between had no row to gate on and the late create re-inserted it with its original rev (observed: deleted Sept 6, back on Sept 8 with a Sept 5 rev), and every `record` row got its `indexedAt` bumped by the replay.

## Design

The sync 1.1 tracker already judged these frames `stale` but only skipped advancing its own state; the jobs were still enqueued and indexed. This PR makes the tracker's existing two-generation cache the gate:

- **Where the gate sits.** `IngesterManager::enqueue_live_commit` (extracted from the live loop in `ingester/mod.rs`) consults `Sync11Handle::is_stale_replay(did, rev)` *before* the CAR is parsed and before anything is enqueued. When a rev is known for the DID and the commit's rev is not newer (`!rev_newer`), every op of the commit (creates, updates, deletes) is dropped, nothing goes to fjall, the tracker is not sent a message, `ingester_live_commits_dropped_total{reason="stale_replay"}` is incremented, and a `debug` line carries did/rev/seq/host. Non-stale commits follow the unchanged flow: enqueue to fjall, then tell the tracker.
- **Why before enqueue.** The indexer's per-row rev gate can only protect rows that exist; a deleted record has no row, so a late create simply re-inserts it. The commit has to be refused as a whole, upstream of the queue.
- **The shared view.** Rather than a second mirror map, the tracker's `Cache` itself now lives behind `Arc<RwLock<Cache>>` (`sync11::KnownRevs`), shared with every `Sync11Handle`. The ingester does one read-locked, non-promoting hash lookup (`Cache::peek_rev`), no allocation, no Postgres, no await on the tracker task. Because it *is* the cache, it is bounded to exactly the cache's budget (2 x 150k entries) and is updated by every path that changes what the tracker holds: a recorded commit, the batch `repo_sync` warm-up load on cache miss, and a forget on `#account` write-off or `#sync`. The tracker pays one uncontended lock acquire per cache op; no extra memory.
- **Cold-cache caveat** (documented on `KnownRevs` and `enqueue_live_commit`, and in the README). A repo the tracker has not touched since the process started (or that rotated out of the cache) has no entry, so its next commit passes even if it is a replay; the tracker then loads the persisted row and judges it `stale`, and the entry is present from then on. The gate therefore never drops anything newer than what we hold, but it cannot catch the first replay per repo after a restart, nor a replay that lands inside the tracker's channel lag behind the original.
- `#identity`, `#account` and `#sync` frames are not gated.

## Metric

`ingester_live_commits_dropped_total{reason="stale_replay"}` (added in `metrics.rs`; documented in the README metrics list and the sync 1.1 section).

## Tests

- `sync11`: pure gate (`is_stale_replay`): newer passes, equal dropped, older dropped, unknown DID passes, malformed revs by equality; `Cache::peek_rev` reads both generations without promoting; the handle's view updates when the tracker records a commit (and not on a stale one), when the batch warm-up loads rows from the in-memory `MemStore`, and clears on write-off; a `spawn`ed handle shares the actor's view.
- `ingester`: `a_stale_replay_enqueues_nothing_and_is_counted` drives a real fjall `Storage` and a hand-driven `Tracker` sharing a handle: the first commit enqueues 2 jobs and the tracker is told; the same commit again (and an older one) enqueues nothing, sends nothing to the tracker, and bumps the counter by exactly 2; a newer commit enqueues again.
- `MemStore` moved to `sync11::testing` (`#[cfg(test)]`) so the ingester test can use it.

`cargo fmt --all -- --check`: clean. `cargo clippy -p rsky-wintermute --all-targets`: zero diagnostics for the crate (this also clears two pre-existing `manual_checked_ops` warnings in the `plc_import` and `label_sync` bins). `cargo test -p rsky-wintermute`: 220 passed, 2 ignored, 31 failed; the 31 are the pre-existing Postgres-backed indexer/ingester tests that need a migrated DB and are unrelated to this change.

Commits are unsigned (GPG pinentry unavailable in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
