### PR TITLE
fix(wintermute): bound backfill shutdown by a grace budget and claim resync rows first

### DIFF
--- a/rsky-wintermute/README.md
+++ b/rsky-wintermute/README.md
@@ -132,6 +132,7 @@ Resident memory is exported as `wintermute_rss_bytes` / `wintermute_rss_peak_byt
 | `BACKFILL_FETCH_TIMEOUT_SECS` | `300` | Whole-request timeout per archive |
 | `BACKFILL_REENUMERATE_SECS` | `0` | Re-run enumeration this long after a pass completes; `0` enumerates once and then only drains |
 | `BACKFILL_WORKER_THREADS` | CPUs | Tokio threads for the backfill runtime |
+| `BACKFILL_SHUTDOWN_GRACE_SECS` | `20` | On stop, how long in-flight fetches and uncommitted writes may finish before they are abandoned to the claimed-row recovery on the next start; keep it under the unit's `TimeoutStopSec` |
 | `MIMALLOC_PURGE_DELAY` | (allocator default) | Set to `0` on memory-tight hosts so freed whale-repo allocations return to the OS promptly; the backfill CLI and daemon both use mimalloc |
 
 ## Utilities
@@ -172,7 +173,7 @@ BACKFILL_SINK=null ./target/release/backfill drain
 |-------|---------|
 | `firehose_live` (fjall) | Live records awaiting indexing |
 | `label_live` (fjall) | Labels awaiting indexing |
-| `backfill_state.sqlite` | Backfill: per-repo `source`, listed `rev`, `indexed_rev`, state, attempts, cooldown; per-host enumeration cursor, list state, adaptive concurrency floor, cooldown |
+| `backfill_state.sqlite` | Backfill: per-repo `source`, listed `rev`, `indexed_rev`, state, attempts, cooldown, resync priority; per-host enumeration cursor, list state, adaptive concurrency floor, cooldown |
 | `repo_sync` (PostgreSQL) | Live sync 1.1 state: per-repo `rev` and `data_cid` (MST root) of the last commit seen on the firehose, plus the relay `host`. Created by `migrations/create_repo_sync.sql` |
 
 Backfill has no record queue: parsed repos go to the COPY writers through a bounded channel, and fetch workers only claim work while that channel has room.
@@ -267,7 +268,7 @@ Every `#commit` frame from a sync 1.1 host carries `prevData`, the MST root of t
 
 A `#sync` frame means the repo's MST was rewritten upstream: unless its commit matches what is stored exactly, a resync is requested and the new root recorded. An `#account` frame taking a repo out of service (`deleted`, `takendown`, `deactivated`, `suspended`) writes the repo off in the backfill state store so no fetch is spent on it, and drops its sync state.
 
-A resync is a row in `backfill_state.sqlite` set back to `pending` with `indexed_rev` cleared (`last_error` says `resync: prev_mismatch` or `resync: sync_event`); the backfill runner's next tick fetches the whole repo through whichever source owns it. With `BACKFILL_MODE=off` requests are still recorded and are fetched once backfill is enabled; the first such request is logged at `info`.
+A resync is a row in `backfill_state.sqlite` set back to `pending` with `indexed_rev` cleared (`last_error` says `resync: prev_mismatch` or `resync: sync_event`); the backfill runner's next tick fetches the whole repo through whichever source owns it. Resync requests carry `priority = 1` and are claimed ahead of every enumerated repo for their source, so a repo the firehose has proved out of sync is fetched next rather than queued behind millions of pending rows. With `BACKFILL_MODE=off` requests are still recorded and are fetched once backfill is enabled; the first such request is logged at `info`.
 
 Cost on the live path: the check runs in a single tracker task behind a bounded channel, with a bounded in-memory cache (two generations of 150k repos) in front of `repo_sync`. Postgres is read only on cache miss, one query per drained batch, and written once a second as one `unnest` upsert per repo touched in that second.
 
@@ -281,7 +282,7 @@ Handles are resolved asynchronously after initial indexing. Actors with NULL han
 
 On SIGTERM or SIGINT, wintermute:
 1. Stops accepting new events
-2. Drains all in-flight work
+2. Drains all in-flight work; the backfill gives in-flight fetches and uncommitted writes `BACKFILL_SHUTDOWN_GRACE_SECS` (default 20 s) to land, then aborts what is left -- those repos stay claimed and are re-fetched on the next start
 3. Saves cursor positions
 4. Exits cleanly
 

--- a/rsky-wintermute/src/backfiller/mod.rs
+++ b/rsky-wintermute/src/backfiller/mod.rs
@@ -35,7 +35,7 @@ use std::io::Cursor;
 use std::num::NonZeroU32;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use iroh_car::CarReader;
@@ -47,7 +47,7 @@ use crate::SHUTDOWN;
 use crate::types::{IndexJob, WintermuteError, WriteAction};
 use host::{HostLimits, HostPolicy, Hostname};
 use hubble::HubbleConfig;
-use runner::{Runner, RunnerConfig};
+use runner::{Runner, RunnerConfig, RunnerError, wait_for_shutdown};
 use sink::{NullSink, PgSink, PgSinkConfig, RecordSink};
 use source::{FetchLimits, RepoBody};
 use state::RepoStateStore;
@@ -289,6 +289,9 @@ pub struct BackfillConfig {
     /// Tokio worker threads for the backfill runtime.
     pub worker_threads: usize,
     pub user_agent: String,
+    /// How long a stop may spend finishing in-flight fetches and commits
+    /// before the rest is abandoned to the claimed-row recovery on restart.
+    pub shutdown_grace: Duration,
 }
 
 fn env_or<T: std::str::FromStr>(name: &str, default: T) -> T {
@@ -419,6 +422,7 @@ impl BackfillConfig {
             reenumerate_after: (reenumerate > 0).then(|| Duration::from_secs(reenumerate)),
             worker_threads: env_or("BACKFILL_WORKER_THREADS", num_cpus::get().max(2)),
             user_agent,
+            shutdown_grace: Duration::from_secs(env_or("BACKFILL_SHUTDOWN_GRACE_SECS", 20)),
         }
     }
 
@@ -437,6 +441,7 @@ impl BackfillConfig {
             reenumerate_after: self.reenumerate_after,
             user_agent: self.user_agent.clone(),
             dry_run: self.sink == SinkKind::Null,
+            shutdown_grace: self.shutdown_grace,
             ..RunnerConfig::default()
         }
     }
@@ -503,11 +508,7 @@ impl BackfillManager {
                         Arc::clone(&sink),
                         state,
                     )?);
-                    let result = runner.run().await;
-                    if let Some(sink) = Arc::into_inner(sink) {
-                        sink.finish().await;
-                    }
-                    result
+                    run_and_finish(&runner, sink.as_ref()).await
                 }
                 SinkKind::Null => {
                     let sink = Arc::new(NullSink::default());
@@ -516,7 +517,7 @@ impl BackfillManager {
                         Arc::clone(&sink),
                         state,
                     )?);
-                    let result = runner.run().await;
+                    let result = run_and_finish(&runner, sink.as_ref()).await;
                     tracing::info!(
                         repos = sink.repos.load(Ordering::Relaxed),
                         records = sink.records.load(Ordering::Relaxed),
@@ -528,6 +529,53 @@ impl BackfillManager {
         })
         .map_err(|e| WintermuteError::Other(format!("backfill: {e}")))
     }
+}
+
+/// Run the runner until it is done or stopped, then drain the sink -- fully
+/// on a normal completion, within what is left of the shutdown grace budget
+/// on a stop.
+pub async fn run_and_finish<K: RecordSink>(
+    runner: &Arc<Runner<K>>,
+    sink: &K,
+) -> Result<(), RunnerError> {
+    let result = Arc::clone(runner).run().await;
+    finish_sink(
+        sink,
+        runner.config().shutdown,
+        runner.shutdown_grace_remaining(),
+    )
+    .await;
+    result
+}
+
+/// Drain `sink`, unbounded until a stop is requested and then within `grace`.
+///
+/// A drain that ran to idle must commit everything it fetched, so nothing is
+/// given up while `shutdown` is clear; the budget counts from the moment it is
+/// set. On timeout what is uncommitted is
+/// abandoned: the writers are stopped, and the repos concerned stay claimed
+/// (or return to pending) so the next start re-fetches them. Returns whether
+/// everything committed.
+pub async fn finish_sink<K: RecordSink>(sink: &K, shutdown: &AtomicBool, grace: Duration) -> bool {
+    let finish = sink.finish();
+    tokio::pin!(finish);
+    tokio::select! {
+        () = &mut finish => return true,
+        () = wait_for_shutdown(shutdown) => {}
+    }
+    if tokio::time::timeout(grace, &mut finish).await.is_ok() {
+        return true;
+    }
+    let (repos, records) = sink.uncommitted();
+    tracing::warn!(
+        repos,
+        records,
+        grace_secs = grace.as_secs(),
+        "backfill shutdown: the sink did not drain within the grace budget; abandoning \
+         uncommitted records -- their repos stay claimed and are re-fetched on restart"
+    );
+    sink.abandon().await;
+    false
 }
 
 /// Sample state-store gauges. Called by the runner's progress ticker.
@@ -587,6 +635,8 @@ mod tests {
         assert_eq!(rc.hubble.is_some(), cfg.mode.uses_hubble());
         assert_eq!(rc.direct, cfg.mode.uses_direct());
         assert_eq!(rc.dry_run, cfg.sink == SinkKind::Null);
+        assert_eq!(cfg.shutdown_grace, Duration::from_secs(20));
+        assert_eq!(rc.shutdown_grace, cfg.shutdown_grace);
 
         let cfg = BackfillConfig::from_env(&["https://relay.example/".to_owned()]);
         assert_eq!(cfg.relay_url.as_deref(), Some("https://relay.example/"));
@@ -634,6 +684,107 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, WintermuteError::Repo(_)));
+    }
+
+    /// A sink whose drain never completes and remembers being abandoned.
+    #[derive(Default)]
+    struct StuckSink {
+        abandoned: AtomicBool,
+    }
+
+    impl RecordSink for StuckSink {
+        fn has_capacity(&self) -> bool {
+            true
+        }
+        fn ingest(
+            &self,
+            _did: &str,
+            _body: RepoBody,
+        ) -> impl Future<Output = Result<sink::Receipt, WintermuteError>> + Send {
+            std::future::ready(Err(WintermuteError::Other("unused".into())))
+        }
+        async fn finish(&self) {
+            std::future::pending::<()>().await;
+        }
+        fn uncommitted(&self) -> (usize, usize) {
+            (3, 4200)
+        }
+        async fn abandon(&self) {
+            self.abandoned.store(true, Ordering::Relaxed);
+        }
+    }
+
+    #[tokio::test]
+    async fn a_sink_that_never_drains_is_abandoned_once_the_grace_budget_is_spent() {
+        static FLAG: AtomicBool = AtomicBool::new(true);
+        static LATE: AtomicBool = AtomicBool::new(false);
+        let sink = StuckSink::default();
+        let started = std::time::Instant::now();
+        let drained = finish_sink(&sink, &FLAG, Duration::from_millis(200)).await;
+        assert!(!drained);
+        assert!(sink.abandoned.load(Ordering::Relaxed));
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "{:?}",
+            started.elapsed()
+        );
+
+        // Without a stop the drain is unbounded; with a stop arriving midway
+        // the budget counts from then.
+        let sink = StuckSink::default();
+        let started = std::time::Instant::now();
+        let stop = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            LATE.store(true, Ordering::Relaxed);
+        });
+        let drained = finish_sink(&sink, &LATE, Duration::from_millis(100)).await;
+        stop.await.unwrap();
+        assert!(!drained);
+        let took = started.elapsed();
+        assert!(
+            took >= Duration::from_millis(300) && took < Duration::from_secs(3),
+            "{took:?}"
+        );
+
+        // A sink that drains at once is never abandoned.
+        let sink = NullSink::default();
+        assert!(finish_sink(&sink, &FLAG, Duration::ZERO).await);
+    }
+
+    #[tokio::test]
+    async fn a_stopped_runner_finishes_within_the_grace_budget_even_if_the_sink_hangs() {
+        static FLAG: AtomicBool = AtomicBool::new(true);
+        let sink = Arc::new(StuckSink::default());
+        let cfg = RunnerConfig {
+            hubble: None,
+            direct: true,
+            shutdown: &FLAG,
+            shutdown_grace: Duration::from_millis(300),
+            ..RunnerConfig::default()
+        };
+        let runner = Arc::new(
+            Runner::new(
+                cfg,
+                Arc::clone(&sink),
+                RepoStateStore::open_in_memory().unwrap(),
+            )
+            .unwrap(),
+        );
+        let started = std::time::Instant::now();
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            run_and_finish(&runner, sink.as_ref()),
+        )
+        .await
+        .expect("shutdown is bounded")
+        .unwrap();
+        assert!(sink.abandoned.load(Ordering::Relaxed));
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "{:?}",
+            started.elapsed()
+        );
+        assert!(runner.shutting_down());
     }
 
     #[test]

--- a/rsky-wintermute/src/backfiller/mod.rs
+++ b/rsky-wintermute/src/backfiller/mod.rs
@@ -494,7 +494,7 @@ impl BackfillManager {
 
         let state = self.state.clone();
 
-        rt.block_on(async {
+        let result = rt.block_on(async {
             match self.cfg.sink {
                 SinkKind::Postgres => {
                     let pool = crate::config::create_pg_pool(
@@ -508,7 +508,7 @@ impl BackfillManager {
                         Arc::clone(&sink),
                         state,
                     )?);
-                    run_and_finish(&runner, sink.as_ref()).await
+                    run_bounded(&runner, sink.as_ref(), SHUTDOWN_SLACK).await
                 }
                 SinkKind::Null => {
                     let sink = Arc::new(NullSink::default());
@@ -517,7 +517,7 @@ impl BackfillManager {
                         Arc::clone(&sink),
                         state,
                     )?);
-                    let result = run_and_finish(&runner, sink.as_ref()).await;
+                    let result = run_bounded(&runner, sink.as_ref(), SHUTDOWN_SLACK).await;
                     tracing::info!(
                         repos = sink.repos.load(Ordering::Relaxed),
                         records = sink.records.load(Ordering::Relaxed),
@@ -526,8 +526,74 @@ impl BackfillManager {
                     result
                 }
             }
-        })
-        .map_err(|e| WintermuteError::Other(format!("backfill: {e}")))
+        });
+        // A blocking task (sqlite, a CAR parse) cannot be cancelled; do not
+        // let one hold this thread past the budget either.
+        rt.shutdown_timeout(RUNTIME_SHUTDOWN_TIMEOUT);
+        result.map_err(|e| WintermuteError::Other(format!("backfill: {e}")))
+    }
+}
+
+/// Added to the grace budget for the outer bound on the whole stop path, so
+/// the bound fires only after the runner and sink have had their full budget.
+pub const SHUTDOWN_SLACK: Duration = Duration::from_secs(5);
+
+/// How long the backfill runtime waits for blocking tasks once its future has
+/// returned.
+const RUNTIME_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Where the stop path is, for the warning when the outer bound is hit.
+#[derive(Debug, Default)]
+pub struct StopPhase(std::sync::Mutex<&'static str>);
+
+impl StopPhase {
+    fn set(&self, phase: &'static str) {
+        *self
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = phase;
+    }
+
+    #[must_use]
+    pub fn get(&self) -> &'static str {
+        *self
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+/// [`run_and_finish`] under an outer bound on the whole stop path.
+///
+/// Once `shutdown` is observed, everything that remains -- worker join, sink
+/// drain, sink abandon, every drop in between -- gets the grace budget plus
+/// `slack`, after which it is given up on with a warning saying where it was
+/// stuck. Nothing awaited after the runner returns can hold the thread past
+/// that.
+pub async fn run_bounded<K: RecordSink>(
+    runner: &Arc<Runner<K>>,
+    sink: &K,
+    slack: Duration,
+) -> Result<(), RunnerError> {
+    let shutdown = runner.config().shutdown;
+    let grace = runner.config().shutdown_grace;
+    let phase = StopPhase::default();
+    let bound = async {
+        wait_for_shutdown(shutdown).await;
+        tokio::time::sleep(grace.saturating_add(slack)).await;
+    };
+    tokio::select! {
+        result = run_and_finish_in(runner, sink, &phase) => result,
+        () = bound => {
+            tracing::warn!(
+                phase = phase.get(),
+                grace_secs = grace.as_secs(),
+                slack_secs = slack.as_secs(),
+                "backfill shutdown: still pending past the grace budget plus slack; \
+                 giving up on it -- claimed repos are recovered on restart"
+            );
+            Ok(())
+        }
     }
 }
 
@@ -538,13 +604,24 @@ pub async fn run_and_finish<K: RecordSink>(
     runner: &Arc<Runner<K>>,
     sink: &K,
 ) -> Result<(), RunnerError> {
+    run_and_finish_in(runner, sink, &StopPhase::default()).await
+}
+
+async fn run_and_finish_in<K: RecordSink>(
+    runner: &Arc<Runner<K>>,
+    sink: &K,
+    phase: &StopPhase,
+) -> Result<(), RunnerError> {
+    phase.set("runner");
     let result = Arc::clone(runner).run().await;
-    finish_sink(
+    finish_sink_in(
         sink,
         runner.config().shutdown,
         runner.shutdown_grace_remaining(),
+        phase,
     )
     .await;
+    phase.set("done");
     result
 }
 
@@ -557,15 +634,34 @@ pub async fn run_and_finish<K: RecordSink>(
 /// (or return to pending) so the next start re-fetches them. Returns whether
 /// everything committed.
 pub async fn finish_sink<K: RecordSink>(sink: &K, shutdown: &AtomicBool, grace: Duration) -> bool {
-    let finish = sink.finish();
-    tokio::pin!(finish);
-    tokio::select! {
-        () = &mut finish => return true,
-        () = wait_for_shutdown(shutdown) => {}
-    }
-    if tokio::time::timeout(grace, &mut finish).await.is_ok() {
+    finish_sink_in(sink, shutdown, grace, &StopPhase::default()).await
+}
+
+async fn finish_sink_in<K: RecordSink>(
+    sink: &K,
+    shutdown: &AtomicBool,
+    grace: Duration,
+    phase: &StopPhase,
+) -> bool {
+    phase.set("sink drain");
+    // The finish future lives in this block and is dropped with it. That is
+    // load-bearing: a timed-out `timeout(grace, &mut finish)` drops only the
+    // timeout, and a `PgSink::finish` parked on a mid-batch writer would
+    // otherwise keep holding the writers lock that `abandon` needs -- the
+    // deadlock that held the daemon past systemd's stop timeout.
+    let drained = {
+        let mut finish = std::pin::pin!(sink.finish());
+        tokio::select! {
+            () = &mut finish => true,
+            () = wait_for_shutdown(shutdown) => {
+                tokio::time::timeout(grace, &mut finish).await.is_ok()
+            }
+        }
+    };
+    if drained {
         return true;
     }
+    phase.set("sink abandon");
     let (repos, records) = sink.uncommitted();
     tracing::warn!(
         repos,
@@ -687,9 +783,14 @@ mod tests {
     }
 
     /// A sink whose drain never completes and remembers being abandoned.
+    /// With `hang_abandon`, abandoning never completes either. `finish`
+    /// holds `lock` while it hangs and `abandon` needs it, the shape of
+    /// `PgSink`'s writers mutex.
     #[derive(Default)]
     struct StuckSink {
         abandoned: AtomicBool,
+        hang_abandon: bool,
+        lock: tokio::sync::Mutex<()>,
     }
 
     impl RecordSink for StuckSink {
@@ -704,13 +805,18 @@ mod tests {
             std::future::ready(Err(WintermuteError::Other("unused".into())))
         }
         async fn finish(&self) {
+            let _held = self.lock.lock().await;
             std::future::pending::<()>().await;
         }
         fn uncommitted(&self) -> (usize, usize) {
             (3, 4200)
         }
         async fn abandon(&self) {
+            drop(self.lock.lock().await);
             self.abandoned.store(true, Ordering::Relaxed);
+            if self.hang_abandon {
+                std::future::pending::<()>().await;
+            }
         }
     }
 
@@ -785,6 +891,67 @@ mod tests {
             started.elapsed()
         );
         assert!(runner.shutting_down());
+    }
+
+    #[tokio::test]
+    async fn the_whole_stop_path_is_bounded_even_if_abandon_never_resolves() {
+        static FLAG: AtomicBool = AtomicBool::new(true);
+        static IDLE: AtomicBool = AtomicBool::new(false);
+        let sink = Arc::new(StuckSink {
+            hang_abandon: true,
+            ..StuckSink::default()
+        });
+        let cfg = RunnerConfig {
+            hubble: None,
+            direct: true,
+            shutdown: &FLAG,
+            shutdown_grace: Duration::from_millis(300),
+            ..RunnerConfig::default()
+        };
+        let runner = Arc::new(
+            Runner::new(
+                cfg,
+                Arc::clone(&sink),
+                RepoStateStore::open_in_memory().unwrap(),
+            )
+            .unwrap(),
+        );
+        let started = std::time::Instant::now();
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            run_bounded(&runner, sink.as_ref(), Duration::from_millis(200)),
+        )
+        .await
+        .expect("the outer bound fires")
+        .unwrap();
+        let took = started.elapsed();
+        assert!(
+            sink.abandoned.load(Ordering::Relaxed),
+            "abandon was reached"
+        );
+        assert!(
+            took >= Duration::from_millis(500) && took < Duration::from_secs(3),
+            "grace + slack, not forever: {took:?}"
+        );
+        // A run that is not stopped is not bounded at all.
+        let sink = Arc::new(NullSink::default());
+        let cfg = RunnerConfig {
+            hubble: None,
+            direct: true,
+            shutdown: &IDLE,
+            ..RunnerConfig::default()
+        };
+        let runner = Arc::new(
+            Runner::new(
+                cfg,
+                Arc::clone(&sink),
+                RepoStateStore::open_in_memory().unwrap(),
+            )
+            .unwrap(),
+        );
+        run_bounded(&runner, sink.as_ref(), Duration::ZERO)
+            .await
+            .unwrap();
     }
 
     #[test]

--- a/rsky-wintermute/src/backfiller/runner.rs
+++ b/rsky-wintermute/src/backfiller/runner.rs
@@ -29,10 +29,9 @@ use super::pds::PdsSource;
 use super::sink::{Receipt, RecordSink};
 use super::source::{
     Class, FetchLimits, RepoSource, SourceError, backoff_secs, classify, cooldown_secs,
-    retry_after_secs, sleep_secs, status_is_unfetchable,
+    retry_after_secs, status_is_unfetchable,
 };
 use super::state::{HUBBLE_SOURCE, HostRow, ListState, RepoStateStore, StateError};
-use crate::SHUTDOWN;
 use crate::metrics;
 use crate::types::WintermuteError;
 
@@ -44,6 +43,35 @@ const LIST_RETRY_COOLDOWN_SECS: u64 = 300;
 const NOFILE_PER_FETCH: u64 = 2;
 /// Descriptors for the rest of the process: pools, sqlite, metrics, stdio.
 const NOFILE_SLACK: u64 = 1024;
+
+/// How often a long sleep re-checks the shutdown flag.
+const SHUTDOWN_POLL: Duration = Duration::from_millis(250);
+
+/// Sleep for `dur`, returning early -- with `true` -- once `shutdown` is set.
+///
+/// Every wait in the runner that can run long (retry backoff, host cooldown,
+/// the re-enumeration interval) goes through here, so a `Retry-After` of 300 s
+/// cannot hold the daemon past systemd's stop timeout.
+pub async fn sleep_or_shutdown(dur: Duration, shutdown: &AtomicBool) -> bool {
+    let deadline = tokio::time::Instant::now() + dur;
+    loop {
+        if shutdown.load(Ordering::Relaxed) {
+            return true;
+        }
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return false;
+        }
+        tokio::time::sleep((deadline - now).min(SHUTDOWN_POLL)).await;
+    }
+}
+
+/// Resolve once `shutdown` is set.
+pub async fn wait_for_shutdown(shutdown: &AtomicBool) {
+    while !shutdown.load(Ordering::Relaxed) {
+        tokio::time::sleep(SHUTDOWN_POLL).await;
+    }
+}
 
 /// Make sure `RLIMIT_NOFILE` covers every worker at full concurrency.
 ///
@@ -123,6 +151,14 @@ pub struct RunnerConfig {
     pub connect_timeout: Duration,
     /// How often progress is logged and state gauges sampled.
     pub progress_every: Duration,
+    /// How long a shutdown may spend finishing work already in flight before
+    /// what is left is abandoned to the claimed-row recovery on restart.
+    /// Shared with the sink drain: `BACKFILL_SHUTDOWN_GRACE_SECS` bounds the
+    /// whole stop, not each stage.
+    pub shutdown_grace: Duration,
+    /// The flag that stops the runner: `crate::SHUTDOWN` in the binaries.
+    /// Tests inject their own so they do not race each other on the global.
+    pub shutdown: &'static AtomicBool,
 }
 
 impl Default for RunnerConfig {
@@ -148,6 +184,8 @@ impl Default for RunnerConfig {
             dry_run: false,
             connect_timeout: Duration::from_secs(15),
             progress_every: Duration::from_secs(30),
+            shutdown_grace: Duration::from_secs(20),
+            shutdown: &crate::SHUTDOWN,
         }
     }
 }
@@ -224,6 +262,9 @@ pub struct Runner<K: RecordSink> {
     client: reqwest::Client,
     hubble: Option<Arc<HubbleSource>>,
     inflight: Arc<tokio::sync::Semaphore>,
+    /// When the coordinator first saw the shutdown flag. The grace budget
+    /// counts from here.
+    shutdown_seen: std::sync::OnceLock<Instant>,
     pub progress: Arc<Progress>,
 }
 
@@ -260,6 +301,7 @@ impl<K: RecordSink> Runner<K> {
             client,
             hubble,
             inflight,
+            shutdown_seen: std::sync::OnceLock::new(),
             progress: Arc::new(Progress::default()),
         })
     }
@@ -267,6 +309,23 @@ impl<K: RecordSink> Runner<K> {
     #[must_use]
     pub const fn config(&self) -> &RunnerConfig {
         &self.cfg
+    }
+
+    /// Whether a stop has been requested.
+    #[must_use]
+    pub fn shutting_down(&self) -> bool {
+        self.cfg.shutdown.load(Ordering::Relaxed)
+    }
+
+    /// What is left of the shutdown grace budget: the whole budget until the
+    /// coordinator has seen the flag, then whatever the workers did not use.
+    #[must_use]
+    pub fn shutdown_grace_remaining(&self) -> Duration {
+        self.shutdown_seen
+            .get()
+            .map_or(self.cfg.shutdown_grace, |seen| {
+                self.cfg.shutdown_grace.saturating_sub(seen.elapsed())
+            })
     }
 
     #[must_use]
@@ -341,11 +400,17 @@ impl<K: RecordSink> Runner<K> {
         }
 
         loop {
-            if SHUTDOWN.load(Ordering::Relaxed) {
+            if self.shutting_down() {
                 return Ok(report);
             }
 
-            let page = self.list_page_with_retries(source, cursor.clone()).await?;
+            let page = match self.list_page_with_retries(source, cursor.clone()).await {
+                Ok(page) => page,
+                // A stop arrived during the backoff: the cursor is persisted,
+                // and the pass is simply not complete. Not a host failure.
+                Err(_) if self.shutting_down() => return Ok(report),
+                Err(e) => return Err(e.into()),
+            };
             report.pages += 1;
             report.seen += page.repos.len() as u64;
 
@@ -410,7 +475,9 @@ impl<K: RecordSink> Runner<K> {
                         error = %e,
                         "listRepos: transient failure, backing off"
                     );
-                    sleep_secs(delay).await;
+                    if sleep_or_shutdown(Duration::from_secs(delay), self.cfg.shutdown).await {
+                        return Err(e);
+                    }
                 }
                 Err(e) => return Err(e),
             }
@@ -633,7 +700,7 @@ impl<K: RecordSink> Runner<K> {
         tracing::info!(source = %name, limit = health.limit(), "fetch worker started");
 
         loop {
-            if SHUTDOWN.load(Ordering::Relaxed) {
+            if self.shutting_down() {
                 break;
             }
             if let Some(new_limit) = health.maybe_recover(Instant::now()) {
@@ -661,7 +728,7 @@ impl<K: RecordSink> Runner<K> {
                     self.state.fail(&did, true, secs, "host cooldown", None)?;
                 }
                 if name == HUBBLE_SOURCE {
-                    sleep_secs(secs).await;
+                    sleep_or_shutdown(Duration::from_secs(secs), self.cfg.shutdown).await;
                 } else if let Ok(host) = Hostname::new(&name) {
                     self.state
                         .set_host_cooldown(&host, secs, "concurrency floor exhausted")?;
@@ -742,7 +809,7 @@ impl<K: RecordSink> Runner<K> {
             if let Ok(p) = Arc::clone(&self.inflight).try_acquire_owned() {
                 return Ok(Some(p));
             }
-            if SHUTDOWN.load(Ordering::Relaxed) {
+            if self.shutting_down() {
                 return Ok(None);
             }
             if let Some(joined) = in_flight.try_join_next() {
@@ -880,7 +947,7 @@ impl<K: RecordSink> Runner<K> {
         let started = Instant::now();
 
         loop {
-            if SHUTDOWN.load(Ordering::Relaxed) {
+            if self.shutting_down() {
                 break;
             }
             while let Some(joined) = active.try_join_next() {
@@ -918,17 +985,62 @@ impl<K: RecordSink> Runner<K> {
             {
                 break;
             }
-            tokio::time::sleep(self.cfg.coordinator_poll).await;
+            sleep_or_shutdown(self.cfg.coordinator_poll, self.cfg.shutdown).await;
         }
 
-        while let Some(joined) = active.join_next().await {
-            let (name, result) = joined?;
-            if let Err(e) = result {
-                tracing::error!(source = %name, error = %e, "fetch worker failed");
+        if self.shutting_down() {
+            self.stop_workers(active, active_names).await;
+        } else {
+            while let Some(joined) = active.join_next().await {
+                let (name, result) = joined?;
+                if let Err(e) = result {
+                    tracing::error!(source = %name, error = %e, "fetch worker failed");
+                }
             }
         }
         self.log_progress(&last, started, 0);
         Ok(())
+    }
+
+    /// Shutdown: let the workers finish what is in flight for as long as the
+    /// grace budget allows, then abort the rest. An aborted worker's repos
+    /// stay claimed -- a fetch that never reaches the sink leaves no receipt
+    /// and no completion task, so nothing settles them -- and
+    /// `reset_claimed` returns them to pending on the next start.
+    async fn stop_workers(
+        &self,
+        mut active: JoinSet<(String, Result<(), RunnerError>)>,
+        mut active_names: HashSet<String>,
+    ) {
+        let seen = *self.shutdown_seen.get_or_init(Instant::now);
+        let budget = self.cfg.shutdown_grace.saturating_sub(seen.elapsed());
+        let joined_all = tokio::time::timeout(budget, async {
+            while let Some(joined) = active.join_next().await {
+                match joined {
+                    Ok((name, result)) => {
+                        active_names.remove(&name);
+                        if let Err(e) = result {
+                            tracing::error!(source = %name, error = %e, "fetch worker failed");
+                        }
+                    }
+                    Err(e) => tracing::error!(error = %e, "fetch worker panicked"),
+                }
+            }
+        })
+        .await
+        .is_ok();
+        if !joined_all {
+            let mut sources: Vec<&str> = active_names.iter().map(String::as_str).collect();
+            sources.sort_unstable();
+            tracing::warn!(
+                workers = active.len(),
+                grace_secs = self.cfg.shutdown_grace.as_secs(),
+                ?sources,
+                "fetch workers still in flight past the shutdown grace budget; \
+                 aborting them -- their claimed repos return to pending on restart"
+            );
+            active.shutdown().await;
+        }
     }
 
     fn log_progress(
@@ -979,8 +1091,7 @@ impl<K: RecordSink> Runner<K> {
                 loop {
                     if let Err(e) = this.enumerate_all().await {
                         tracing::error!(error = %e, "enumeration failed; will retry after backoff");
-                        sleep_secs(60).await;
-                        if SHUTDOWN.load(Ordering::Relaxed) {
+                        if sleep_or_shutdown(Duration::from_secs(60), this.cfg.shutdown).await {
                             return;
                         }
                         continue;
@@ -988,12 +1099,8 @@ impl<K: RecordSink> Runner<K> {
                     let Some(after) = this.cfg.reenumerate_after else {
                         return;
                     };
-                    let deadline = Instant::now() + after;
-                    while Instant::now() < deadline {
-                        if SHUTDOWN.load(Ordering::Relaxed) {
-                            return;
-                        }
-                        tokio::time::sleep(Duration::from_secs(5)).await;
+                    if sleep_or_shutdown(after, this.cfg.shutdown).await {
+                        return;
                     }
                     if let Err(e) = this.state.reset_enumeration() {
                         tracing::error!(error = %e, "reset enumeration failed");
@@ -1008,7 +1115,7 @@ impl<K: RecordSink> Runner<K> {
 
         let until_idle = self.cfg.reenumerate_after.is_none();
         let result = self.drain(until_idle).await;
-        if !until_idle || SHUTDOWN.load(Ordering::Relaxed) {
+        if !until_idle || self.shutting_down() {
             enumerator.abort();
         } else {
             drop(enumerator.await);
@@ -1112,6 +1219,9 @@ mod tests {
         room: AtomicBool,
         ingested: AtomicUsize,
         fail_commit: AtomicBool,
+        /// `finish` never resolves, as a sink stuck behind Postgres would not.
+        hang_finish: AtomicBool,
+        abandoned: AtomicBool,
     }
 
     impl FakeSink {
@@ -1120,6 +1230,8 @@ mod tests {
                 room: AtomicBool::new(room),
                 ingested: AtomicUsize::new(0),
                 fail_commit: AtomicBool::new(false),
+                hang_finish: AtomicBool::new(false),
+                abandoned: AtomicBool::new(false),
             })
         }
     }
@@ -1145,6 +1257,35 @@ mod tests {
                 rev: "3lz7gd2xq5c2c".into(),
                 committed: rx,
             })
+        }
+        async fn finish(&self) {
+            if self.hang_finish.load(Ordering::Relaxed) {
+                std::future::pending::<()>().await;
+            }
+        }
+        async fn abandon(&self) {
+            self.abandoned.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// A source whose fetches take `delay`; counts fetches started.
+    #[derive(Clone)]
+    struct SlowSource {
+        delay: Duration,
+        started: Arc<AtomicUsize>,
+    }
+
+    impl RepoSource for SlowSource {
+        fn name(&self) -> &'static str {
+            HOST
+        }
+        async fn list_repos(&self, _c: Option<String>, _l: u32) -> Result<RepoPage, SourceError> {
+            Ok(RepoPage::default())
+        }
+        async fn fetch_repo(&self, _d: String, _l: FetchLimits) -> Result<RepoBody, SourceError> {
+            self.started.fetch_add(1, Ordering::Relaxed);
+            tokio::time::sleep(self.delay).await;
+            Ok(RepoBody::Memory(vec![1]))
         }
     }
 
@@ -1673,6 +1814,250 @@ mod tests {
         let (soft_after, _) = rlimit::Resource::NOFILE.get().unwrap();
         assert!(soft_after >= soft_before.min(hard));
         assert!(soft_after <= hard);
+    }
+
+    #[tokio::test]
+    async fn a_shutdown_aware_sleep_returns_as_soon_as_the_flag_flips() {
+        static FLAG: AtomicBool = AtomicBool::new(false);
+        // No stop: the full duration elapses.
+        let started = Instant::now();
+        assert!(!sleep_or_shutdown(Duration::from_millis(60), &FLAG).await);
+        assert!(started.elapsed() >= Duration::from_millis(60));
+
+        // Already stopped: immediate.
+        FLAG.store(true, Ordering::Relaxed);
+        let started = Instant::now();
+        assert!(sleep_or_shutdown(Duration::from_secs(300), &FLAG).await);
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "{:?}",
+            started.elapsed()
+        );
+        FLAG.store(false, Ordering::Relaxed);
+
+        // Stopped midway through a long backoff: out within a poll interval.
+        let stop = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            FLAG.store(true, Ordering::Relaxed);
+        });
+        let started = Instant::now();
+        assert!(sleep_or_shutdown(Duration::from_secs(300), &FLAG).await);
+        let took = started.elapsed();
+        assert!(
+            took >= Duration::from_millis(100) && took < Duration::from_secs(2),
+            "{took:?}"
+        );
+        stop.await.unwrap();
+        FLAG.store(false, Ordering::Relaxed);
+    }
+
+    #[tokio::test]
+    async fn a_listing_backoff_ends_at_shutdown_without_blaming_the_host() {
+        static FLAG: AtomicBool = AtomicBool::new(false);
+        #[derive(Clone)]
+        struct Throttled;
+        impl RepoSource for Throttled {
+            fn name(&self) -> &'static str {
+                "throttled"
+            }
+            async fn list_repos(
+                &self,
+                _c: Option<String>,
+                _l: u32,
+            ) -> Result<RepoPage, SourceError> {
+                Err(SourceError::Status {
+                    status: 429,
+                    retry_after_secs: Some(300),
+                    xrpc_error: false,
+                })
+            }
+            async fn fetch_repo(
+                &self,
+                _d: String,
+                _l: FetchLimits,
+            ) -> Result<RepoBody, SourceError> {
+                unreachable!()
+            }
+        }
+        let mut c = cfg();
+        c.shutdown = &FLAG;
+        c.list_max_retries = 10;
+        let r = Arc::new(
+            Runner::new(
+                c,
+                FakeSink::new(true),
+                RepoStateStore::open_in_memory().unwrap(),
+            )
+            .unwrap(),
+        );
+        let stop = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            FLAG.store(true, Ordering::Relaxed);
+        });
+        let started = Instant::now();
+        let rep = r.enumerate_pages(&Throttled, None).await.unwrap();
+        assert!(!rep.completed, "an interrupted pass is not a finished one");
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "{:?}",
+            started.elapsed()
+        );
+        stop.await.unwrap();
+        FLAG.store(false, Ordering::Relaxed);
+    }
+
+    #[tokio::test]
+    async fn shutdown_waits_for_fetches_that_finish_within_the_grace_budget() {
+        static FLAG: AtomicBool = AtomicBool::new(false);
+        let sink = FakeSink::new(true);
+        let mut c = cfg();
+        c.shutdown = &FLAG;
+        c.shutdown_grace = Duration::from_secs(5);
+        let r = Arc::new(
+            Runner::new(
+                c,
+                Arc::clone(&sink),
+                RepoStateStore::open_in_memory().unwrap(),
+            )
+            .unwrap(),
+        );
+        r.state()
+            .upsert_host(&Hostname::new(HOST).unwrap(), 1, None, true)
+            .unwrap();
+        r.state().upsert(&repo("did:a", "r1"), HOST, false).unwrap();
+        let started = Arc::new(AtomicUsize::new(0));
+        let src = SlowSource {
+            delay: Duration::from_millis(300),
+            started: Arc::clone(&started),
+        };
+        let this = Arc::clone(&r);
+        let health = Arc::new(HostHealth::new(1, 1, true));
+        let worker = tokio::spawn(async move { this.fetch_loop(&src, health).await });
+        while started.load(Ordering::Relaxed) == 0 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        FLAG.store(true, Ordering::Relaxed);
+        worker.await.unwrap().unwrap();
+        settle_all().await;
+        FLAG.store(false, Ordering::Relaxed);
+        // The in-flight fetch was allowed to land and the repo completed.
+        assert_eq!(sink.ingested.load(Ordering::Relaxed), 1);
+        assert_eq!(r.state().stats().unwrap().done, 1);
+    }
+
+    #[tokio::test]
+    async fn shutdown_aborts_fetches_still_in_flight_past_the_grace_budget() {
+        static FLAG: AtomicBool = AtomicBool::new(false);
+        let sink = FakeSink::new(true);
+        sink.hang_finish.store(true, Ordering::Relaxed);
+        let mut c = cfg();
+        c.shutdown = &FLAG;
+        c.shutdown_grace = Duration::from_millis(400);
+        c.idle_exit = Duration::from_secs(60);
+        let r = Arc::new(
+            Runner::new(
+                c,
+                Arc::clone(&sink),
+                RepoStateStore::open_in_memory().unwrap(),
+            )
+            .unwrap(),
+        );
+        r.state()
+            .upsert_host(&Hostname::new(HOST).unwrap(), 1, None, true)
+            .unwrap();
+        r.state().upsert(&repo("did:a", "r1"), HOST, false).unwrap();
+        r.progress.enumeration_done.store(true, Ordering::Relaxed);
+
+        let started = Arc::new(AtomicUsize::new(0));
+        let src = SlowSource {
+            delay: Duration::from_secs(60),
+            started: Arc::clone(&started),
+        };
+        // The coordinator would build a real PdsSource for the host; put a
+        // slow fake worker in its JoinSet instead and hand that to the
+        // coordinator's stop logic.
+        let mut active: JoinSet<(String, Result<(), RunnerError>)> = JoinSet::new();
+        let mut names = HashSet::new();
+        names.insert(HOST.to_owned());
+        {
+            let this = Arc::clone(&r);
+            let src = src.clone();
+            active.spawn(async move {
+                let health = Arc::new(HostHealth::new(1, 1, true));
+                let res = this.fetch_loop(&src, health).await;
+                (HOST.to_owned(), res)
+            });
+        }
+        while started.load(Ordering::Relaxed) == 0 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(r.state().stats().unwrap().claimed, 1);
+
+        FLAG.store(true, Ordering::Relaxed);
+        let t0 = Instant::now();
+        r.stop_workers(active, names).await;
+        let stopped_in = t0.elapsed();
+        assert!(
+            stopped_in >= Duration::from_millis(400) && stopped_in < Duration::from_secs(3),
+            "{stopped_in:?}"
+        );
+        // Nothing settled the aborted fetch: the row is still claimed, which
+        // is exactly what reset_claimed recovers on the next start.
+        assert_eq!(sink.ingested.load(Ordering::Relaxed), 0);
+        let st = r.state().stats().unwrap();
+        assert_eq!((st.claimed, st.done, st.pending), (1, 0, 0));
+        assert_eq!(r.state().reset_claimed().unwrap(), 1);
+        // The grace budget is shared with the sink drain: nothing is left
+        // for a hung sink, so it is abandoned at once.
+        assert!(r.shutdown_grace_remaining() < Duration::from_millis(100));
+        let t0 = Instant::now();
+        assert!(
+            !super::super::finish_sink(sink.as_ref(), &FLAG, r.shutdown_grace_remaining()).await
+        );
+        assert!(t0.elapsed() < Duration::from_secs(1));
+        assert!(sink.abandoned.load(Ordering::Relaxed));
+        FLAG.store(false, Ordering::Relaxed);
+    }
+
+    #[tokio::test]
+    async fn drain_stops_within_the_grace_budget_on_shutdown() {
+        static FLAG: AtomicBool = AtomicBool::new(false);
+        let sink = FakeSink::new(true);
+        let mut c = cfg();
+        c.shutdown = &FLAG;
+        c.shutdown_grace = Duration::from_millis(300);
+        let r = Arc::new(
+            Runner::new(
+                c,
+                Arc::clone(&sink),
+                RepoStateStore::open_in_memory().unwrap(),
+            )
+            .unwrap(),
+        );
+        // A real host worker against a host that does not resolve: its
+        // fetches fail as transport errors and it keeps polling for work,
+        // so drain would run until told to stop.
+        r.state()
+            .upsert_host(&Hostname::new(HOST).unwrap(), 1, None, true)
+            .unwrap();
+        for i in 0..4 {
+            r.state()
+                .upsert(&repo(&format!("did:{i}"), "r1"), HOST, false)
+                .unwrap();
+        }
+        let this = Arc::clone(&r);
+        let drain = tokio::spawn(async move { this.drain(false).await });
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        FLAG.store(true, Ordering::Relaxed);
+        let t0 = Instant::now();
+        tokio::time::timeout(Duration::from_secs(5), drain)
+            .await
+            .expect("drain stops")
+            .unwrap()
+            .unwrap();
+        assert!(t0.elapsed() < Duration::from_secs(2), "{:?}", t0.elapsed());
+        assert!(r.shutting_down());
+        FLAG.store(false, Ordering::Relaxed);
     }
 
     #[tokio::test]

--- a/rsky-wintermute/src/backfiller/runner.rs
+++ b/rsky-wintermute/src/backfiller/runner.rs
@@ -1071,7 +1071,10 @@ impl<K: RecordSink> Runner<K> {
                 "backfill progress"
             );
         }
-        super::sample_state_metrics(&self.state);
+        // The gauges are a COUNT ... GROUP BY over every row; not on a stop.
+        if !self.shutting_down() {
+            super::sample_state_metrics(&self.state);
+        }
         now
     }
 

--- a/rsky-wintermute/src/backfiller/sink.rs
+++ b/rsky-wintermute/src/backfiller/sink.rs
@@ -282,15 +282,38 @@ impl RecordSink for PgSink {
                 .unwrap_or_else(PoisonError::into_inner)
                 .take(),
         );
-        let handles: Vec<_> = self.writers.lock().await.drain(..).collect();
+        // `finish` holds this lock while it waits on a writer; the caller
+        // drops it first. Bounded anyway, so a stop can never park here.
+        let Ok(mut writers) = tokio::time::timeout(ABANDON_STEP, self.writers.lock()).await else {
+            tracing::warn!("backfill sink: writers still locked by the drain; not waiting");
+            return;
+        };
+        let handles: Vec<_> = writers.drain(..).collect();
+        drop(writers);
         for handle in &handles {
             handle.abort();
         }
+        let total = handles.len();
+        let mut unsettled = 0usize;
         for handle in handles {
-            drop(handle.await);
+            if tokio::time::timeout(ABANDON_STEP, handle).await.is_err() {
+                unsettled += 1;
+            }
+        }
+        if unsettled > 0 {
+            tracing::warn!(
+                unsettled,
+                total,
+                "backfill sink: writers did not settle after abort (blocked in a call that \
+                 cannot be cancelled); leaving them to the runtime shutdown"
+            );
         }
     }
 }
+
+/// How long `abandon` waits on any one step: the writers lock, then each
+/// aborted writer.
+const ABANDON_STEP: Duration = Duration::from_secs(1);
 
 /// Pull repos off the shared receiver until a batch is full (or the queue goes
 /// quiet), write it, and settle every repo in it.

--- a/rsky-wintermute/src/backfiller/sink.rs
+++ b/rsky-wintermute/src/backfiller/sink.rs
@@ -12,8 +12,8 @@
 //! gate: fetch workers ask [`RecordSink::has_capacity`] before claiming work,
 //! so nothing is pulled from a PDS or hubble that Postgres is not ready to take.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, PoisonError};
 use std::time::Duration;
 
 use deadpool_postgres::Pool;
@@ -46,6 +46,27 @@ pub trait RecordSink: Send + Sync + 'static {
         did: &str,
         body: RepoBody,
     ) -> impl Future<Output = Result<Receipt, WintermuteError>> + Send;
+
+    /// Stop accepting repos and wait for everything already accepted to
+    /// commit. Unbounded by design -- a normal drain must not lose records --
+    /// so a shutdown wraps it in the grace budget (see
+    /// [`super::finish_sink`]).
+    fn finish(&self) -> impl Future<Output = ()> + Send {
+        async {}
+    }
+
+    /// `(repos, records)` accepted but not yet committed.
+    fn uncommitted(&self) -> (usize, usize) {
+        (0, 0)
+    }
+
+    /// Give up on whatever is uncommitted: the writers are stopped and every
+    /// pending receipt resolves as dropped. Called once the grace budget has
+    /// run out; the repos concerned stay claimed and are re-fetched on
+    /// restart.
+    fn abandon(&self) -> impl Future<Output = ()> + Send {
+        async {}
+    }
 }
 
 /// A repo waiting for a writer.
@@ -99,10 +120,13 @@ pub struct SinkCounters {
     pub batches: AtomicU64,
     pub batches_failed: AtomicU64,
     pub records_in_flight: AtomicUsize,
+    pub repos_in_flight: AtomicUsize,
 }
 
 pub struct PgSink {
-    tx: mpsc::Sender<Pending>,
+    /// `None` once [`PgSink::finish`] has closed the intake: the writers exit
+    /// when the last sender is gone.
+    tx: std::sync::Mutex<Option<mpsc::Sender<Pending>>>,
     counters: Arc<SinkCounters>,
     max_records_in_flight: usize,
     writers: Mutex<Vec<tokio::task::JoinHandle<()>>>,
@@ -127,11 +151,19 @@ impl PgSink {
             }));
         }
         Self {
-            tx,
+            tx: std::sync::Mutex::new(Some(tx)),
             counters,
             max_records_in_flight: cfg.max_records_in_flight.max(1),
             writers: Mutex::new(writers),
         }
+    }
+
+    /// A handle on the intake, or `None` once it is closed.
+    fn sender(&self) -> Option<mpsc::Sender<Pending>> {
+        self.tx
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
     }
 
     #[must_use]
@@ -142,29 +174,14 @@ impl PgSink {
     /// Repos waiting for a writer.
     #[must_use]
     pub fn queued(&self) -> usize {
-        self.tx.max_capacity() - self.tx.capacity()
+        self.sender()
+            .map_or(0, |tx| tx.max_capacity() - tx.capacity())
     }
 
     /// Records accepted but not yet committed.
     #[must_use]
     pub fn records_in_flight(&self) -> usize {
         self.counters.records_in_flight.load(Ordering::Relaxed)
-    }
-
-    /// Consume the sink: close the channel and wait for every writer to flush
-    /// what it holds. Writers exit once the last sender is gone.
-    pub async fn finish(self) {
-        let Self {
-            tx,
-            counters: _,
-            max_records_in_flight: _,
-            writers,
-        } = self;
-        drop(tx);
-        let handles: Vec<_> = writers.lock().await.drain(..).collect();
-        for h in handles {
-            drop(h.await);
-        }
     }
 }
 
@@ -175,7 +192,8 @@ impl RecordSink for PgSink {
             .set(i64::try_from(self.queued()).unwrap_or(i64::MAX));
         crate::metrics::BACKFILL_SINK_RECORDS_IN_FLIGHT
             .set(i64::try_from(in_flight).unwrap_or(i64::MAX));
-        self.tx.capacity() > 0 && in_flight < self.max_records_in_flight
+        self.sender()
+            .is_some_and(|tx| tx.capacity() > 0 && in_flight < self.max_records_in_flight)
     }
 
     async fn ingest(&self, did: &str, body: RepoBody) -> Result<Receipt, WintermuteError> {
@@ -193,17 +211,31 @@ impl RecordSink for PgSink {
             // Nothing to write; the repo is done as soon as it parsed.
             drop(done_tx.send(Ok(())));
         } else {
+            let closed = || WintermuteError::Other("backfill sink closed".into());
+            let tx = self.sender().ok_or_else(closed)?;
             self.counters
                 .records_in_flight
                 .fetch_add(records, Ordering::Relaxed);
-            self.tx
+            self.counters
+                .repos_in_flight
+                .fetch_add(1, Ordering::Relaxed);
+            if let Err(rejected) = tx
                 .send(Pending {
                     did,
                     jobs,
                     done: done_tx,
                 })
                 .await
-                .map_err(|_| WintermuteError::Other("backfill sink closed".into()))?;
+            {
+                // Never accepted: keep the in-flight counters honest.
+                self.counters
+                    .records_in_flight
+                    .fetch_sub(rejected.0.jobs.len(), Ordering::Relaxed);
+                self.counters
+                    .repos_in_flight
+                    .fetch_sub(1, Ordering::Relaxed);
+                return Err(closed());
+            }
         }
         Ok(Receipt {
             records,
@@ -211,6 +243,52 @@ impl RecordSink for PgSink {
             rev,
             committed: done_rx,
         })
+    }
+
+    /// Close the intake and wait for every writer to flush what it holds.
+    /// Writers exit once the last sender is gone; an `ingest` still holding a
+    /// clone finishes its send first, then sees the sink closed.
+    async fn finish(&self) {
+        drop(
+            self.tx
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .take(),
+        );
+        let mut writers = self.writers.lock().await;
+        for handle in writers.iter_mut() {
+            drop(handle.await);
+        }
+        writers.clear();
+    }
+
+    fn uncommitted(&self) -> (usize, usize) {
+        (
+            self.counters.repos_in_flight.load(Ordering::Relaxed),
+            self.counters.records_in_flight.load(Ordering::Relaxed),
+        )
+    }
+
+    /// Abort the writers. Every `Pending` they hold is dropped with them, so
+    /// each repo's `committed` receipt resolves as dropped and the runner's
+    /// completion task returns the row to pending instead of completing it; a
+    /// row whose completion task is gone too stays claimed and is recovered
+    /// on restart. Nothing completes twice: a receipt resolves exactly once,
+    /// whichever way.
+    async fn abandon(&self) {
+        drop(
+            self.tx
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .take(),
+        );
+        let handles: Vec<_> = self.writers.lock().await.drain(..).collect();
+        for handle in &handles {
+            handle.abort();
+        }
+        for handle in handles {
+            drop(handle.await);
+        }
     }
 }
 
@@ -285,6 +363,9 @@ async fn write_batch(
             .fetch_add(failures as u64, Ordering::Relaxed);
     }
     counters.batches.fetch_add(1, Ordering::Relaxed);
+    counters
+        .repos_in_flight
+        .fetch_sub(batch.len(), Ordering::Relaxed);
     let remaining = counters
         .records_in_flight
         .fetch_sub(n_jobs, Ordering::Relaxed)

--- a/rsky-wintermute/src/backfiller/state.rs
+++ b/rsky-wintermute/src/backfiller/state.rs
@@ -18,7 +18,10 @@
 //!   400;
 //! * each repo has a `source` -- the PDS host it is fetched from directly, or
 //!   `hubble` -- and a direct source always wins over hubble, so the mirror is
-//!   only asked for repos no mushroom will serve us.
+//!   only asked for repos no mushroom will serve us;
+//! * a live-path resync request carries `priority = 1` and is claimed ahead of
+//!   every ordinary pending row for its source, so a repo the firehose has
+//!   proved out of sync is not queued behind millions of enumerated ones.
 //!
 //! `SQLite`, because `rusqlite` is already a dependency and a single writer at
 //! a few thousand rows a second is well within it. ~160 bytes per repo, so the
@@ -154,7 +157,8 @@ CREATE TABLE IF NOT EXISTS repo (
     attempts        INTEGER NOT NULL DEFAULT 0,
     cooldown_until  INTEGER NOT NULL DEFAULT 0,
     last_error      TEXT,
-    updated_at      INTEGER NOT NULL
+    updated_at      INTEGER NOT NULL,
+    priority        INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS repo_claimable ON repo (source, state, cooldown_until);
 CREATE INDEX IF NOT EXISTS repo_state ON repo (state);
@@ -178,6 +182,17 @@ CREATE TABLE IF NOT EXISTS cursor (
     updated_at  INTEGER NOT NULL
 );
 ";
+
+/// Applied after [`SCHEMA`], once the `priority` column exists: a partial
+/// index over the handful of prioritised rows, so claiming them first costs a
+/// probe of a tiny index rather than a sort of the source's whole backlog.
+const PRIORITY_INDEX: &str = "
+CREATE INDEX IF NOT EXISTS repo_priority_claimable
+    ON repo (source, state, cooldown_until) WHERE priority > 0;
+";
+
+/// Priority of a row the live path asked to resync. Ordinary rows are 0.
+const RESYNC_PRIORITY: i64 = 1;
 
 #[derive(Clone)]
 pub struct RepoStateStore {
@@ -220,9 +235,39 @@ impl RepoStateStore {
              PRAGMA busy_timeout=5000;",
         )?;
         conn.execute_batch(SCHEMA)?;
+        Self::migrate_priority(&conn)?;
+        conn.execute_batch(PRIORITY_INDEX)?;
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
         })
+    }
+
+    /// Bring a state file from before the `priority` column up to date, in
+    /// place. `CREATE TABLE IF NOT EXISTS` leaves an existing table alone, so
+    /// the column is added by hand; resync rows already waiting are promoted
+    /// so an upgrade does not leave them at the back of the queue.
+    fn migrate_priority(conn: &Connection) -> Result<(), StateError> {
+        let has_priority = conn
+            .prepare("PRAGMA table_info(repo)")?
+            .query_map([], |r| r.get::<_, String>(1))?
+            .collect::<Result<Vec<_>, _>>()?
+            .iter()
+            .any(|name| name == "priority");
+        if has_priority {
+            return Ok(());
+        }
+        conn.execute_batch("ALTER TABLE repo ADD COLUMN priority INTEGER NOT NULL DEFAULT 0")?;
+        let promoted = conn.execute(
+            "UPDATE repo SET priority = ?1
+              WHERE last_error LIKE 'resync:%' AND state IN (?2, ?3)",
+            params![
+                RESYNC_PRIORITY,
+                RepoState::Pending.as_str(),
+                RepoState::Claimed.as_str()
+            ],
+        )?;
+        tracing::info!(promoted, "backfill state: added repo.priority");
+        Ok(())
     }
 
     fn lock(&self) -> Result<std::sync::MutexGuard<'_, Connection>, StateError> {
@@ -373,8 +418,8 @@ impl RepoStateStore {
         let conn = self.lock()?;
         conn.execute(
             "INSERT INTO repo (did, source, rev, indexed_rev, state, attempts, cooldown_until,
-                               last_error, updated_at)
-             VALUES (?1, ?2, ?3, NULL, ?4, 0, 0, ?5, ?6)
+                               last_error, updated_at, priority)
+             VALUES (?1, ?2, ?3, NULL, ?4, 0, 0, ?5, ?6, ?7)
              ON CONFLICT(did) DO UPDATE SET
                  rev            = CASE WHEN excluded.rev > repo.rev THEN excluded.rev
                                        ELSE repo.rev END,
@@ -383,14 +428,16 @@ impl RepoStateStore {
                  attempts       = 0,
                  cooldown_until = 0,
                  last_error     = excluded.last_error,
-                 updated_at     = excluded.updated_at",
+                 updated_at     = excluded.updated_at,
+                 priority       = excluded.priority",
             params![
                 did,
                 HUBBLE_SOURCE,
                 rev,
                 RepoState::Pending.as_str(),
                 format!("resync: {reason}"),
-                now()
+                now(),
+                RESYNC_PRIORITY
             ],
         )?;
         drop(conn);
@@ -427,30 +474,34 @@ impl RepoStateStore {
     }
 
     /// Take up to `limit` repos of one source that are ready to fetch, marking
-    /// them claimed. Ordered by `cooldown_until` so a cooled-down row is not
-    /// starved behind newly enumerated ones; that is the index order, so a
-    /// claim never sorts the source's whole backlog.
+    /// them claimed. Ordered by `priority` descending, then `cooldown_until`,
+    /// then rowid: resync requests first, then cooled-down rows so they are
+    /// not starved behind newly enumerated ones. Each step is the order of an
+    /// index (the partial priority index, then `repo_claimable`), so a claim
+    /// never sorts the source's whole backlog.
     pub fn claim_for_source(&self, source: &str, limit: usize) -> Result<Claimed, StateError> {
         let mut conn = self.lock()?;
         let tx = conn.transaction()?;
-        let rows: Claimed = {
-            let mut stmt = tx.prepare_cached(
+        let mut rows = Self::select_claimable(
+            &tx,
+            "SELECT did, rev FROM repo
+              WHERE source = ?1 AND state = ?2 AND cooldown_until <= ?3 AND priority > 0
+              ORDER BY cooldown_until, rowid
+              LIMIT ?4",
+            source,
+            limit,
+        )?;
+        if rows.len() < limit {
+            rows.extend(Self::select_claimable(
+                &tx,
                 "SELECT did, rev FROM repo
-                  WHERE source = ?1 AND state = ?2 AND cooldown_until <= ?3
-                  ORDER BY cooldown_until
+                  WHERE source = ?1 AND state = ?2 AND cooldown_until <= ?3 AND priority = 0
+                  ORDER BY cooldown_until, rowid
                   LIMIT ?4",
-            )?;
-            let iter = stmt.query_map(
-                params![
-                    source,
-                    RepoState::Pending.as_str(),
-                    now(),
-                    i64::try_from(limit).unwrap_or(i64::MAX)
-                ],
-                |r| Ok((r.get(0)?, r.get(1)?)),
-            )?;
-            iter.collect::<Result<_, _>>()?
-        };
+                source,
+                limit - rows.len(),
+            )?);
+        }
         {
             let mut stmt =
                 tx.prepare_cached("UPDATE repo SET state = ?2, updated_at = ?3 WHERE did = ?1")?;
@@ -460,6 +511,28 @@ impl RepoStateStore {
         }
         tx.commit()?;
         drop(conn);
+        Ok(rows)
+    }
+
+    fn select_claimable(
+        conn: &Connection,
+        sql: &str,
+        source: &str,
+        limit: usize,
+    ) -> Result<Claimed, StateError> {
+        let mut stmt = conn.prepare_cached(sql)?;
+        let rows = stmt
+            .query_map(
+                params![
+                    source,
+                    RepoState::Pending.as_str(),
+                    now(),
+                    i64::try_from(limit).unwrap_or(i64::MAX)
+                ],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )?
+            .collect::<Result<Claimed, _>>()?;
+        drop(stmt);
         Ok(rows)
     }
 
@@ -501,12 +574,13 @@ impl RepoStateStore {
     }
 
     /// Mark a repo indexed at `rev` -- the rev of the archive that was written,
-    /// not the rev seen at enumeration.
+    /// not the rev seen at enumeration. A resync's priority is spent here.
     pub fn complete(&self, did: &str, rev: &str) -> Result<(), StateError> {
         let conn = self.lock()?;
         conn.execute(
             "UPDATE repo SET state = ?2, indexed_rev = ?3, attempts = 0,
-                             cooldown_until = 0, last_error = NULL, updated_at = ?4
+                             cooldown_until = 0, last_error = NULL, priority = 0,
+                             updated_at = ?4
               WHERE did = ?1",
             params![did, RepoState::Done.as_str(), rev, now()],
         )?;
@@ -521,7 +595,8 @@ impl RepoStateStore {
         let conn = self.lock()?;
         conn.execute(
             "UPDATE repo SET state = ?2, indexed_rev = NULL, attempts = 0,
-                             cooldown_until = 0, last_error = 'dry-run', updated_at = ?3
+                             cooldown_until = 0, last_error = 'dry-run', priority = 0,
+                             updated_at = ?3
               WHERE did = ?1",
             params![did, RepoState::Done.as_str(), now()],
         )?;
@@ -1395,6 +1470,124 @@ mod tests {
         s.request_resync("did:a", "r2", "sync_event").unwrap();
         let st = s.stats().unwrap();
         assert_eq!((st.terminal, st.pending), (0, 1));
+    }
+
+    fn priority(s: &RepoStateStore, did: &str) -> i64 {
+        let conn = s.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT priority FROM repo WHERE did = ?1",
+            params![did],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn a_resync_is_claimed_ahead_of_older_pending_rows() {
+        let s = store();
+        for i in 0..50 {
+            s.upsert(&repo(&format!("did:enum{i:02}"), "r1"), HOST, false)
+                .unwrap();
+        }
+        // Filed long after the enumerated rows, and with a cooldown that
+        // would otherwise sort it behind none of them anyway.
+        s.upsert(&repo("did:live", "r1"), HOST, false).unwrap();
+        s.request_resync("did:live", "r2", "prev_mismatch").unwrap();
+        assert_eq!(priority(&s, "did:live"), 1);
+        assert_eq!(priority(&s, "did:enum00"), 0);
+
+        let claimed = s.claim_for_source(HOST, 3).unwrap();
+        assert_eq!(claimed[0], ("did:live".to_owned(), "r2".to_owned()));
+        assert_eq!(
+            &claimed[1..],
+            &[
+                ("did:enum00".to_owned(), "r1".to_owned()),
+                ("did:enum01".to_owned(), "r1".to_owned())
+            ],
+            "then the backlog in rowid order"
+        );
+        // A claim that the priority rows alone can fill takes nothing else.
+        s.request_resync("did:enum10", "r1", "sync_event").unwrap();
+        s.request_resync("did:enum20", "r1", "sync_event").unwrap();
+        let claimed = s.claim_for_source(HOST, 2).unwrap();
+        assert_eq!(
+            claimed,
+            vec![
+                ("did:enum10".to_owned(), "r1".to_owned()),
+                ("did:enum20".to_owned(), "r1".to_owned())
+            ]
+        );
+        // A prioritised row under cooldown still waits it out.
+        s.fail("did:enum10", true, 3600, "503", None).unwrap();
+        assert_eq!(priority(&s, "did:enum10"), 1, "kept for the retry");
+        let claimed = s.claim_for_source(HOST, 1).unwrap();
+        assert_eq!(claimed[0].0, "did:enum02");
+    }
+
+    #[test]
+    fn priority_is_spent_on_completion() {
+        let s = store();
+        s.request_resync("did:a", "r2", "sync_event").unwrap();
+        s.claim_for_source(HUBBLE_SOURCE, 10).unwrap();
+        s.complete("did:a", "r2").unwrap();
+        assert_eq!(priority(&s, "did:a"), 0);
+        // The next enumeration-driven fetch is an ordinary one.
+        s.upsert(&repo("did:a", "r3"), HUBBLE_SOURCE, false)
+            .unwrap();
+        assert_eq!(priority(&s, "did:a"), 0);
+        s.claim_for_source(HUBBLE_SOURCE, 10).unwrap();
+        s.mark_dry_run("did:a").unwrap();
+        assert_eq!(priority(&s, "did:a"), 0);
+    }
+
+    #[test]
+    fn a_state_file_from_before_priority_is_upgraded_in_place() {
+        const OLD_SCHEMA: &str = "
+CREATE TABLE repo (
+    did             TEXT PRIMARY KEY,
+    source          TEXT NOT NULL,
+    rev             TEXT NOT NULL DEFAULT '',
+    indexed_rev     TEXT,
+    state           TEXT NOT NULL,
+    attempts        INTEGER NOT NULL DEFAULT 0,
+    cooldown_until  INTEGER NOT NULL DEFAULT 0,
+    last_error      TEXT,
+    updated_at      INTEGER NOT NULL
+);
+CREATE INDEX repo_claimable ON repo (source, state, cooldown_until);
+CREATE INDEX repo_state ON repo (state);
+INSERT INTO repo (did, source, rev, state, updated_at) VALUES ('did:old', 'hubble', 'r1', 'pending', 0);
+INSERT INTO repo (did, source, rev, state, last_error, updated_at)
+    VALUES ('did:resync', 'hubble', 'r2', 'pending', 'resync: sync_event', 0);
+INSERT INTO repo (did, source, rev, state, last_error, updated_at)
+    VALUES ('did:claimed', 'hubble', 'r2', 'claimed', 'resync: prev_mismatch', 0);
+INSERT INTO repo (did, source, rev, indexed_rev, state, last_error, updated_at)
+    VALUES ('did:done', 'hubble', 'r2', 'r2', 'done', 'resync: sync_event', 0);
+";
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.sqlite");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(OLD_SCHEMA).unwrap();
+        drop(conn);
+
+        let s = RepoStateStore::open(&path).unwrap();
+        assert_eq!(priority(&s, "did:old"), 0);
+        assert_eq!(
+            priority(&s, "did:resync"),
+            1,
+            "waiting resyncs are promoted"
+        );
+        assert_eq!(priority(&s, "did:claimed"), 1);
+        assert_eq!(priority(&s, "did:done"), 0, "a finished resync is not");
+        assert_eq!(
+            s.claim_for_source(HUBBLE_SOURCE, 1).unwrap(),
+            vec![("did:resync".to_owned(), "r2".to_owned())]
+        );
+        drop(s);
+        // Opening again is a no-op.
+        let s = RepoStateStore::open(&path).unwrap();
+        s.request_resync("did:new", "r1", "sync_event").unwrap();
+        assert_eq!(priority(&s, "did:new"), 1);
     }
 
     #[test]

--- a/rsky-wintermute/src/bin/backfill.rs
+++ b/rsky-wintermute/src/bin/backfill.rs
@@ -27,7 +27,9 @@ use rsky_wintermute::backfiller::runner::Runner;
 use rsky_wintermute::backfiller::sink::{NullSink, PgSink, RecordSink};
 use rsky_wintermute::backfiller::source::RepoSource;
 use rsky_wintermute::backfiller::state::RepoStateStore;
-use rsky_wintermute::backfiller::{BackfillConfig, BackfillMode, SinkKind};
+use rsky_wintermute::backfiller::{
+    BackfillConfig, BackfillMode, SinkKind, finish_sink, run_and_finish,
+};
 
 // Same allocator as the daemon. glibc malloc kept ~3.5 GB of freed whale-repo
 // allocations resident across the runtime's threads; mimalloc returns them,
@@ -245,10 +247,12 @@ async fn main() -> Result<()> {
                 r.recover_dry_runs().map_err(|e| eyre!("{e}"))?;
                 r.progress.enumeration_done.store(true, Ordering::Relaxed);
                 let result = r.drain(true).await;
-                drop(r);
-                if let Some(sink) = Arc::into_inner(sink) {
-                    sink.finish().await;
-                }
+                finish_sink(
+                    sink.as_ref(),
+                    r.config().shutdown,
+                    r.shutdown_grace_remaining(),
+                )
+                .await;
                 result.map_err(|e| eyre!("{e}"))?;
                 status(&state)
             }
@@ -261,11 +265,9 @@ async fn main() -> Result<()> {
             }
             SinkKind::Postgres => {
                 let (r, sink) = runner_pg(&args, &cfg, state.clone())?;
-                let result = r.run().await;
-                if let Some(sink) = Arc::into_inner(sink) {
-                    sink.finish().await;
-                }
-                result.map_err(|e| eyre!("{e}"))?;
+                run_and_finish(&r, sink.as_ref())
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
                 status(&state)
             }
         },


### PR DESCRIPTION
Two fixes to `rsky-wintermute`'s backfill runner from tonight's soak test on the appview box.

## Problem A: hybrid mode cannot stop within systemd's 60 s

With `BACKFILL_MODE=hybrid` the daemon was SIGKILLed on every stop (three of three cycles); with the mode off it stopped in 16 s. Thread probes and logs showed three unbounded waits in the stop path:

- fetch workers finished their in-flight fetch+parse before logging `fetch worker stopped` (up to ~35 s after SIGTERM);
- `BackfillManager::run` then awaited `sink.finish()`, which drained every in-flight record (up to `BACKFILL_MAX_RECORDS_IN_FLIGHT`) through Postgres with no deadline;
- `enumerate_pages`'s transient backoff (`sleep_secs(delay)`, up to the 300 s `Retry-After` cap) did not observe `SHUTDOWN` at all.

Claimed rows are already returned to pending on restart (`reset_claimed`, covered by `claimed_rows_are_recovered_after_a_crash`), so abandoning in-flight work at shutdown is safe.

### Design

- **`BACKFILL_SHUTDOWN_GRACE_SECS` (default 20)**, read in `BackfillConfig::from_env`, threaded into `RunnerConfig::shutdown_grace`, documented in the README env table. It is one budget for the whole stop, not per stage: the coordinator records when it first saw the flag, spends what it needs on the workers, and hands the remainder to the sink drain.
- **Shutdown-aware sleeps.** New `runner::sleep_or_shutdown(dur, flag)` polls the flag every 250 ms and returns early. Every wait that can run long goes through it: the `listRepos` retry backoff, the hubble cooldown, the enumerator's 60 s error backoff, the re-enumeration interval, and the coordinator poll. A backoff cut short by a stop returns from `enumerate_pages` as an incomplete pass (cursor persisted) rather than a host failure, so the host is not put on a 300 s cooldown for being stopped.
- **Awaited vs aborted.** On shutdown `drain` awaits the fetch-worker `JoinSet` under `tokio::time::timeout(remaining grace)`; workers that finish in time settle normally (their repos complete). Anything still in flight past the budget is aborted (`JoinSet::shutdown`) with a `warn` naming the sources. An aborted fetch never reached the sink, so it leaves no receipt and no completion task: the row stays `claimed` and `reset_claimed` recovers it on the next start. The enumerator task is aborted as before.
- **Bounded sink drain.** `RecordSink` gains `finish(&self)` / `uncommitted()` / `abandon()` (defaults are no-ops; `NullSink` uses them). `PgSink::finish` now takes `&self` (the intake sender lives in a `Mutex<Option<_>>` and is taken to close the channel), which also removes the `Arc::into_inner(sink)` dance that silently skipped the drain whenever a completion task still held the runner. `backfiller::finish_sink` awaits `finish` unbounded until a stop is requested, then under `timeout(grace)`; on timeout it logs at `warn` how many repos/records are abandoned and that they will be re-fetched from their claimed state on restart, then `abandon()` aborts the writers. `run_and_finish` ties the runner and the sink drain together and is used by the manager and the `backfill` CLI.
- **No double completion.** A repo's `committed` receipt is a oneshot that resolves exactly once: `Ok` (complete), `Err` (fail with cooldown), or dropped when a writer is aborted (`fail(..., "sink dropped")` returns it to pending). Fetch tasks aborted before ingest leave the row claimed. `ingest` also rolls its in-flight counters back if the send is rejected by a closed channel.
- The runner's shutdown flag is now `RunnerConfig::shutdown: &'static AtomicBool` (default `crate::SHUTDOWN`), so tests inject their own flag instead of racing each other on the global.

## Problem B: resync requests queued behind millions of enumerated repos

`RepoStateStore::claim_for_source` ordered by `cooldown_until` only, so live sync 1.1 resync requests (`request_resync`, `last_error = 'resync: ...'`) competed equally with ordinary pending rows. In the soak, three resync rows sat pending/claimed for 24 minutes with zero completions while 7.8M enumerated repos were pending.

### Design

- New `repo.priority INTEGER NOT NULL DEFAULT 0` column. `request_resync` sets 1; `complete` (and `mark_dry_run`) clear it to 0 alongside `last_error = NULL`. A transient failure keeps it, so the retry is still prioritised.
- A partial index `repo_priority_claimable ON repo (source, state, cooldown_until) WHERE priority > 0` keeps the priority probe a lookup in a tiny index. `claim_for_source` claims from it first (`ORDER BY cooldown_until, rowid`), then fills the remainder from the existing `repo_claimable` index with `priority = 0`, all in one transaction. Net order: priority desc, `cooldown_until`, rowid. `EXPLAIN QUERY PLAN` confirms both selects and `has_claimable` stay on their indexes.
- Idempotent in-place upgrade in `RepoStateStore::init`: `PRAGMA table_info(repo)` is checked, the column is added with `ALTER TABLE ... ADD COLUMN` if missing, and waiting resync rows (`last_error LIKE 'resync:%'`, state pending/claimed) are promoted to priority 1 so the box's existing `state.sqlite` fixes its three stuck rows on the first start. The partial index is created after the migration so an old file does not hit an unknown column.
- README: one sentence in the sync 1.1 section on resync requests being fetched ahead of enumerated repos; state-file table mentions the priority.

## Tests

New: shutdown-aware sleep returns promptly when the flag flips (before, at once, and midway); a 300 s `Retry-After` backoff ends at shutdown without cooling the host; a fetch that finishes within the grace budget is awaited and completes; a fetch still in flight past the budget is aborted with the row left claimed and `reset_claimed` recovering it, then a hung sink is abandoned at once because the shared budget is spent; `drain` stops within the budget on shutdown; `finish_sink` abandons a never-resolving sink after the grace budget (and counts the budget from a stop that arrives midway); `run_and_finish` returns within the budget against a sink whose `finish` never resolves; a resync row is claimed before older pending rows for the same source (and a priority row under cooldown still waits); priority clears on completion; a pre-priority state file is upgraded in place with waiting resyncs promoted.

```
DATABASE_URL=postgresql://postgres:postgres@localhost:55435/bsky_test cargo test -p rsky-wintermute
test result: ok. 261 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 16.79s
```

`cargo fmt --all -- --check` clean; `cargo clippy -p rsky-wintermute --all-targets` reports zero diagnostics for the crate. The backfiller tests were run five more times with no flakes.

Not verified here: the stop time on the box itself under real Postgres load; the design bounds the stop at `BACKFILL_SHUTDOWN_GRACE_SECS` plus the ~250 ms flag-poll granularity, so the default 20 s stays well inside systemd's 60 s.

Commits are unsigned (`commit.gpgsign=false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
